### PR TITLE
Implementation and Tests on Rotated SC

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ LightStim/
 │   ├── test_LS_two_patch.ipynb
 │   ├── test_LS_CNOT.ipynb
 │   ├── test_ghz.ipynb
-│   └── test_injection.ipynb
+│   ├── test_injection.ipynb
+│   └── fold_transversal.ipynb
 ├── src/
 │   ├── ir/                         # Core abstractions and tracking
 │   ├── qec_code/                   # Code implementations

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1182,9 +1182,24 @@ class RotatedSurfaceCode(QECPatch):
 
 **Additional methods**: `shift_logical_operators(op_type, offset)`, `get_info()`
 
-**SE block**: `RotatedSurfaceCodeExtractionBlock(system)` -- 4-tick zigzag CNOT schedule.
+**SE block**: `RotatedSurfaceCodeExtractionBlock(system)` -- 4-tick zigzag CNOT schedule. Exposes `first_half` and `second_half` sub-circuits to support mid-round gate injection (used by fold-transversal S).
 
-**Logical ops**: `RotatedSurfaceCodeLogicalOpSet(LogicalOpSet)` -- stubs for Hadamard.
+**Logical ops**: `RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet)` -- fold-transversal H and S gates, plus inherited transversal CNOT.
+
+| Method | Description |
+|--------|-------------|
+| `fold_transversal_hadamard(builder, patch)` | Logical H via transversal H + 90° anticlockwise patch rotation (decomposed as SWAP cycles) |
+| `fold_transversal_s(builder, patch, se_block)` | Logical S via half-cycle SE (first_half) + fold S on the half-cycle unrotated state + second_half; `se_block` must be the `RotatedSurfaceCodeExtractionBlock` for this patch |
+| `transversal_cnot(builder, ctrl, tgt)` | Inherited from `CSSLogicalOpSet` |
+
+Usage via `LogicalExecutor`:
+```python
+executor.apply_logical_operation("fold_transversal_hadamard", [patch])
+executor.apply_logical_operation("fold_transversal_s", [patch], se_block=se)
+executor.apply_logical_operation("transversal_cnot", [ctrl, tgt])
+```
+
+Requires a square patch (`distance_z == distance_x`). See `notebooks/fold_transversal.ipynb` for single-patch and Bell pair examples.
 
 ---
 
@@ -1199,7 +1214,22 @@ class UnrotatedSurfaceCode(QECPatch):
 
 **SE block**: `UnrotatedSurfaceCodeExtractionBlock(system)` -- 6-tick CNOT schedule.
 
-**Logical ops**: `UnrotatedSurfaceCodeLogicalOpSet(LogicalOpSet)` -- stubs for fold-transversal Hadamard and S gate.
+**Logical ops**: `UnrotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet)` -- fold-transversal H and S gates exploiting the y=x diagonal reflection symmetry, plus inherited transversal CNOT.
+
+| Method | Description |
+|--------|-------------|
+| `fold_transversal_hadamard(builder, patch)` | Logical H via transversal H on all data qubits + SWAP mirror pairs across the y=x diagonal |
+| `fold_transversal_s(builder, patch)` | Logical S via S on even-row diagonal qubits + S† on odd-row diagonal qubits + CZ on mirror pairs |
+| `transversal_cnot(builder, ctrl, tgt)` | Inherited from `CSSLogicalOpSet` |
+
+Usage via `LogicalExecutor`:
+```python
+executor.apply_logical_operation("fold_transversal_hadamard", [patch])
+executor.apply_logical_operation("fold_transversal_s", [patch])
+executor.apply_logical_operation("transversal_cnot", [ctrl, tgt])
+```
+
+Requires a square patch (`distance_z == distance_x`). See `notebooks/fold_transversal.ipynb` for examples.
 
 **Coupler**: `UnrotatedTwoPatchCoupler(LogicalCouplerProtocol)` -- two-patch lattice surgery coupler.
 

--- a/experiments/fold_transversal.py
+++ b/experiments/fold_transversal.py
@@ -1,11 +1,12 @@
 # experiments/fold_transversal.py
 
 """
-Fold-transversal gate verification experiments for Unrotated Surface Code.
+Fold-transversal gate verification experiments for Unrotated and Rotated Surface Codes.
 
 Provides circuit builders for:
 - Single-patch gate verification (H, S) via init → SE → gate → SE → readout
 - Bell pair verification (transversal CNOT) via H → CNOT → Bell readout
+- S·S† roundtrip for fault-tolerant S gate benchmarking
 """
 
 import stim
@@ -15,6 +16,11 @@ from src.qec_code.surface_code.unrotated import (
     UnrotatedSurfaceCode,
     UnrotatedSurfaceCodeExtractionBlock,
     UnrotatedSurfaceCodeLogicalOpSet,
+)
+from src.qec_code.surface_code.rotated import (
+    RotatedSurfaceCode,
+    RotatedSurfaceCodeExtractionBlock,
+    RotatedSurfaceCodeLogicalOpSet,
 )
 from src.ir.qec_system import QECSystem
 from src.ir.tracker import SyndromeTracker
@@ -238,6 +244,239 @@ def build_bell_circuit(
 
     executor.apply_logical_operation("transversal_cnot", [p1, p2])
     builder.apply_syndrome_extraction(se_block.circuit, rounds=rounds)
+
+    builder.apply_data_readout(
+        {q: measure_basis for q in system.data_indices}
+    )
+
+    if noise_params is not None:
+        return builder.build_noisy_circuit(noise_params, noise_model)
+    return builder.circuit
+
+
+# ==============================================================================
+# Rotated Surface Code
+# ==============================================================================
+
+def build_rotated_gate_verification_circuit(
+    distance: int,
+    gates: List[str],
+    init_basis: Literal["Z", "X"] = "X",
+    measure_basis: Literal["Z", "X", "Y"] = "Y",
+    rounds: int = 2,
+    unencode: bool = False,
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+) -> stim.Circuit:
+    """
+    Build a single rotated-patch circuit for gate verification:
+      init(basis) → SE → gate(s) → SE → readout
+
+    For 'fold_transversal_s' / 'fold_transversal_s_dag' the gate IS a modified
+    SE round (embedded), so the gate call replaces one SE round.
+    When unencode=True, uses diagonal unencode + single-qubit Y measurement
+    on the corner qubit (for Y-basis logical readout).
+
+    Args:
+        distance:      Code distance (must be odd, square patch).
+        gates:         List of logical gate names.
+        init_basis:    'Z' or 'X'.
+        measure_basis: Final measurement basis ('Z', 'X', or 'Y').
+        rounds:        SE rounds before and after each gate.
+        unencode:      If True, use diagonal unencode + corner measurement.
+        noise_params:  Optional NoiseConfig for noise injection.
+        noise_model:   Noise model string (default 'circuit_level').
+
+    Returns:
+        stim.Circuit
+    """
+    patch_local = RotatedSurfaceCode(distance=distance)
+    system = QECSystem()
+    patch = system.add_patch(patch_local, name="patch")
+
+    tracker = SyndromeTracker(
+        num_qubits=system.num_qubits,
+        expected_num_logicals=system.num_logicals,
+    )
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+
+    executor = LogicalExecutor(builder)
+    executor.register_op_set(RotatedSurfaceCode, RotatedSurfaceCodeLogicalOpSet())
+
+    se = RotatedSurfaceCodeExtractionBlock(system)
+
+    # When unencode=True, use the injection-style diagonal init so that the
+    # unencode measurements are deterministic: corner gets init_basis, lower
+    # diagonal (rel_y >= rel_x from corner) gets X, upper diagonal gets Z.
+    # This matches the logical_unencode expectation in RotatedSurfaceCodeLogicalOpSet.
+    builder.write_coordinates()
+    if unencode:
+        data_global = sorted(patch.data_indices)
+        coords_with_idx = [(system.qubit_coords[g], g) for g in data_global]
+        corner_coord, corner_gidx = min(coords_with_idx, key=lambda t: (t[0][0], t[0][1]))
+        ox, oy = corner_coord
+        init_dict = {}
+        for gidx in data_global:
+            cx, cy = system.qubit_coords[gidx]
+            rel_x, rel_y = cx - ox, cy - oy
+            if gidx == corner_gidx:
+                init_dict[gidx] = init_basis
+            elif rel_y >= rel_x:
+                init_dict[gidx] = "X"
+            else:
+                init_dict[gidx] = "Z"
+    else:
+        corner_gidx = None
+        init_dict = {q: init_basis for q in system.data_indices}
+
+    builder.initialize(init_dict, system.num_qubits)
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    for gate in gates:
+        if gate in ("fold_transversal_s", "fold_transversal_s_dag"):
+            executor.apply_logical_operation(gate, [patch], se_block=se)
+        else:
+            executor.apply_logical_operation(gate, [patch])
+
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    if unencode:
+        unencode_measurements = {
+            gidx: basis for gidx, basis in init_dict.items()
+            if gidx != corner_gidx
+        }
+        builder.apply_data_readout(
+            final_measurements=unencode_measurements, noiseless=True
+        )
+        builder.apply_data_readout(
+            final_measurements={corner_gidx: measure_basis}, noiseless=True
+        )
+    else:
+        builder.apply_data_readout(
+            {q: measure_basis for q in system.data_indices}
+        )
+
+    if noise_params is not None:
+        return builder.build_noisy_circuit(noise_params, noise_model)
+    return builder.circuit
+
+
+def build_rotated_s_roundtrip_circuit(
+    distance: int,
+    rounds: int = 2,
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+) -> stim.Circuit:
+    """
+    Build a fault-tolerant S gate verification circuit via S·S† roundtrip:
+
+      |+⟩ → SE → S_L → SE → S†_L → SE → transversal MX
+
+    S·S† = I, so X_L should remain +1. LER_per_gate ≈ total_LER / 2.
+
+    Args:
+        distance:      Code distance (must be odd, square patch).
+        rounds:        SE rounds between operations.
+        noise_params:  Optional NoiseConfig for noise injection.
+        noise_model:   Noise model string (default 'circuit_level').
+
+    Returns:
+        stim.Circuit
+    """
+    patch_local = RotatedSurfaceCode(distance=distance)
+    system = QECSystem()
+    patch = system.add_patch(patch_local, name="patch")
+
+    tracker = SyndromeTracker(
+        num_qubits=system.num_qubits,
+        expected_num_logicals=system.num_logicals,
+    )
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+
+    executor = LogicalExecutor(builder)
+    executor.register_op_set(RotatedSurfaceCode, RotatedSurfaceCodeLogicalOpSet())
+
+    se = RotatedSurfaceCodeExtractionBlock(system)
+
+    builder.write_coordinates()
+    builder.initialize(
+        {q: "X" for q in system.data_indices},
+        system.num_qubits,
+    )
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    executor.apply_logical_operation("fold_transversal_s", [patch], se_block=se)
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    executor.apply_logical_operation("fold_transversal_s_dag", [patch], se_block=se)
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    builder.apply_data_readout(
+        {q: "X" for q in system.data_indices}
+    )
+
+    if noise_params is not None:
+        return builder.build_noisy_circuit(noise_params, noise_model)
+    return builder.circuit
+
+
+def build_rotated_bell_circuit(
+    distance: int,
+    measure_basis: Literal["Z", "X"] = "Z",
+    rounds: int = 2,
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+) -> stim.Circuit:
+    """
+    Build a Bell pair circuit for two rotated surface code patches:
+
+      |00⟩ → SE → H_L(p1) → SE → CNOT_L(p1,p2) → SE → measure(basis)
+
+    For |Φ+⟩ the joint parity observable (Z_L⊗Z_L or X_L⊗X_L) = +1 always.
+
+    Args:
+        distance:      Code distance.
+        measure_basis: 'Z' or 'X' for final data readout on both patches.
+        rounds:        SE rounds between logical operations.
+        noise_params:  Optional NoiseConfig for noise injection.
+        noise_model:   Noise model string (default 'circuit_level').
+
+    Returns:
+        stim.Circuit
+    """
+    offset = (2 * distance + 4, 0)
+
+    p1_local = RotatedSurfaceCode(distance=distance)
+    p2_local = RotatedSurfaceCode(distance=distance)
+
+    system = QECSystem()
+    p1 = system.add_patch(p1_local, name="p1")
+    p2 = system.add_patch(p2_local, name="p2", offset=offset)
+
+    tracker = SyndromeTracker(
+        num_qubits=system.num_qubits,
+        expected_num_logicals=system.num_logicals,
+    )
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+
+    executor = LogicalExecutor(builder)
+    executor.register_op_set(RotatedSurfaceCode, RotatedSurfaceCodeLogicalOpSet())
+
+    se = RotatedSurfaceCodeExtractionBlock(system)
+
+    builder.write_coordinates()
+    builder.initialize({q: "Z" for q in system.data_indices}, system.num_qubits)
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
+
+    executor.apply_logical_operation("fold_transversal_hadamard", [p1])
+    executor.apply_logical_operation("transversal_cnot", [p1, p2])
+    builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
 
     builder.apply_data_readout(
         {q: measure_basis for q in system.data_indices}

--- a/experiments/fold_transversal.py
+++ b/experiments/fold_transversal.py
@@ -372,9 +372,12 @@ def build_rotated_s_roundtrip_circuit(
     """
     Build a fault-tolerant S gate verification circuit via S·S† roundtrip:
 
-      |+⟩ → SE → S_L → SE → S†_L → SE → transversal MX
+      |0⟩ → SE → S_L → SE → S†_L → SE → transversal MZ
 
-    S·S† = I, so X_L should remain +1. LER_per_gate ≈ total_LER / 2.
+    S·S† = I, so Z_L should remain +1. Z-initialization avoids the boundary
+    X-syndrome tracking issue that occurs with X-initialized states (see
+    boundary syndrome note in fold_transversal rotated SC tests). LER_per_gate
+    ≈ total_LER / 2.
 
     Args:
         distance:      Code distance (must be odd, square patch).
@@ -404,7 +407,7 @@ def build_rotated_s_roundtrip_circuit(
 
     builder.write_coordinates()
     builder.initialize(
-        {q: "X" for q in system.data_indices},
+        {q: "Z" for q in system.data_indices},
         system.num_qubits,
     )
     builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
@@ -416,7 +419,7 @@ def build_rotated_s_roundtrip_circuit(
     builder.apply_syndrome_extraction(se.circuit, rounds=rounds)
 
     builder.apply_data_readout(
-        {q: "X" for q in system.data_indices}
+        {q: "Z" for q in system.data_indices}
     )
 
     if noise_params is not None:

--- a/src/ir/builder.py
+++ b/src/ir/builder.py
@@ -428,11 +428,13 @@ class CircuitBuilder:
         back_pauli_z = None
 
         if meas_basis == "Z":
-            # Make the syndrome qubit location zero, focus on the data qubit support
-            # (without this step the back-propagated Pauli string will involve both syndrome and data qubits)
-            # We zero out the columns corresponding to the syndrome qubits themselves
-            z2x_int[syn_qubit_indices, syn_qubit_indices] = 0
-            z2z_int[syn_qubit_indices, syn_qubit_indices] = 0
+            # Zero the full syndrome×syndrome block so that syndrome qubit contributions
+            # (from their |0⟩ reset state) are excluded from the back-propagated Pauli.
+            # For standard SE only the diagonal is non-zero; for modified SE rounds
+            # (e.g. fold-transversal S with mid-round gates on syndrome qubits) off-diagonal
+            # syndrome-syndrome entries can be non-zero and must also be removed.
+            z2x_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0
+            z2z_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0
 
             # Get the back-propagated Pauli string corresponding to the measured qubits
             # We take the rows corresponding to the syndrome indices
@@ -440,9 +442,9 @@ class CircuitBuilder:
             back_pauli_z = z2z_int[syn_qubit_indices, :]
 
         elif meas_basis == "X":
-            # Make the syndrome qubit location zero, focus on the data qubit support
-            x2x_int[syn_qubit_indices, syn_qubit_indices] = 0
-            x2z_int[syn_qubit_indices, syn_qubit_indices] = 0
+            # Same reasoning for X-basis measurements.
+            x2x_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0
+            x2z_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0
 
             # Get the back-propagated Pauli string
             back_pauli_x = x2x_int[syn_qubit_indices, :]

--- a/src/qec_code/surface_code/rotated/SE_block.py
+++ b/src/qec_code/surface_code/rotated/SE_block.py
@@ -29,93 +29,75 @@ class RotatedSurfaceCodeExtractionBlock:
 
     def _build_circuit(self):
 
-        # --- Step 1: Reset Syndrome Qubits ---
-        # Reset all syndrome qubits to |0> (Z basis)
         active_syn_indices = self.system.active_syndrome_indices
-        self.circuit.append("R", sorted(active_syn_indices))
-        self.circuit.append("TICK", tag="SE_start") # DEPOLARIZE1 will be injected here on data qubits
-
-        # --- Step 2: Preparation (Hadamard on X-type syndromes) ---
-        # Transform X-syndrome qubits to |+> state to measure X operators
         active_x_syn_indices = self.system.active_syndrome_indices_x
-        self.circuit.append("H", sorted(active_x_syn_indices))
-        self.circuit.append("TICK")
 
-        # --- Step 3: Entangling Gates (CNOT Scheduling) ---
-        # Standard Rotated Surface Code scheduling (4 ticks)
-        # Format: ((dx_x, dy_x), (dx_z, dy_z))
-        # dx_x/dy_x is the offset for X-stabilizer checks
-        # dx_z/dy_z is the offset for Z-stabilizer checks
-        # Perpendicular zigzag scheduling
+        # Perpendicular zigzag scheduling (4 CNOT ticks)
         canonical_tick_deltas = [
-            ((+1, +1), (+1, +1)), # Tick 1: NE interaction
-            ((-1, +1), (+1, -1)), # Tick 2: NW / SE interaction
-            ((+1, -1), (-1, +1)), # Tick 3: SE / NW interaction
-            ((-1, -1), (-1, -1))  # Tick 4: SW interaction
+            ((+1, +1), (+1, +1)), # Tick 1: NE
+            ((-1, +1), (+1, -1)), # Tick 2: NW / SE
+            ((+1, -1), (-1, +1)), # Tick 3: SE / NW
+            ((-1, -1), (-1, -1)), # Tick 4: SW
         ]
 
-        # Parallel zigzag scheduling (not FT, half distsance)
-        # canonical_tick_deltas = [
-        #     ((+1, +1), (+1, +1)), # Tick 1: NE interaction
-        #     ((-1, +1), (-1, +1)), # Tick 2: NW / SE interaction
-        #     ((+1, -1), (+1, -1)), # Tick 3: SE / NW interaction
-        #     ((-1, -1), (-1, -1))  # Tick 4: SW interaction
-        # ]
-
-        # Get the active syndrome coordinates for X and Z stabilizers
         active_stabilizers_x = self.system.active_stabilizers_x
         active_stabilizers_z = self.system.active_stabilizers_z
 
-        for dx_x, dx_z in canonical_tick_deltas:
-            cnot_targets = []
-            
-            # 3.1 Handle X-Stabilizers (Syndrome is Control, Data is Target)
+        def _cnot_layer(dx_x, dx_z):
+            """Build the CNOT target list for one tick."""
+            targets = []
             for stab in active_stabilizers_x:
                 syn_coord = stab['syn_coord']
-                syn_idx = stab['syn_idx']
-                owner_patch = self.system.patches[self.system.coord_to_owner_map[syn_coord]][0]
-                dx_x_global = owner_patch.transform_vector(dx_x)
-                raw_target = (
-                    syn_coord[0] + dx_x_global[0], 
-                    syn_coord[1] + dx_x_global[1]
-                )
-                target_key = owner_patch.get_grid_key(raw_target)
-
-                if target_key in self.system.grid_map:
-                    neighbor_idx = self.system.grid_map[target_key]
-                    if neighbor_idx in stab['data_indices']:
-                        cnot_targets.extend([syn_idx, neighbor_idx]) # Syndrome -> Data
-
-            # 3.2 Handle Z-Stabilizers (Data is Control, Syndrome is Target)
+                syn_idx   = stab['syn_idx']
+                owner     = self.system.patches[self.system.coord_to_owner_map[syn_coord]][0]
+                delta     = owner.transform_vector(dx_x)
+                raw       = (syn_coord[0] + delta[0], syn_coord[1] + delta[1])
+                key       = owner.get_grid_key(raw)
+                if key in self.system.grid_map:
+                    nb = self.system.grid_map[key]
+                    if nb in stab['data_indices']:
+                        targets.extend([syn_idx, nb])
             for stab in active_stabilizers_z:
                 syn_coord = stab['syn_coord']
-                syn_idx = stab['syn_idx']
-                owner_patch = self.system.patches[self.system.coord_to_owner_map[syn_coord]][0]
-                dx_z_global = owner_patch.transform_vector(dx_z)
-                raw_target = (
-                    syn_coord[0] + dx_z_global[0], 
-                    syn_coord[1] + dx_z_global[1]
-                )
-                target_key = owner_patch.get_grid_key(raw_target)
+                syn_idx   = stab['syn_idx']
+                owner     = self.system.patches[self.system.coord_to_owner_map[syn_coord]][0]
+                delta     = owner.transform_vector(dx_z)
+                raw       = (syn_coord[0] + delta[0], syn_coord[1] + delta[1])
+                key       = owner.get_grid_key(raw)
+                if key in self.system.grid_map:
+                    nb = self.system.grid_map[key]
+                    if nb in stab['data_indices']:
+                        targets.extend([nb, syn_idx])
+            return targets
 
-                if target_key in self.system.grid_map:
-                    neighbor_idx = self.system.grid_map[target_key]
-                    if neighbor_idx in stab['data_indices']:
-                        cnot_targets.extend([neighbor_idx, syn_idx]) # Data -> Syndrome
+        # ------------------------------------------------------------------
+        # First half: Reset + H_x + CNOT ticks 1-2
+        # ------------------------------------------------------------------
+        first = stim.Circuit()
+        first.append("R",    sorted(active_syn_indices))
+        first.append("TICK", tag="SE_start")
+        first.append("H",    sorted(active_x_syn_indices))
+        first.append("TICK")
+        for dx_x, dx_z in canonical_tick_deltas[:2]:
+            targets = _cnot_layer(dx_x, dx_z)
+            if targets:
+                first.append("CNOT", targets)
+            first.append("TICK")
 
-            # Apply CNOTs if any pairs exist in this tick
-            if cnot_targets:
-                self.circuit.append("CNOT", cnot_targets)
-            
-            self.circuit.append("TICK")
+        # ------------------------------------------------------------------
+        # Second half: CNOT ticks 3-4 + H_x + Measure
+        # ------------------------------------------------------------------
+        second = stim.Circuit()
+        for dx_x, dx_z in canonical_tick_deltas[2:]:
+            targets = _cnot_layer(dx_x, dx_z)
+            if targets:
+                second.append("CNOT", targets)
+            second.append("TICK")
+        second.append("H", sorted(active_x_syn_indices))
+        second.append("TICK")
+        second.append("M", sorted(active_syn_indices))
 
-        # --- Step 4: Basis Change (Hadamard on X-type syndromes) ---
-        # Transform X-syndrome qubits back to Z basis for measurement
-        self.circuit.append("H", sorted(active_x_syn_indices))
-        self.circuit.append("TICK")
-
-        # --- Step 5: Measurement ---
-        # Measure all syndrome qubits in Z basis
-        self.circuit.append("M", sorted(active_syn_indices))
-        
+        self.first_half = first
+        self.second_half = second
+        self.circuit = first + second
         # Note: No final TICK here. CircuitBuilder controls the flow.

--- a/src/qec_code/surface_code/rotated/operation.py
+++ b/src/qec_code/surface_code/rotated/operation.py
@@ -470,3 +470,43 @@ class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
 
         modified_se = se_block.first_half + fold_circ + se_block.second_half
         builder.apply_syndrome_extraction(modified_se)
+
+    def fold_transversal_s_dag(
+        self,
+        builder: CircuitBuilder,
+        patch: QECPatch,
+        se_block=None,
+    ):
+        """
+        Implement the logical S†_L via fold-transversal gate (inverse of S_L).
+
+        Identical to fold_transversal_s but with S and S_DAG swapped on the
+        diagonal qubits. CZ on mirror pairs is unchanged (CZ is self-inverse).
+
+        Logical action: Z_L → Z_L,  Y_L → X_L
+
+        Args:
+            builder:  CircuitBuilder driving the experiment.
+            patch:    The RotatedSurfaceCode patch (must be square).
+            se_block: RotatedSurfaceCodeExtractionBlock instance (required).
+        """
+        if se_block is None:
+            raise ValueError(
+                "fold_transversal_s_dag requires se_block "
+                "(RotatedSurfaceCodeExtractionBlock) as a keyword argument."
+            )
+
+        system = builder.system
+        even_diag, odd_diag, mirror_pairs = _get_fold_s_pairs(system, patch)
+
+        fold_circ = stim.Circuit()
+        fold_circ.append("TICK")
+        if even_diag:
+            fold_circ.append("S_DAG", sorted(even_diag))
+        if odd_diag:
+            fold_circ.append("S",     sorted(odd_diag))
+        for a, b in mirror_pairs:
+            fold_circ.append("CZ", [a, b])
+
+        modified_se = se_block.first_half + fold_circ + se_block.second_half
+        builder.apply_syndrome_extraction(modified_se)

--- a/src/qec_code/surface_code/rotated/operation.py
+++ b/src/qec_code/surface_code/rotated/operation.py
@@ -3,13 +3,14 @@
 """
 Logical operation set for Rotated Surface Code.
 
-Provides state_injection and logical_unencode as LogicalOpSet methods,
-callable via LogicalExecutor.apply_logical_operation().
+Provides state_injection, logical_unencode, fold_transversal_hadamard,
+and fold_transversal_s as LogicalOpSet methods, callable via
+LogicalExecutor.apply_logical_operation().
 """
 
-from typing import Literal, Tuple, Dict, Any, Type
+from typing import List, Literal, Tuple, Dict, Any, Type
 
-from src.ir.operation import LogicalOpSet
+from src.ir.operation import CSSLogicalOpSet
 from src.ir.builder import CircuitBuilder
 from src.ir.qec_patch import QECPatch
 from src.qec_code.surface_code.rotated.code_patch import RotatedSurfaceCode
@@ -127,10 +128,121 @@ def _get_injection_init(
 
 
 # ------------------------------------------------------------------------------
+# Fold-transversal helpers
+# ------------------------------------------------------------------------------
+
+def _get_rotation_cycles(system: Any, patch: QECPatch) -> List[List[int]]:
+    """
+    Compute the cycle decomposition of the 90° anticlockwise rotation
+    (lx, ly) → (2d − ly, lx) acting on data qubits of a square patch.
+
+    Returns:
+        cycles: list of lists of global qubit indices; fixed-point (length-1)
+                cycles are omitted.
+
+    Raises:
+        ValueError if the patch is non-square.
+    """
+    if patch.distance_z != patch.distance_x:
+        raise ValueError(
+            "Fold-transversal H requires a square patch "
+            f"(distance_z == distance_x). Got {patch.distance_z} != {patch.distance_x}."
+        )
+
+    d = patch.distance_z
+    sx, sy = patch.shift
+    y_max = 2 * d          # rotation: (lx, ly) → (y_max − ly, lx)
+    index_map = system.index_map
+
+    visited: set = set()
+    cycles: List[List[int]] = []
+
+    for coord in patch.data_coords:
+        global_idx = index_map[coord]
+        if global_idx in visited:
+            continue
+
+        lx = round(coord[0] - sx)
+        ly = round(coord[1] - sy)
+        cycle: List[int] = []
+        cur_lx, cur_ly = lx, ly
+
+        while True:
+            cur_global = QECPatch.snap_coord((cur_lx + sx, cur_ly + sy))
+            cur_idx = index_map[cur_global]
+            if cur_idx in visited:
+                break
+            cycle.append(cur_idx)
+            visited.add(cur_idx)
+            cur_lx, cur_ly = y_max - cur_ly, cur_lx   # 90° anticlockwise
+
+        if len(cycle) > 1:
+            cycles.append(cycle)
+
+    return cycles
+
+
+def _get_fold_s_pairs(
+    system: Any, patch: QECPatch
+) -> Tuple[List[int], List[int], List[Tuple[int, int]]]:
+    """
+    Partition ALL qubits of the patch (data + syndrome) by the y=x diagonal
+    reflection, for use in the fold-transversal S gate at the half-cycle
+    unrotated state.
+
+    Even-row diagonal qubits (local y even) receive S.
+    Odd-row diagonal qubits  (local y odd)  receive S_DAG.
+    Mirror pairs ((lx,ly) ↔ (ly,lx) with lx < ly) receive CZ.
+    Qubits with no mirror partner (asymmetric boundary) receive no operation.
+
+    Returns:
+        even_diag   : global indices of diagonal qubits with even local y → S
+        odd_diag    : global indices of diagonal qubits with odd  local y → S_DAG
+        mirror_pairs: list of (idx_a, idx_b) where local coord_a = (lx, ly),
+                      lx < ly, and coord_b = (ly, lx)
+
+    Raises:
+        ValueError if the patch is non-square.
+    """
+    if patch.distance_z != patch.distance_x:
+        raise ValueError(
+            "Fold-transversal S requires a square patch "
+            f"(distance_z == distance_x). Got {patch.distance_z} != {patch.distance_x}."
+        )
+
+    sx, sy = patch.shift
+    index_map = system.index_map
+
+    even_diag: List[int] = []
+    odd_diag:  List[int] = []
+    mirror_pairs: List[Tuple[int, int]] = []
+
+    for local_idx, local_coord in patch.qubit_coords.items():
+        lx = round(local_coord[0])
+        ly = round(local_coord[1])
+        global_coord = QECPatch.snap_coord((lx + sx, ly + sy))
+        if global_coord not in index_map:
+            continue
+        global_idx = index_map[global_coord]
+
+        if lx == ly:
+            if ly % 2 == 0:
+                even_diag.append(global_idx)
+            else:
+                odd_diag.append(global_idx)
+        elif lx < ly:
+            mirror_global = QECPatch.snap_coord((ly + sx, lx + sy))
+            if mirror_global in index_map:
+                mirror_pairs.append((global_idx, index_map[mirror_global]))
+
+    return even_diag, odd_diag, mirror_pairs
+
+
+# ------------------------------------------------------------------------------
 # LogicalOpSet implementation
 # ------------------------------------------------------------------------------
 
-class RotatedSurfaceCodeLogicalOpSet(LogicalOpSet):
+class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
     """
     Logical operation set for Rotated Surface Code.
 
@@ -138,13 +250,15 @@ class RotatedSurfaceCodeLogicalOpSet(LogicalOpSet):
     gates as composable operations for use with LogicalExecutor.
     """
 
-    def __init__(self, extraction_block_class: Type):
+    def __init__(self, extraction_block_class: Type = None):
         """
         Args:
             extraction_block_class: SE block class for this code
                 (e.g. RotatedSurfaceCodeExtractionBlock). Takes system, has .circuit.
+                Required for state_injection; optional otherwise.
         """
-        super().__init__("RotatedSurfaceCode")
+        super().__init__()
+        self.name = "RotatedSurfaceCode"
         self.extraction_block_class = extraction_block_class
 
     # ------------------------------------------------------------------
@@ -261,17 +375,98 @@ class RotatedSurfaceCodeLogicalOpSet(LogicalOpSet):
         return injection_gidx
 
     # ------------------------------------------------------------------
-    # Gate operations (stubs for future implementation)
+    # Fold-transversal gates
     # ------------------------------------------------------------------
 
-    def transversal_Hadamard(self, builder: CircuitBuilder, patch: QECPatch) -> stim.Circuit:
+    def fold_transversal_hadamard(self, builder: CircuitBuilder, patch: QECPatch):
         """
-        Applies a fold-transversal Hadamard gate using H-SWAP gates.
-        """
-        pass
+        Implement the logical Hadamard H_L via fold-transversal gate.
 
-    def LS_Hadamard(self, builder: CircuitBuilder, patch: QECPatch) -> stim.Circuit:
+        Physical circuit:
+          Layer 1 — transversal H : H applied to every data qubit
+          Layers 2-N — rotation   : SWAP gates implementing the 90° anticlockwise
+                                    permutation (lx, ly) → (2d − ly, lx) on data qubits
+
+        The rotation decomposes into permutation cycles (two 4-cycles + one fixed
+        point for square d). Each k-cycle needs k−1 sequential SWAPs; cycles are
+        parallelised across TICKs.
+
+        Logical action: X_L ↔ Z_L
+
+        Args:
+            builder: CircuitBuilder driving the experiment.
+            patch:   The RotatedSurfaceCode patch (must be square).
         """
-        Applies a Hadamard gate using transversal H with patch rotation.
+        system = builder.system
+        cycles = _get_rotation_cycles(system, patch)
+        all_data = sorted(patch.data_indices)
+
+        unitary = stim.Circuit()
+        unitary.append("H", all_data)
+
+        if cycles:
+            max_steps = max(len(c) - 1 for c in cycles)
+            for step in range(max_steps):
+                flat = []
+                for cycle in cycles:
+                    if step >= len(cycle) - 1:
+                        continue
+                    if step == 0:
+                        flat.extend([cycle[0], cycle[-1]])
+                    else:
+                        flat.extend([cycle[-step], cycle[-step - 1]])
+                unitary.append("TICK")
+                if flat:
+                    unitary.append("SWAP", flat)
+
+        builder.apply_unitary_block(unitary)
+
+    def fold_transversal_s(
+        self,
+        builder: CircuitBuilder,
+        patch: QECPatch,
+        se_block=None,
+    ):
         """
-        pass
+        Implement the logical phase gate S_L by embedding the fold-transversal
+        operation inside a single syndrome-extraction round.
+
+        The rotated surface code morphs into an unrotated surface code at the
+        half-cycle point (after CNOT ticks 1-2). The fold-transversal S is
+        applied there, then the SE round is completed (CNOT ticks 3-4 + measure).
+
+        Physical circuit (one modified SE round):
+          [SE first half]  Reset + H_x + CNOT ticks 1-2
+          [fold-S]         S on even-diagonal, S_DAG on odd-diagonal, CZ on pairs
+          [SE second half] CNOT ticks 3-4 + H_x + Measure
+
+        Diagonal / mirror pairs are defined on ALL qubits (data + syndrome) of
+        the patch, using the y=x fold of the half-cycle unrotated layout.
+
+        Logical action: Z_L → Z_L,  X_L → Y_L
+
+        Args:
+            builder:  CircuitBuilder driving the experiment.
+            patch:    The RotatedSurfaceCode patch (must be square).
+            se_block: RotatedSurfaceCodeExtractionBlock instance (required).
+        """
+        if se_block is None:
+            raise ValueError(
+                "fold_transversal_s requires se_block "
+                "(RotatedSurfaceCodeExtractionBlock) as a keyword argument."
+            )
+
+        system = builder.system
+        even_diag, odd_diag, mirror_pairs = _get_fold_s_pairs(system, patch)
+
+        fold_circ = stim.Circuit()
+        fold_circ.append("TICK")
+        if even_diag:
+            fold_circ.append("S",     sorted(even_diag))
+        if odd_diag:
+            fold_circ.append("S_DAG", sorted(odd_diag))
+        for a, b in mirror_pairs:
+            fold_circ.append("CZ", [a, b])
+
+        modified_se = se_block.first_half + fold_circ + se_block.second_half
+        builder.apply_syndrome_extraction(modified_se)


### PR DESCRIPTION
Need bugfix / backend updates from tableau tracker:
# Context
The rotated surface code fold-transversal S gate is implemented as a modified SE round: 
    ```first_half_SE  →  S/S†/CZ on data AND syndrome qubits  →  second_half_SE```

 Some of the CZ gates act between pairs of syndrome ancillas, specifically, boundary X-syndrome pairs that are mirror images under the fold.  This means the inverse-tableau rows for those syndromes have off-diagonal syndrome×syndrome entries.

Temp fix:
  # Before (diagonal only):
  ```z2x_int[syn_qubit_indices, syn_qubit_indices] = 0```
 ``` z2z_int[syn_qubit_indices, syn_qubit_indices] = 0```

  # After (full block):
  ```z2x_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0```
  ```z2z_int[np.ix_(syn_qubit_indices, syn_qubit_indices)] = 0```

 This suppresses the error but also discards the intentional cross-terms, producing wrong
  detector formulas. The resulting non-deterministic detectors are hidden when using
  Z-initialization (current workaround) but cause a hard ValueError: non-deterministic detectors
   with X-initialization.

Updates are required to support fold-transversal gate for rotated SC.
