### PR TITLE
Prepare CPU-safe benchmark setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ cd LightStim
 python3 -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
 
-pip install -e .                   # core (PyMatching included)
-pip install -e ".[decoders]"       # + BP+OSD (stimbposd) and MWPF
-pip install -e ".[gpu]"            # + NVIDIA GPU decoder (requires CUDA)
-pip install -r requirements-dev.txt  # dev / notebook environment
+pip install -e .                   # core library (PyMatching included)
+pip install -e ".[decoders]"       # optional CPU decoders: BP+OSD and MWPF
+pip install -e ".[dev]"            # development / notebook environment
+pip install -e ".[gpu]"            # optional NVIDIA GPU decoder (requires CUDA)
 ```
 
-> **GPU decoder** (`nv-qldpc-decoder`) requires NVIDIA GPU + CUDA 12.x. `cudaq-qec` is included in `requirements.txt` but will fail to install on non-CUDA systems — comment it out if not needed.
+> **GPU decoder** (`nv-qldpc-decoder`) requires NVIDIA GPU + CUDA 12.x. Install it only with
+> `pip install -e ".[gpu]"` on compatible systems.
 
 ### 2) Optional: Jupyter kernel
 

--- a/benchmarks/logical_ops/README.md
+++ b/benchmarks/logical_ops/README.md
@@ -49,7 +49,7 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
 | `--distances` | `3 5 7` | Code distances |
 | `--p-values` | `5e-4 1e-3 2e-3 5e-3 1e-2` | Physical error rates |
 | `--rounds` | `2` | SE rounds for gate benchmarks (memory always uses rounds=d) |
-| `--decoder` | `bposd` (gates) / `pymatching` (memory) | Decoder |
+| `--decoder` | `pymatching` for memory/LS CNOT; `bposd` for other gates | Decoder |
 | `--max-shots` | `1e9` | Max shots per task |
 | `--max-errors` | `100` | Stop after this many errors |
 | `--num-workers` | `8` | Parallel workers |

--- a/benchmarks/logical_ops/run_logical_ops.py
+++ b/benchmarks/logical_ops/run_logical_ops.py
@@ -21,9 +21,9 @@ For state injection benchmarks, see benchmarks/state_injection/.
 
 Decoders
 --------
-    cpu_bposd     CPU BP+OSD  (default for gates; handles non-CSS correlations)
+    cpu_bposd     CPU BP+OSD  (default for non-LS gates; handles non-CSS correlations)
     gpu_bposd     GPU BP+OSD  (same algorithm, CUDA-accelerated)
-    pymatching    CPU MWPM    (default for memory; sufficient for CSS memory)
+    pymatching    CPU MWPM    (default for memory and surface-code LS CNOT)
     mwpf          CPU MWPF    (general purpose)
 
 CSV output schema
@@ -511,7 +511,7 @@ def main():
     )
     ap.add_argument(
         "--decoder", choices=["cpu_bposd", "gpu_bposd", "pymatching", "mwpf"], default=None,
-        help="Decoder to use (default: cpu_bposd for gates, pymatching for memory)",
+        help="Decoder to use (default: pymatching for memory/LS CNOT, cpu_bposd for other gates)",
     )
     ap.add_argument("--max-shots",   type=int, default=1_000_000_000)
     ap.add_argument("--max-errors",  type=int, default=100)
@@ -562,7 +562,7 @@ def main():
         # Choose decoder: explicit flag > sensible default per gate
         if args.decoder is not None:
             decoder_name = args.decoder
-        elif gate == "memory":
+        elif gate == "memory" or gate.startswith("CNOT_LS_"):
             decoder_name = "pymatching"
         else:
             decoder_name = "cpu_bposd"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -63,8 +63,15 @@ python3 -m venv venv
 source venv/bin/activate    # Linux/macOS
 # venv\Scripts\activate     # Windows
 
-# Install dependencies
-pip install -r requirements.txt
+# Install the core library
+pip install -e .
+
+# Optional CPU decoders and development tools
+pip install -e ".[decoders]"
+pip install -e ".[dev]"
+
+# Optional GPU decoder; requires NVIDIA GPU + CUDA 12.x
+pip install -e ".[gpu]"
 ```
 
 ### Jupyter kernel (for notebooks)
@@ -75,18 +82,12 @@ python -m ipykernel install --user --name=lightstim --display-name="LightStim"
 
 ### Decoder packages
 
-`requirements.txt` already includes CPU decoder dependencies (`stimbposd`, `mwpf`, `frozendict`, `frozenlist`).
-
-Install extra decoder packages only when needed:
-
-```bash
-pip install pymatching  # MWPM decoder (recommended if not already installed)
-pip install cudaq_qec   # BP+OSD GPU decoder (NVIDIA only)
-```
+PyMatching is included in the core install. Optional CPU decoder backends are available via
+`pip install -e ".[decoders]"`; the GPU backend is available via `pip install -e ".[gpu]"`
+on CUDA-capable systems.
 
 > **Always use `venv/bin/python`**, not the system Python. The GPU decoder (`cudaq_qec`) is
-> only installed inside the venv; using system Python silently disables it and produces garbage
-> LER results.
+> installed only in environments where the GPU extra succeeds.
 
 ---
 
@@ -235,4 +236,4 @@ decoder's prediction disagrees with the actual observable.
 | Debug unexpected detector counts or LER≈50% | [`skills/gotchas/`](../skills/gotchas/SKILL.md) |
 | Precise API signatures for every class | [`docs/api/ir.md`](api/ir.md), [`docs/api/simulation.md`](api/simulation.md) |
 | Reproduce paper figures | [`paper_artifact/README.md`](../paper_artifact/README.md) |
-| Browse demo notebooks | [`notebooks/README.md`](../notebooks/README.md) |
+| Browse demo notebooks | `notebooks/README.md` once the notebook bundle is restored |

--- a/paper_artifact/logical_ops/README.md
+++ b/paper_artifact/logical_ops/README.md
@@ -86,7 +86,7 @@ PYTHONPATH=. venv/bin/python paper_artifact/logical_ops/run_all.py --quick
 | Gate | CNOT via Lattice Surgery (ancilla \|+>, ZZ-XX coupling) |
 | Sub-experiments | ZZ_ZZ, ZX_ZX, XZ_XX, XZ_ZZ, XX_XX |
 | Distances | 3, 5, 7 |
-| Decoder | bposd (CPU) |
+| Decoder | pymatching (CPU) |
 | p-values | `[5e-4, 1e-3, 2e-3, 5e-3, 1e-2]` |
 | Plot aggregation | mean LER over 5 sub-experiments |
 

--- a/paper_artifact/logical_ops/run_all.py
+++ b/paper_artifact/logical_ops/run_all.py
@@ -66,7 +66,7 @@ QUICK_SWEEP = {
     "rounds": 2,
 }
 
-# bposd handles non-CSS correlations; pymatching fails for S/CNOT
+# LS CNOT artifacts use PyMatching; non-LS gates use BP+OSD for correlated faults.
 BPOSD_DECODER = DecoderConfig(name="bposd", backend="cpu")
 PYMATCHING_DECODER = DecoderConfig(name="pymatching", backend="cpu")
 
@@ -200,7 +200,7 @@ def run_figure1(sweep, max_shots, max_errors, num_workers):
     return _run_tasks(
         tasks, max_shots, max_errors, num_workers,
         checkpoint_path=OUTPUT_DIR / "fig1_cnot_ls_zz_xx.csv",
-        decoder_config=BPOSD_DECODER,
+        decoder_config=PYMATCHING_DECODER,
     )
 
 
@@ -248,7 +248,7 @@ def run_figure2(sweep, max_shots, max_errors, num_workers):
     return _run_tasks(
         tasks, max_shots, max_errors, num_workers,
         checkpoint_path=OUTPUT_DIR / "fig2_cnot_ls_xx_zz.csv",
-        decoder_config=BPOSD_DECODER,
+        decoder_config=PYMATCHING_DECODER,
     )
 
 

--- a/paper_artifact/state_injection/README.md
+++ b/paper_artifact/state_injection/README.md
@@ -4,9 +4,9 @@ This directory reproduces the state injection benchmark figures for the rotated 
 
 ```
 paper_artifact/state_injection/
-├── precomputed/          # Pre-run data (git-tracked). Only covers Z/X states.
+├── precomputed/          # Pre-run data (git-tracked).
 ├── results/              # Generated outputs (gitignored). Plots land here.
-├── run_all.py            # Reproduce raw data (required for Y state figures)
+├── run_all.py            # Reproduce raw data
 ├── plot_fig1.py          # Middle injection, d=3, Z/X/Y states (Fig 7)
 ├── plot_fig2.py          # Middle injection, d=5, Z/X/Y states (Fig 8)
 ├── plot_fig3.py          # Corner injection, d=7, Z/X/Y states (Fig 9)
@@ -15,36 +15,24 @@ paper_artifact/state_injection/
 
 ---
 
-## Important: precomputed data only covers Z/X states
+## Precomputed Data Coverage
 
-The file `precomputed/state_injection.csv` contains data for `inject_state=[X, Z]` only.
-**Y state data is missing from precomputed.**
-
-- Figs 7–9 show Z, X, and Y states. With only precomputed data, the Y state line will be skipped.
-- Fig 10 shows only the Z state (all 3 modes), so it can be fully plotted from precomputed data.
-
-To generate full figures including Y state, run `run_all.py` first:
-
-```bash
-PYTHONPATH=. venv/bin/python paper_artifact/state_injection/run_all.py --inject-state Y
-```
+The file `precomputed/state_injection.csv` contains data for `inject_state=[Z, X, Y]`,
+both injection protocols (`corner`, `middle`), all three post-selection modes
+(`full_postselection`, `full_qec`, `hybrid`), distances `d=3,5,7`, `rounds=2`,
+and the tracked physical error-rate sweep.
 
 ---
 
 ## Quick start: regenerate figures from available data
 
-Fig 10 (Z state, all modes) can be fully generated from precomputed data:
-
-```bash
-PYTHONPATH=. venv/bin/python paper_artifact/state_injection/plot_fig4.py
-```
-
-Figs 7–9 will plot Z and X state lines from precomputed data (Y line skipped):
+All state-injection figures can be generated directly from the tracked precomputed data:
 
 ```bash
 PYTHONPATH=. venv/bin/python paper_artifact/state_injection/plot_fig1.py
 PYTHONPATH=. venv/bin/python paper_artifact/state_injection/plot_fig2.py
 PYTHONPATH=. venv/bin/python paper_artifact/state_injection/plot_fig3.py
+PYTHONPATH=. venv/bin/python paper_artifact/state_injection/plot_fig4.py
 ```
 
 Each plot script loads `results/state_injection.csv` first, then merges with `precomputed/state_injection.csv`.
@@ -60,7 +48,7 @@ Fresh results take priority automatically via deduplication.
 PYTHONPATH=. venv/bin/python paper_artifact/state_injection/run_all.py
 ```
 
-### Run only Y state (to fill in missing precomputed data)
+### Run only one state
 
 ```bash
 PYTHONPATH=. venv/bin/python paper_artifact/state_injection/run_all.py --inject-state Y
@@ -95,7 +83,6 @@ PYTHONPATH=. venv/bin/python paper_artifact/state_injection/run_all.py --quick
 - Color by state: Z=RUST, X=TEAL, Y=VIOLET
 - Mode: `full_postselection`
 - Dual y-axis: LER (log, solid lines) + PS survival rate (linear, dashed lines)
-- Y state requires running `run_all.py`
 
 ### Fig 8 — Middle injection, d=5 (`results/fig2_middle_d5.png`)
 
@@ -121,8 +108,6 @@ Same as Fig 7 but d=5.
 
 | File | Description |
 |------|-------------|
-| `precomputed/state_injection.csv` | Z/X injection, corner+middle protocols, d=3,5,7, r=2, p sweep |
+| `precomputed/state_injection.csv` | Z/X/Y injection, corner+middle protocols, all post-selection modes, d=3,5,7, r=2, p sweep |
 
 Schema: `shots, post_selected_shots, post_selection_rate, errors, logical_error_rate, seconds, decoder, injection_protocol, inject_state, post_select_mode, rounds, d, p`
-
-**Y state data is not included.** Run `run_all.py --inject-state Y` to generate it.

--- a/paper_artifact/state_injection/run_all.py
+++ b/paper_artifact/state_injection/run_all.py
@@ -4,9 +4,6 @@ State Injection Benchmark Suite — Paper Figures 7-10.
 Sweeps injection_protocol × inject_state × post_select_mode × distances × rounds × p.
 Outputs CSV results with per-task checkpointing.
 
-Note: precomputed/ only covers inject_state=[X, Z].
-Run this script to generate full data including Y state.
-
 Usage:
     # Full run (all states, all protocols):
     PYTHONPATH=. venv/bin/python paper_artifact/state_injection/run_all.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,8 +98,6 @@ stimbposd
 mwpf
 frozendict
 frozenlist
-# GPU decoder (requires NVIDIA GPU + CUDA 12.x): pip install cudaq-qec
-cudaq-qec
 pandas
 seaborn
 PyMatching

--- a/skills/simulate-decode/SKILL.md
+++ b/skills/simulate-decode/SKILL.md
@@ -46,6 +46,29 @@ print(stats.shots)                 # total shots attempted
 print(stats.post_selected_shots)   # shots surviving post-selection (= shots if no PS)
 ```
 
+## Sampling rule of thumb
+
+For reported LER experiments, prefer error-targeted collection: choose a target
+number of logical errors and run until that count is reached, with a large
+`max_shots` cap. Fixed-shot simulations are useful for smoke tests, but they often
+produce long error bars when the LER is small.
+
+Typical settings:
+
+```python
+pipeline = SimulationPipeline(
+    decoder_config=DecoderConfig("pymatching"),
+    max_errors=100,          # collect this many logical errors per point
+    max_shots=100_000_000,   # hard safety cap
+    batch_size=10_000,
+    num_workers=4,
+    print_progress=False,
+)
+```
+
+Use a smaller `max_errors` only for quick local demos; use 100-200+ errors for
+figures or comparisons.
+
 ## Decoder options
 
 | Name | Backend | When to use |
@@ -56,9 +79,14 @@ print(stats.post_selected_shots)   # shots surviving post-selection (= shots if 
 | `"nv-qldpc-decoder"` | gpu | GPU BP+OSD via `cudaq_qec`. Use `batch_size ≥ 50_000`, `num_workers=1`. |
 
 **Decoder selection rule:**
-- Surface codes (rotated, unrotated, toric): `pymatching`
-- LDPC codes (BB, PQRM) with no hyperedges: `bposd`
-- CrossLS / PQRM (X-stabs weight > 2 → hyperedges): `mwpf`
+- Prefer `pymatching` whenever the detector error model is graphlike / has no
+  hyperedges. This includes ordinary surface-code memory and surface-code
+  lattice-surgery circuits.
+- Use `mwpf` or `bposd` when the circuit has hyperedges or important correlated
+  fault mechanisms that should not be decomposed away.
+- Use `bposd` for LDPC codes such as BB/PQRM when BP+OSD is the intended decoder.
+- Use `mwpf` for CrossLS/PQRM-style hypergraph decoding, especially when
+  high-weight X stabilizers or cross-code surgery create hyperedges.
 
 ## Post-selection
 
@@ -117,7 +145,7 @@ from lightstim.noise.config import NoiseConfig
 
 pipeline = SimulationPipeline(
     decoder_config=DecoderConfig("pymatching"),
-    max_errors=200, max_shots=500_000, print_progress=False,
+    max_errors=100, max_shots=100_000_000, print_progress=False,
 )
 
 results = []


### PR DESCRIPTION
## Summary

- Make install docs CPU-safe by keeping CUDA-only dependencies behind the `gpu` extra.
- Update logical-ops LS CNOT benchmark defaults/docs to use PyMatching, matching precomputed artifacts.
- Correct state-injection artifact docs to reflect that precomputed data includes Z/X/Y.
- Add simulate/decode skill guidance for error-targeted sampling and decoder selection.

## Notes

- `cudaq-qec` remains available via `pip install -e ".[gpu]"`; it is no longer part of `requirements-dev.txt`.
- I only tested notebooks that don't need bposd to run. 