### PR TITLE
ci: group Dependabot updates + auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Python dependencies (requirements.txt + pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Roll all minor/patch bumps into a single weekly PR.
+      # Major bumps still open as individual PRs for manual review.
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep the actions used by our CI workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot PRs once the required CI checks pass.
+# Only patch and minor updates are merged automatically; major version
+# bumps stay open for manual review.
+#
+# Requires (one-time, in repo Settings → General):
+#   - "Allow auto-merge" enabled
+#   - "Allow GitHub Actions to create and approve pull requests" enabled
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+              steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up Tier-1 PR automation so routine dependency bumps don't need manual handling.

**What this adds**
- `.github/dependabot.yml` — weekly checks for `pip` and `github-actions`; minor/patch bumps are **grouped into one PR** (fewer notifications). Major bumps still open individually.
- `.github/workflows/dependabot-auto-merge.yml` — enables **auto-merge** on Dependabot PRs once the required `test` check passes. Only **patch/minor** auto-merge; **major** bumps and all human PRs stay manual.

**One-time setup after merge** (Settings → General):
- ✅ Allow auto-merge
- ✅ Allow GitHub Actions to create and approve pull requests