### PR TITLE
feat(skills/api): extend new decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LightStim is a modular Quantum Error Correction (QEC) framework built on [Stim](
 - Build QEC experiments from reusable abstractions (`QECPatch`, `QECSystem`, `CircuitBuilder`, `SyndromeTracker`)
 - Support multi-patch workflows (transversal gates, lattice surgery, state injection)
 - Inject standardized noise models (`code_capacity`, `phenomenological`, `circuit_level`, `XZ_biased`)
-- Decode with a unified backend (PyMatching, BP+OSD CPU/GPU, MWPF)
+- Decode with a unified backend (PyMatching, BP+OSD CPU/GPU, MWPF, Relay-BP, Tesseract)
 - Analyze and visualize logical error rates
 - Inspect circuits interactively in a browser (DEM 3D, Circuit Timeline, DetSlice animator)
 
@@ -54,7 +54,7 @@ python3 -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
 
 pip install -e .                   # core library (PyMatching included)
-pip install -e ".[decoders]"       # optional CPU decoders: BP+OSD and MWPF
+pip install -e ".[decoders]"       # optional CPU decoders: BP+OSD, MWPF, Relay-BP, Tesseract
 pip install -e ".[server]"         # optional FastAPI server for the web UI
 pip install -e ".[dev]"            # development / notebook environment
 pip install -e ".[gpu]"            # optional NVIDIA GPU decoder (requires CUDA)
@@ -62,6 +62,11 @@ pip install -e ".[gpu]"            # optional NVIDIA GPU decoder (requires CUDA)
 
 > **GPU decoder** (`nv-qldpc-decoder`) requires NVIDIA GPU + CUDA 12.x. Install it only with
 > `pip install -e ".[gpu]"` on compatible systems.
+>
+> **Tesseract**: a prebuilt `tesseract-decoder` wheel may not match every CPU. If it fails to
+> import on your machine, build it from source (the repo's `CMakeLists.txt` uses `-march=native`).
+> LightStim imports `tesseract_decoder` lazily, so this only affects the Tesseract decoder — not
+> `import lightstim` or the other decoders.
 
 ### 2) Optional: Jupyter kernel
 
@@ -118,6 +123,8 @@ print(f"LER: {stats.logical_error_rate:.3e} ± {stats.ler_error_bar():.3e}")
 | PyMatching (MWPM) | `DecoderConfig('pymatching')` | Default. Surface / LS circuits. |
 | BP+OSD CPU | `DecoderConfig('bposd')` | LDPC codes, hyperedge circuits. |
 | MWPF | `DecoderConfig('mwpf')` | Hyperedges (CrossLS, PQRM, color code). |
+| Relay-BP | `DecoderConfig('relay-bp')` | LDPC / hyperedge circuits. Needs `.[decoders]`. |
+| Tesseract | `DecoderConfig('tesseract', params={'det_beam': 50})` | Beam-search MLE. Needs `.[decoders]`. |
 | GPU BP+OSD | `DecoderConfig('nv-qldpc-decoder')` | NVIDIA GPU. Large d or high p. |
 
 ### Available QEC codes

--- a/lightstim/simulation/README.md
+++ b/lightstim/simulation/README.md
@@ -38,6 +38,8 @@
 | `"bposd"` | `"cpu"` | `stimbposd` | BP+OSD; alias `"bp_osd"` |
 | `"bposd"` / `"nv-qldpc-decoder"` | `"gpu"` | `cudaq_qec` | GPU BP+OSD via NVIDIA cudaq_qec |
 | `"mwpf"` | `"cpu"` | `mwpf` | — |
+| `"relay-bp"` | `"cpu"` | `relay_bp` | Relay-BP; aliases `"relay_bp"`, `"relaybp"` |
+| `"tesseract"` | `"cpu"` | `tesseract_decoder` | Beam-search MLE; lazy import |
 
 Requesting a backend with no registration raises `ImportError` immediately (e.g. `backend="gpu"` without `cudaq_qec`).
 
@@ -110,7 +112,9 @@ simulation/
 │   │   ├── pymatching.py  # PyMatchingDecoder (CPU)
 │   │   ├── bposd.py       # BpOsdCpuDecoder + unified param translation (CPU)
 │   │   ├── cudaqx.py      # CudaQxDecoder + CudaQxCompiledDecoder (GPU)
-│   │   └── mwpf.py        # MWPF decoder (CPU)
+│   │   ├── mwpf.py        # MWPF decoder (CPU)
+│   │   ├── relay_bp.py    # Relay-BP decoder (CPU, sinter-native)
+│   │   └── tesseract.py   # Tesseract beam-search MLE (CPU, lazy import)
 │   ├── pipeline.py        # SimulationPipeline, ExperimentTask
 │   ├── post_select.py     # apply_post_selection, get_post_select_detector_indices
 │   ├── progress.py        # ProgressReporter, ProgressSnapshot
@@ -127,6 +131,8 @@ simulation/
 - `pymatching` — MWPM decoder: `pip install pymatching`
 - `stimbposd` — CPU BP+OSD: `pip install stimbposd`
 - `mwpf` — MWPF decoder: `pip install mwpf frozendict frozenlist`
+- `relay_bp` — Relay-BP decoder: `pip install "relay-bp[stim]"`
+- `tesseract_decoder` — Tesseract beam-search MLE: `pip install tesseract-decoder` (a prebuilt wheel may not match every CPU; build from source if it fails to import)
 - `cudaq_qec` — GPU BP+OSD: `pip install cudaq_qec` (NVIDIA GPU required)
 
 ---

--- a/lightstim/simulation/decoder_backend/_accounting.py
+++ b/lightstim/simulation/decoder_backend/_accounting.py
@@ -1,0 +1,87 @@
+"""Shared shot-accounting for the custom decode loop.
+
+Both the single-process loop (:mod:`pipeline`) and the multi-process worker
+(:mod:`worker`) turn a batch of decoder predictions into a ``(kept, errors)``
+pair. Keeping that arithmetic in one place stops the two paths from drifting
+apart, and gives :class:`~.external.ExternalDecoder` failure flags a single
+place to be honoured.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+
+def count_batch(
+    *,
+    obs_filtered: np.ndarray,
+    pred_packed: np.ndarray,
+    post_select_corrected_observable_indices: Optional[List[int]],
+    target_observable_indices: Optional[List[int]],
+    flags: Optional[np.ndarray] = None,
+    on_decode_failure: str = "error",
+) -> tuple[int, int]:
+    """Return ``(kept, errors)`` for one decoded batch.
+
+    Args:
+        obs_filtered: uint8 ground-truth observables, shape ``(n_shots, n_obs)``
+            (already pre-decode post-selected).
+        pred_packed: bit-packed observable predictions from the decoder,
+            little-endian, one row per shot.
+        post_select_corrected_observable_indices: if set, post-decode
+            post-selection — keep only shots whose *corrected* observables at
+            these indices are all 0.
+        target_observable_indices: if set, only these observables count toward
+            a logical error.
+        flags: optional per-shot convergence flags from an external decoder,
+            shape ``(n_shots,)``; ``False`` marks a failed decode. ``None`` means
+            every shot converged.
+        on_decode_failure: policy for flagged-failed shots — ``"error"`` counts
+            them as logical errors, ``"discard"`` drops them from the
+            denominator, ``"ignore"`` leaves the prediction untouched.
+
+    Returns:
+        ``(kept, errors)`` deltas to add to the running denominator and error
+        count.
+    """
+    n_shots, n_obs = obs_filtered.shape
+    pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
+
+    ps_corr = post_select_corrected_observable_indices
+    target = target_observable_indices
+
+    if ps_corr:
+        # Post-decode PS: corrected[i] = obs[i] XOR pred[i] is the residual.
+        corrected = obs_filtered ^ pred_unpacked
+        keep_mask = np.all(corrected[:, ps_corr] == 0, axis=1)
+        if target is not None:
+            error_mask = np.any(corrected[:, target] != 0, axis=1)
+        else:
+            error_mask = np.any(corrected != 0, axis=1)
+    elif target is not None:
+        keep_mask = np.ones(n_shots, dtype=bool)
+        error_mask = np.any(
+            pred_unpacked[:, target] != obs_filtered[:, target], axis=1
+        )
+    else:
+        keep_mask = np.ones(n_shots, dtype=bool)
+        error_mask = np.any(pred_unpacked != obs_filtered, axis=1)
+
+    if flags is not None and on_decode_failure != "ignore":
+        failed = ~np.asarray(flags, dtype=bool)
+        if on_decode_failure == "discard":
+            keep_mask = keep_mask & ~failed
+        else:  # "error"
+            # A failed decode is a definite logical error. It must also stay in
+            # the denominator even if post-decode post-selection would reject its
+            # (untrusted) corrected observables — otherwise a failed-and-rejected
+            # shot would silently vanish (kept=0, errors=0) instead of counting,
+            # underestimating the LER.
+            keep_mask = keep_mask | failed
+            error_mask = error_mask | failed
+
+    kept = int(keep_mask.sum())
+    errors = int(np.sum(error_mask & keep_mask))
+    return kept, errors

--- a/lightstim/simulation/decoder_backend/config.py
+++ b/lightstim/simulation/decoder_backend/config.py
@@ -11,11 +11,22 @@ class DecoderConfig:
     name: str  # e.g. 'pymatching', 'bposd', 'nv-qldpc-decoder'
     backend: Literal["cpu", "gpu", "fpga"] = "cpu"
     params: Dict[str, Any] = field(default_factory=dict)
+    # Policy for shots an ExternalDecoder flags as failed (flag=False):
+    #   "error"   -- count the shot as a logical error (default; pessimistic)
+    #   "discard" -- herald the failure: drop the shot from the denominator
+    #   "ignore"  -- trust whatever prediction was returned anyway
+    # Has no effect on decoders that never emit failure flags.
+    on_decode_failure: Literal["error", "discard", "ignore"] = "error"
 
     def __post_init__(self):
         self.backend = self.backend.lower()
         if self.backend not in ("cpu", "gpu", "fpga"):
             raise ValueError(f"backend must be 'cpu', 'gpu', or 'fpga', got {self.backend}")
+        if self.on_decode_failure not in ("error", "discard", "ignore"):
+            raise ValueError(
+                "on_decode_failure must be 'error', 'discard', or 'ignore', "
+                f"got {self.on_decode_failure!r}"
+            )
 
 
 @dataclass

--- a/lightstim/simulation/decoder_backend/decoders/__init__.py
+++ b/lightstim/simulation/decoder_backend/decoders/__init__.py
@@ -31,6 +31,26 @@ if importlib.util.find_spec("mwpf") is not None:
 else:
     _log.debug("mwpf not installed; skipping MWPF decoder")
 
+# relay_bp — optional Relay-BP backend (sinter-native).
+if importlib.util.find_spec("relay_bp") is not None:
+    try:
+        from . import relay_bp  # noqa: F401 — registers relay-bp/cpu
+    except ImportError as exc:
+        _log.debug("relay_bp import failed: %s", exc)
+else:
+    _log.debug("relay_bp not installed; skipping Relay-BP decoder")
+
+# tesseract_decoder — optional beam-search MLE decoder (sinter-native).
+# Imported unconditionally on purpose: decoders/tesseract.py is import-safe —
+# it does NOT import tesseract_decoder at module load. It self-guards with
+# find_spec and registers a lazy wrapper that imports the native extension only
+# when the decoder is constructed, so a prebuilt wheel that doesn't match the
+# host CPU affects only the Tesseract decoder, not the whole registry.
+try:
+    from . import tesseract  # noqa: F401 — registers tesseract/cpu if installed
+except ImportError as exc:
+    _log.debug("tesseract registration skipped: %s", exc)
+
 # cudaq_qec — optional NVIDIA GPU backend.
 # Import cudaqx unconditionally: it no longer eager-imports cudaq_qec at module
 # scope. The actual `import cudaq_qec` is deferred to first use of the GPU

--- a/lightstim/simulation/decoder_backend/decoders/cudaqx.py
+++ b/lightstim/simulation/decoder_backend/decoders/cudaqx.py
@@ -13,57 +13,8 @@ import numpy as np
 import sinter
 import stim
 
+from ..dem_matrices import dem_to_matrices as _dem_to_matrices
 from ..registry import register_decoder
-
-# ---------------------------------------------------------------------------
-# DEM → matrix parser
-# ---------------------------------------------------------------------------
-
-
-def _dem_to_matrices(
-    dem: stim.DetectorErrorModel,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Convert a stim DEM to the three arrays cudaq_qec needs.
-
-    Returns:
-        H          -- uint8 parity-check matrix (n_detectors, n_error_mechanisms)
-        obs_matrix -- uint8 observable-flip matrix (n_observables, n_error_mechanisms)
-        probs      -- float64 prior error probabilities (n_error_mechanisms,)
-    """
-    n_dets = dem.num_detectors
-    n_obs = dem.num_observables
-
-    error_cols: list[dict] = []
-
-    for instruction in dem.flattened():
-        if instruction.type != "error":
-            continue
-        p = instruction.args_copy()[0]
-        dets: list[int] = []
-        obs: list[int] = []
-        for t in instruction.targets_copy():
-            if t.is_relative_detector_id():
-                dets.append(t.val)
-            elif t.is_logical_observable_id():
-                obs.append(t.val)
-        error_cols.append({"p": p, "dets": dets, "obs": obs})
-
-    n_err = len(error_cols)
-    # Explicitly C-contiguous (row-major) to match cudaq_qec's expected layout,
-    # equivalent to scipy sparse_matrix.todense(order='C').
-    H = np.zeros((n_dets, n_err), dtype=np.uint8, order='C')
-    obs_matrix = np.zeros((n_obs, n_err), dtype=np.uint8, order='C')
-    probs = np.zeros(n_err, dtype=np.float64)
-
-    for e, col in enumerate(error_cols):
-        probs[e] = col["p"]
-        for d in col["dets"]:
-            H[d, e] = 1
-        for o in col["obs"]:
-            obs_matrix[o, e] = 1
-
-    return np.ascontiguousarray(H), obs_matrix, probs
-
 
 # ---------------------------------------------------------------------------
 # sinter CompiledDecoder wrapper

--- a/lightstim/simulation/decoder_backend/decoders/relay_bp.py
+++ b/lightstim/simulation/decoder_backend/decoders/relay_bp.py
@@ -1,0 +1,44 @@
+"""Relay-BP decoder (CPU) — wraps relay_bp's sinter integration.
+
+relay_bp (https://github.com/trmue/relay) already ships sinter-compatible
+decoders: ``SinterDecoder_RelayBP`` is a ``sinter.Decoder`` that implements
+both ``compile_decoder_for_dem`` and ``decode_via_files``. So this is a
+Pattern A integration — we register the upstream class directly, no subclass
+or CompiledDecoder of our own. Registration is skipped silently if relay_bp
+is not installed.
+
+User-facing params flow straight through ``DecoderConfig(params={...})`` to
+``SinterDecoder_RelayBP``. The important ones (see upstream for the rest):
+
+    alpha               : float | None  -- disordered memory strength (None disables)
+    gamma0              : float = 0.1    -- ordered memory parameter
+    pre_iter            : int   = 60     -- BP iterations for the first ensemble
+    num_sets            : int   = 60     -- number of Relay-BP ensemble members
+    set_max_iter        : int   = 60     -- iterations per ensemble member
+    gamma_dist_interval : (float, float) = (-0.24, 0.66)  -- memory-weight range
+    stop_nconv          : int   = 5      -- stop after this many converged solutions
+    parallel            : bool  = False  -- relay_bp-internal threading
+
+``gamma_dist_interval`` is highly sensitive and should be tuned per code/DEM
+using relay_bp's analysis notebooks.
+
+Note: Relay-BP consumes the *un-decomposed* DEM (it handles hyperedges
+natively), which is what the pipeline produces by default — we deliberately do
+not set ``decompose_errors`` on the decoder.
+"""
+
+from __future__ import annotations
+
+from ..registry import register_decoder
+
+try:
+    from relay_bp.stim import SinterDecoder_RelayBP
+
+    register_decoder(
+        "relay-bp",
+        SinterDecoder_RelayBP,
+        aliases=["relay_bp", "relaybp"],
+        backend="cpu",
+    )
+except ImportError:
+    pass

--- a/lightstim/simulation/decoder_backend/decoders/tesseract.py
+++ b/lightstim/simulation/decoder_backend/decoders/tesseract.py
@@ -1,0 +1,56 @@
+"""Tesseract decoder (CPU) — Google's beam-search most-likely-error decoder.
+
+tesseract_decoder (https://github.com/quantumlib/tesseract-decoder) ships a
+sinter-compatible decoder, ``TesseractSinterDecoder``. This is a Pattern A
+integration — we register it under the LightStim name ``"tesseract"`` and let
+user params flow straight through ``DecoderConfig(params={...})``. Common ones:
+
+    det_beam       : int   -- beam width (accuracy/speed trade-off, e.g. 50)
+    beam_climbing  : bool  -- cost-based beam climbing
+    det_penalty    : float -- detector penalty heuristic
+    pqlimit        : int   -- priority-queue size limit
+
+See upstream for the full list, and ``tesseract-long-beam`` /
+``tesseract-short-beam`` for the paper's reference parameter sets.
+
+Unlike :mod:`relay_bp`, the import is **deferred to construction time** rather
+than done at module load. ``tesseract_decoder`` is a native extension and a
+prebuilt wheel may not match every CPU; deferring the import means that if it
+fails to load on a given host, only an explicit ``DecoderConfig("tesseract")``
+is affected rather than the whole LightStim registry. (If it fails to import,
+build tesseract_decoder from source — the repo's ``CMakeLists.txt`` uses
+``-march=native``.)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import sinter
+import stim
+
+from ..registry import register_decoder
+
+
+class TesseractDecoder(sinter.Decoder):
+    """Lazy wrapper around ``tesseract_decoder.TesseractSinterDecoder``.
+
+    The upstream class duck-types the sinter interface (it is not a
+    ``sinter.Decoder`` subclass), so we delegate ``compile_decoder_for_dem`` to
+    it. The ``tesseract_decoder`` import happens in ``__init__`` so a broken
+    wheel can't crash the registry at import time.
+    """
+
+    def __init__(self, **params: object) -> None:
+        from tesseract_decoder import TesseractSinterDecoder
+
+        self._inner = TesseractSinterDecoder(**params)
+
+    def compile_decoder_for_dem(self, *, dem: stim.DetectorErrorModel):
+        return self._inner.compile_decoder_for_dem(dem=dem)
+
+
+# find_spec checks availability without importing the native extension. The
+# actual import is deferred to TesseractDecoder.__init__.
+if importlib.util.find_spec("tesseract_decoder") is not None:
+    register_decoder("tesseract", TesseractDecoder, backend="cpu")

--- a/lightstim/simulation/decoder_backend/dem_matrices.py
+++ b/lightstim/simulation/decoder_backend/dem_matrices.py
@@ -1,0 +1,67 @@
+"""Convert a stim DetectorErrorModel into parity-check / observable matrices.
+
+Shared by every decoder backend that needs raw matrices instead of a stim DEM
+(the GPU ``cudaqx`` backend and the :mod:`external` decoder facade). Keeping a
+single implementation here avoids the subtle bit-ordering / contiguity bugs
+that creep in when this conversion is re-derived per decoder.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import stim
+
+
+def dem_to_matrices(
+    dem: stim.DetectorErrorModel,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert a stim DEM to ``(H, obs_matrix, priors)``.
+
+    Returns:
+        H          -- uint8 parity-check matrix, shape ``(n_detectors, n_error_mechanisms)``,
+                      C-contiguous (row-major) to match C++/CUDA decoder expectations.
+        obs_matrix -- uint8 observable-flip matrix, shape ``(n_observables, n_error_mechanisms)``.
+        priors     -- float64 prior error probabilities, shape ``(n_error_mechanisms,)``.
+
+    Each error instruction in the (flattened) DEM becomes one column: ``H[d, e]``
+    is 1 iff error ``e`` flips detector ``d``, and ``obs_matrix[o, e]`` is 1 iff
+    error ``e`` flips observable ``o``.
+    """
+    n_dets = dem.num_detectors
+    n_obs = dem.num_observables
+
+    error_cols: list[dict] = []
+
+    for instruction in dem.flattened():
+        if instruction.type != "error":
+            continue
+        p = instruction.args_copy()[0]
+        dets: list[int] = []
+        obs: list[int] = []
+        for t in instruction.targets_copy():
+            if t.is_relative_detector_id():
+                dets.append(t.val)
+            elif t.is_logical_observable_id():
+                obs.append(t.val)
+        error_cols.append({"p": p, "dets": dets, "obs": obs})
+
+    n_err = len(error_cols)
+    # Explicitly C-contiguous (row-major) to match decoder expectations,
+    # equivalent to scipy sparse_matrix.todense(order='C').
+    H = np.zeros((n_dets, n_err), dtype=np.uint8, order="C")
+    obs_matrix = np.zeros((n_obs, n_err), dtype=np.uint8, order="C")
+    priors = np.zeros(n_err, dtype=np.float64)
+
+    for e, col in enumerate(error_cols):
+        priors[e] = col["p"]
+        # XOR, not assignment: stim treats a target listed an even number of
+        # times as cancelling (parity), so e.g. an error listing D0 twice flips
+        # D0 zero times. Circuit-generated DEMs don't repeat targets, but a
+        # hand-written / externally-built DEM can, and assignment would mis-set
+        # those entries to 1.
+        for d in col["dets"]:
+            H[d, e] ^= 1
+        for o in col["obs"]:
+            obs_matrix[o, e] ^= 1
+
+    return np.ascontiguousarray(H), obs_matrix, priors

--- a/lightstim/simulation/decoder_backend/external.py
+++ b/lightstim/simulation/decoder_backend/external.py
@@ -1,0 +1,259 @@
+"""Friendly base class for integrating an external decoder.
+
+Most third-party / research decoders are *not* ``sinter``-compatible: they want
+a parity-check matrix and priors, they operate on plain (unpacked) syndrome
+arrays, and some of them can *fail to converge* (BP) — a fact the standard
+``sinter`` bit-packed contract has no way to express.
+
+:class:`ExternalDecoder` is a thin facade over that contract. A subclass only
+has to:
+
+1. declare ``output_type`` (``"correction"`` or ``"observables"``),
+2. build its decoder in :meth:`setup` (called once per DEM), and
+3. implement :meth:`decode_batch` *or* :meth:`decode_single` (whichever is
+   natural — lightstim bridges the other).
+
+Everything else — bit-packing, the observable-matrix multiply, and routing
+per-shot convergence flags to the pipeline — is handled here.
+
+Example::
+
+    from lightstim.simulation.decoder_backend.external import ExternalDecoder
+    from lightstim.simulation.decoder_backend.registry import register_decoder
+
+    class MyDecoder(ExternalDecoder):
+        output_type = "correction"
+
+        def setup(self, *, H, priors, **_):
+            self._inner = my_lib.Decoder(H, priors, **self.params)
+
+        def decode_single(self, syndrome):
+            correction, converged = self._inner.decode(syndrome)
+            return correction, converged   # flag=None means "always converged"
+
+    register_decoder("my-decoder", MyDecoder, backend="cpu")
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import numpy as np
+import sinter
+import stim
+
+from .dem_matrices import dem_to_matrices
+
+# Permitted values for ``ExternalDecoder.output_type``.
+_OUTPUT_CORRECTION = "correction"
+_OUTPUT_OBSERVABLES = "observables"
+_OUTPUT_TYPES = (_OUTPUT_CORRECTION, _OUTPUT_OBSERVABLES)
+
+
+class ExternalDecoder(sinter.Decoder):
+    """Base class for user-supplied decoders. Subclass and override.
+
+    Class attribute:
+        output_type: **Required.** ``"correction"`` if :meth:`decode_batch` /
+            :meth:`decode_single` return a correction over error mechanisms
+            (length ``n_error_mechanisms``) — lightstim then computes the
+            observable flips for you. ``"observables"`` if they already return
+            logical-observable flips (length ``n_observables``).
+    """
+
+    # Subclasses MUST set this; left None so a forgotten declaration fails loudly
+    # rather than silently decoding on the wrong axis.
+    output_type: Optional[str] = None
+
+    def __init__(self, **params: Any) -> None:
+        # Stored as primitives so the instance is picklable across workers.
+        self.params = dict(params)
+
+    # ------------------------------------------------------------------ #
+    # Override hooks
+    # ------------------------------------------------------------------ #
+
+    def setup(
+        self,
+        *,
+        dem: stim.DetectorErrorModel,
+        H: np.ndarray,
+        obs_matrix: np.ndarray,
+        priors: np.ndarray,
+        num_detectors: int,
+        num_observables: int,
+    ) -> None:
+        """Build the underlying decoder. Called once per DEM, before any decode.
+
+        Override and keep whatever you need on ``self``. Accept ``**_`` to
+        ignore the arguments you don't use.
+        """
+
+    def decode_batch(
+        self, syndromes: np.ndarray
+    ) -> tuple[np.ndarray, Optional[np.ndarray]]:
+        """Decode a batch of syndromes.
+
+        Args:
+            syndromes: uint8 array, shape ``(n_shots, n_detectors)``, unpacked.
+
+        Returns:
+            ``(predictions, flags)`` where ``predictions`` is a uint8 array of
+            shape ``(n_shots, k)`` — ``k = n_error_mechanisms`` if
+            ``output_type == "correction"`` else ``n_observables`` — and
+            ``flags`` is either ``None`` (every shot converged) or a boolean
+            array of shape ``(n_shots,)`` that is ``False`` for shots the
+            decoder failed on.
+        """
+        raise NotImplementedError
+
+    def decode_single(
+        self, syndrome: np.ndarray
+    ) -> tuple[np.ndarray, Optional[bool]]:
+        """Decode one syndrome.
+
+        Args:
+            syndrome: uint8 array, shape ``(n_detectors,)``, unpacked.
+
+        Returns:
+            ``(prediction, flag)`` where ``prediction`` is a uint8 array of
+            shape ``(k,)`` and ``flag`` is ``True``/``None`` (converged) or
+            ``False`` (decode failed).
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------ #
+    # sinter.Decoder glue
+    # ------------------------------------------------------------------ #
+
+    def compile_decoder_for_dem(
+        self, *, dem: stim.DetectorErrorModel
+    ) -> "_ExternalCompiledDecoder":
+        if self.output_type not in _OUTPUT_TYPES:
+            raise ValueError(
+                f"{type(self).__name__}.output_type must be one of {_OUTPUT_TYPES}, "
+                f"got {self.output_type!r}. Set it as a class attribute."
+            )
+
+        prefers_batch = self._overrides("decode_batch")
+        if not prefers_batch and not self._overrides("decode_single"):
+            raise NotImplementedError(
+                f"{type(self).__name__} must override decode_batch or decode_single."
+            )
+
+        H, obs_matrix, priors = dem_to_matrices(dem)
+        self.setup(
+            dem=dem,
+            H=H,
+            obs_matrix=obs_matrix,
+            priors=priors,
+            num_detectors=dem.num_detectors,
+            num_observables=dem.num_observables,
+        )
+        return _ExternalCompiledDecoder(
+            decoder=self,
+            obs_matrix=obs_matrix,
+            n_detectors=dem.num_detectors,
+            n_observables=dem.num_observables,
+            output_type=self.output_type,
+            prefers_batch=prefers_batch,
+        )
+
+    def _overrides(self, method_name: str) -> bool:
+        """True if a subclass overrides ``method_name`` (vs. the base stub)."""
+        return getattr(type(self), method_name) is not getattr(
+            ExternalDecoder, method_name
+        )
+
+
+class _ExternalCompiledDecoder(sinter.CompiledDecoder):
+    """Adapts an :class:`ExternalDecoder` to ``sinter.CompiledDecoder``.
+
+    Owns all bit-(un)packing and the correction → observable-flip multiply.
+    Per-shot convergence flags ride a side channel: after each
+    :meth:`decode_shots_bit_packed` call, ``self.last_flags`` holds either
+    ``None`` (all shots converged) or a boolean array (``False`` = failed). The
+    pipeline reads it in-process; it is never serialised through the bit-packed
+    return value.
+    """
+
+    def __init__(
+        self,
+        *,
+        decoder: ExternalDecoder,
+        obs_matrix: np.ndarray,
+        n_detectors: int,
+        n_observables: int,
+        output_type: str,
+        prefers_batch: bool,
+    ) -> None:
+        self._decoder = decoder
+        self._obs_matrix = obs_matrix  # (n_obs, n_err) uint8
+        self._n_detectors = n_detectors
+        self._n_observables = n_observables
+        self._output_type = output_type
+        self._prefers_batch = prefers_batch
+        # Side channel read by the pipeline after each decode call.
+        self.last_flags: Optional[np.ndarray] = None
+
+    def decode_shots_bit_packed(
+        self, *, bit_packed_detection_event_data: np.ndarray
+    ) -> np.ndarray:
+        syndromes = np.unpackbits(
+            bit_packed_detection_event_data, axis=1, bitorder="little"
+        )[:, : self._n_detectors].astype(np.uint8)
+        n_shots = syndromes.shape[0]
+
+        if self._prefers_batch:
+            predictions, flags = self._decoder.decode_batch(syndromes)
+            predictions = np.asarray(predictions, dtype=np.uint8)
+            flags = self._normalize_flags(flags, n_shots)
+        else:
+            preds: list[np.ndarray] = []
+            single_flags: list[bool] = []
+            any_flag = False
+            for i in range(n_shots):
+                pred, flag = self._decoder.decode_single(syndromes[i])
+                preds.append(np.asarray(pred, dtype=np.uint8))
+                if flag is None:
+                    single_flags.append(True)
+                else:
+                    single_flags.append(bool(flag))
+                    any_flag = True
+            predictions = (
+                np.stack(preds, axis=0)
+                if preds
+                else np.zeros((0, self._n_observables), dtype=np.uint8)
+            )
+            flags = np.asarray(single_flags, dtype=bool) if any_flag else None
+
+        self.last_flags = flags
+
+        if self._output_type == _OUTPUT_CORRECTION:
+            # corrections (n_shots, n_err) @ (n_err, n_obs) -> (n_shots, n_obs) mod 2
+            obs_preds = (
+                predictions.astype(np.int64) @ self._obs_matrix.T.astype(np.int64)
+            ) % 2
+            obs_preds = obs_preds.astype(np.uint8)
+        else:
+            obs_preds = (predictions % 2).astype(np.uint8)
+
+        n_obs_bytes = math.ceil(self._n_observables / 8) if self._n_observables else 0
+        packed = np.packbits(obs_preds, axis=1, bitorder="little")
+        return packed[:, :n_obs_bytes]
+
+    @staticmethod
+    def _normalize_flags(
+        flags: Optional[np.ndarray], n_shots: int
+    ) -> Optional[np.ndarray]:
+        """Coerce a batch flag return into ``None`` or a length-``n_shots`` bool array."""
+        if flags is None:
+            return None
+        flags = np.asarray(flags, dtype=bool).reshape(-1)
+        if flags.shape[0] != n_shots:
+            raise ValueError(
+                f"decode_batch returned {flags.shape[0]} flags for {n_shots} shots."
+            )
+        # All-converged is equivalent to no flags; collapse so the pipeline can skip work.
+        return None if flags.all() else flags

--- a/lightstim/simulation/decoder_backend/pipeline.py
+++ b/lightstim/simulation/decoder_backend/pipeline.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import stim
 
+from ._accounting import count_batch
 from .config import DecoderConfig, PipelineConfig, SimulationStats
 from .post_select import apply_post_selection, get_post_select_detector_indices
 from .progress import ProgressReporter, ProgressSnapshot, get_progress_logger
@@ -186,6 +187,7 @@ class SimulationPipeline:
                     lock,
                     wid,
                     wid if self.config.decoder.backend != "cpu" else None,
+                    self.config.decoder.on_decode_failure,
                 ),
             )
             p.start()
@@ -280,39 +282,22 @@ class SimulationPipeline:
 
             # sinter.Decoder expects little-endian bit packing.
             det_packed = np.packbits(det_filtered, axis=1, bitorder="little")
-            obs_packed = np.packbits(obs_filtered, axis=1, bitorder="little")
             pred_packed = compiled.decode_shots_bit_packed(
                 bit_packed_detection_event_data=det_packed,
             )
 
-            ps_corr_idx = self.config.post_select_corrected_observable_indices
-            if ps_corr_idx:
-                # Post-decode PS: keep only shots where corrected obs[ps_corr_idx] == 0.
-                # corrected[i] = obs[i] XOR pred[i] — the residual after applying the decoder.
-                n_obs = obs_filtered.shape[1]
-                pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
-                corrected = obs_filtered ^ pred_unpacked
-                corr_mask = np.all(corrected[:, ps_corr_idx] == 0, axis=1)
-                post_selected_shots += int(corr_mask.sum())
-                if corr_mask.sum() > 0:
-                    corrected_kept = corrected[corr_mask]
-                    target = self.config.target_observable_indices
-                    if target is not None:
-                        errors += int(np.sum(np.any(corrected_kept[:, target] != 0, axis=1)))
-                    else:
-                        errors += int(np.sum(np.any(corrected_kept != 0, axis=1)))
-            elif self.config.target_observable_indices is not None:
-                # Only count errors on specified observables
-                n_obs = obs_filtered.shape[1]
-                pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
-                target = self.config.target_observable_indices
-                post_selected_shots += kept
-                errors += int(np.sum(np.any(
-                    pred_unpacked[:, target] != obs_filtered[:, target], axis=1
-                )))
-            else:
-                post_selected_shots += kept
-                errors += int(np.sum(np.any(pred_packed != obs_packed, axis=1)))
+            batch_kept, batch_errors = count_batch(
+                obs_filtered=obs_filtered,
+                pred_packed=pred_packed,
+                post_select_corrected_observable_indices=(
+                    self.config.post_select_corrected_observable_indices
+                ),
+                target_observable_indices=self.config.target_observable_indices,
+                flags=getattr(compiled, "last_flags", None),
+                on_decode_failure=self.config.decoder.on_decode_failure,
+            )
+            post_selected_shots += batch_kept
+            errors += batch_errors
             reporter.emit(
                 self._build_snapshot(
                     shots=total_shots,

--- a/lightstim/simulation/decoder_backend/worker.py
+++ b/lightstim/simulation/decoder_backend/worker.py
@@ -30,6 +30,7 @@ def _decode_worker_cpu(
     lock,
     worker_id: int = 0,
     gpu_id: Optional[int] = None,
+    on_decode_failure: str = "error",
 ) -> None:
     """
     Single worker process: reserve shots -> sample -> post-select -> decode.
@@ -37,6 +38,7 @@ def _decode_worker_cpu(
     shots_counter tracks reserved/completed work units, preventing large overshoot
     when many workers race near max_shots.
     """
+    from ._accounting import count_batch
     from .registry import get_decoder
     from .post_select import apply_post_selection
 
@@ -73,40 +75,18 @@ def _decode_worker_cpu(
 
         # sinter.Decoder expects little-endian bit packing.
         det_packed = np.packbits(det_filtered, axis=1, bitorder="little")
-        obs_packed = np.packbits(obs_filtered, axis=1, bitorder="little")
         pred_packed = compiled.decode_shots_bit_packed(
             bit_packed_detection_event_data=det_packed,
         )
 
-        if post_select_corrected_observable_indices:
-            # Post-decode PS: keep only shots where corrected obs == 0.
-            n_obs = obs_filtered.shape[1]
-            pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
-            corrected = obs_filtered ^ pred_unpacked
-            corr_mask = np.all(corrected[:, post_select_corrected_observable_indices] == 0, axis=1)
-            kept_corr = int(corr_mask.sum())
-            if kept_corr > 0:
-                corrected_kept = corrected[corr_mask]
-                if target_observable_indices is not None:
-                    batch_errors = int(np.sum(np.any(corrected_kept[:, target_observable_indices] != 0, axis=1)))
-                else:
-                    batch_errors = int(np.sum(np.any(corrected_kept != 0, axis=1)))
-            else:
-                batch_errors = 0
-            with lock:
-                post_counter.value += kept_corr
-                errors_counter.value += batch_errors
-        elif target_observable_indices is not None:
-            n_obs = obs_filtered.shape[1]
-            pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
-            batch_errors = int(np.sum(np.any(
-                pred_unpacked[:, target_observable_indices] != obs_filtered[:, target_observable_indices], axis=1
-            )))
-            with lock:
-                post_counter.value += kept
-                errors_counter.value += batch_errors
-        else:
-            batch_errors = int(np.sum(np.any(pred_packed != obs_packed, axis=1)))
-            with lock:
-                post_counter.value += kept
-                errors_counter.value += batch_errors
+        batch_kept, batch_errors = count_batch(
+            obs_filtered=obs_filtered,
+            pred_packed=pred_packed,
+            post_select_corrected_observable_indices=post_select_corrected_observable_indices,
+            target_observable_indices=target_observable_indices,
+            flags=getattr(compiled, "last_flags", None),
+            on_decode_failure=on_decode_failure,
+        )
+        with lock:
+            post_counter.value += batch_kept
+            errors_counter.value += batch_errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,14 @@ server = [
     "uvicorn>=0.29.0",
 ]
 decoders = [
-    "stimbposd",
-    "mwpf",
+    "stimbposd",                # BP+OSD
+    "mwpf",                     # MWPF
     "frozendict",
     "frozenlist",
+    "relay-bp[stim]",           # Relay-BP
+    # Tesseract (beam-search MLE). A prebuilt wheel may not match every CPU;
+    # build it from source if it fails to import.
+    "tesseract-decoder",
 ]
 gpu = [
     "cudaq-qec",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -93,11 +93,16 @@ soupsieve==2.8.4
 stack-data==0.6.3
 stim==1.16.0
 sinter>=1.15.0
-# Optional decoders. Install individually: pip install stimbposd  OR  pip install mwpf frozendict frozenlist
+# Optional decoders. Install individually, e.g.:
+#   pip install stimbposd  |  pip install mwpf frozendict frozenlist
+#   pip install "relay-bp[stim]"  |  pip install tesseract-decoder
+# (a prebuilt tesseract-decoder wheel may not match every CPU; build from source if it fails to import.)
 stimbposd
 mwpf
 frozendict
 frozenlist
+relay-bp[stim]
+tesseract-decoder
 pandas
 seaborn
 PyMatching

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ stimbposd
 mwpf
 frozendict
 frozenlist
+relay-bp[stim]
+# Tesseract: a prebuilt wheel may not match every CPU; build from source if it fails to import.
+tesseract-decoder

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -22,8 +22,10 @@ Adding a decoder is **always one new file** in
 `decoders/__init__.py` to soft-import it, plus **one smoke test** in
 `tests/test_simulation_backend_quality.py`.
 
-This skill walks through three real patterns in the repo, ordered by
-complexity. Pick the one that matches your situation.
+This skill walks through four patterns, ordered by complexity. Patterns A/B/C
+are real decoders in the repo; Pattern D is the `ExternalDecoder` facade — the
+recommended path for any decoder that isn't already sinter-compatible. Pick the
+one that matches your situation.
 
 ---
 
@@ -92,9 +94,17 @@ That's it. No subclass needed.
 
 ## Pattern B: wrapper with parameter translation
 
-**When to use**: the upstream library implements `sinter.Decoder`, but its
-parameter names don't match LightStim's user-facing conventions, or you
-want to set defaults.
+**When to use**: you're registering a sinter-native decoder (Pattern A) and want
+to (a) expose a *unified* parameter vocabulary across several backends of the
+**same** decoder family — the reason this pattern exists in LightStim, where
+`bposd` spans a CPU (`stimbposd`) and a GPU (`cudaqx`) backend that take different
+kwarg names — or (b) set sensible defaults / rename an awkward upstream API.
+
+**When *not* to use**: a brand-new, unrelated decoder. The translation table
+below is tailored to BP+OSD and does **not** generalize. If you're just wrapping
+one library, prefer plain Pattern A and let users pass its native parameter names
+straight through `DecoderConfig(params={...})`; only add a translation layer once
+you have a second backend to keep consistent, or a concrete renaming/default need.
 
 **Real example**:
 `lightstim/simulation/decoder_backend/decoders/bposd.py`. The user passes
@@ -126,11 +136,12 @@ Key things to copy from this pattern:
 
 ---
 
-## Pattern C: custom decoder from a DEM matrix
+## Pattern C: custom decoder from a DEM matrix (full control)
 
-**When to use**: the upstream library is **not** sinter-compatible (most
-research-paper decoders, GPU libraries, neural networks). You need to
-parse the DEM into matrices yourself and write the decode loop.
+**When to use**: the upstream library is **not** sinter-compatible and you need
+lower-level control than Pattern D gives — e.g. you want to own the
+`sinter.CompiledDecoder` lifecycle yourself. You parse the DEM into matrices and
+write the decode loop by hand.
 
 **Real example**:
 `lightstim/simulation/decoder_backend/decoders/cudaqx.py` — wraps NVIDIA's
@@ -141,9 +152,11 @@ The pattern has three parts:
 ### 1. DEM → matrices
 
 Convert a `stim.DetectorErrorModel` into the (H, observable matrix,
-priors) triple your decoder needs. Steal this verbatim from `cudaqx.py`
-(`_dem_to_matrices`); it handles flattened DEMs, detector targets,
-observable targets, and decomposed errors.
+priors) triple your decoder needs. **Reuse the shared helper** rather than
+re-deriving it: `from ..dem_matrices import dem_to_matrices`. It handles
+flattened DEMs, detector targets, observable targets, and decomposed errors,
+and returns C-contiguous matrices. The equivalent code (shown here for
+reference) is:
 
 ```python
 def _dem_to_matrices(dem: stim.DetectorErrorModel):
@@ -213,6 +226,74 @@ class MyDecoder(sinter.Decoder):
 
 ---
 
+## Pattern D: `ExternalDecoder` facade (recommended for non-sinter decoders)
+
+**When to use**: the upstream library is **not** sinter-compatible (most
+research-paper decoders, GPU libraries, neural networks) **and** you'd rather
+not touch bit-packing, the observable matrix, or the sinter contract. This is
+the friendliest path — prefer it over Pattern C unless you need full control.
+
+**What you write**: subclass
+`lightstim.simulation.decoder_backend.external.ExternalDecoder`, declare
+`output_type`, build your decoder in `setup`, and implement **one** of
+`decode_batch` / `decode_single`. LightStim handles the rest (bit-packing, the
+correction→observable multiply, parallel workers, and failure-flag accounting).
+
+```python
+import numpy as np
+from lightstim.simulation.decoder_backend.external import ExternalDecoder
+from lightstim.simulation.decoder_backend.registry import register_decoder
+
+class MyDecoder(ExternalDecoder):
+    # REQUIRED. "correction" => you return a correction over error mechanisms
+    # (length n_err) and LightStim computes the observable flips for you.
+    # "observables" => you already return logical-observable flips (length n_obs).
+    output_type = "correction"
+
+    def setup(self, *, H, obs_matrix, priors, num_detectors, num_observables, dem):
+        # Called ONCE per DEM. Stash whatever you need on self.
+        # self.params holds the DecoderConfig(params=...) dict.
+        self._inner = my_lib.Decoder(H, priors, **self.params)
+
+    # Implement EITHER decode_single OR decode_batch — LightStim bridges the other.
+    def decode_single(self, syndrome):          # syndrome: (n_dets,) uint8, UNPACKED
+        correction, converged = self._inner.run(syndrome)
+        return correction, converged            # flag: True/None = ok, False = failed
+
+    # def decode_batch(self, syndromes):        # syndromes: (n_shots, n_dets) uint8
+    #     preds, flags = self._inner.run_batch(syndromes)
+    #     return preds, flags                   # flags: (n_shots,) bool, or None
+
+register_decoder("my-decoder", MyDecoder, backend="cpu")
+```
+
+### The three axes `ExternalDecoder` formalises
+
+1. **`output_type` (mandatory, no default).** `"correction"` (length `n_err`,
+   LightStim multiplies by the observable matrix) vs `"observables"` (length
+   `n_obs`, used directly). Forgetting it raises at compile time — never a
+   silent wrong-axis bug.
+2. **single vs batch.** Override whichever is natural. LightStim loops a
+   single-shot decoder over a batch, and feeds a batch decoder one-row batches.
+   Don't implement both.
+3. **failure flags.** Return a per-shot `bool` (`False` = the decoder failed to
+   converge, e.g. BP) or `None`/`True` for "always converged". What LightStim
+   does with a `False` is set by `DecoderConfig(on_decode_failure=...)`:
+   - `"error"` (default) — count the shot as a logical error.
+   - `"discard"` — herald the failure: drop it from the denominator.
+   - `"ignore"` — trust the returned prediction anyway.
+
+### What you never touch
+Bit-packing (LSB-first), the `sinter.Decoder`/`CompiledDecoder` classes, the
+`obs @ correction mod 2` step, and worker plumbing. The facade owns all of it.
+DEM→matrix conversion is shared via
+`decoder_backend/dem_matrices.py::dem_to_matrices` if you want it directly.
+
+See `tests/test_simulation_backend_quality.py` for worked examples covering the
+single→batch bridge and all three failure-flag policies.
+
+---
+
 ## Registration
 
 After your decoder file is written, add one call at module bottom:
@@ -254,6 +335,10 @@ else:
 This is mandatory. If you `import` your module unconditionally and the
 underlying library isn't installed, every LightStim user will hit an
 `ImportError` at startup.
+
+(`ExternalDecoder` subclasses register themselves the same way — there is no
+auto-discovery for them, so add the soft-import hook here too if the decoder
+depends on an optional library.)
 
 ---
 
@@ -300,8 +385,11 @@ so CI doesn't fail when the library isn't installed.
 | `lightstim/simulation/decoder_backend/decoders/mwpf.py` | **Pattern A reference** (no subclass at all) |
 | `lightstim/simulation/decoder_backend/decoders/bposd.py` | **Pattern B reference** — param translation |
 | `lightstim/simulation/decoder_backend/decoders/cudaqx.py` | **Pattern C reference** — DEM matrix + custom CompiledDecoder + GPU |
+| `lightstim/simulation/decoder_backend/external.py` | **Pattern D** — `ExternalDecoder` facade + adapter |
+| `lightstim/simulation/decoder_backend/dem_matrices.py` | Shared `dem_to_matrices()` (H, obs_matrix, priors) |
+| `lightstim/simulation/decoder_backend/_accounting.py` | Shared `count_batch()` — denominator/error counting + failure-flag policy |
 | `lightstim/simulation/decoder_backend/pipeline.py` | Consumer of the registry; you shouldn't need to touch it |
-| `lightstim/simulation/decoder_backend/config.py` | `DecoderConfig` dataclass |
+| `lightstim/simulation/decoder_backend/config.py` | `DecoderConfig` dataclass (incl. `on_decode_failure`) |
 | `tests/test_simulation_backend_quality.py` | Decoder smoke tests live here |
 
 ---
@@ -313,7 +401,7 @@ so CI doesn't fail when the library isn't installed.
 use `np.unpackbits(..., bitorder="little")` / `np.packbits(...,
 bitorder="little")`. Use big-endian by accident and every observable
 prediction will be wrong but the shape will be right — a silent
-correctness bug.
+correctness bug. (Pattern D handles this for you.)
 
 ### 2. C-contiguous matrices for GPU
 Pattern C constructs `H` and `obs_matrix` with `order="C"`. Most C++/CUDA
@@ -343,6 +431,12 @@ post-selection (state injection, distillation) works automatically — the
 pipeline filters shots before they reach you. If you need to inspect the
 post-selection mask, see `lightstim/simulation/decoder_backend/post_select.py`.
 
+### 7. Failure flags need LightStim's pipeline (Pattern D)
+Per-shot failure flags ride a side channel (`compiled.last_flags`) that the
+LightStim pipeline reads in-process. They are **not** carried by the sinter
+bit-packed return, so a decoder that relies on `on_decode_failure` heralding
+must run through `SimulationPipeline`, not a raw `sinter.collect`.
+
 ---
 
 ## End-to-end checklist
@@ -370,7 +464,7 @@ The simplest possible decoder to extend from is **PyMatching** — read
 `lightstim/simulation/decoder_backend/decoders/pymatching.py` end to end
 (it's 56 lines including imports). For parameter handling, read
 `bposd.py`. For an end-to-end custom decoder with DEM parsing and GPU
-integration, read `cudaqx.py`.
+integration, read `cudaqx.py`. For the high-level facade, read `external.py`.
 
 Once your decoder is registered, it's usable from anywhere:
 

--- a/tests/test_simulation_backend_quality.py
+++ b/tests/test_simulation_backend_quality.py
@@ -1,7 +1,12 @@
+import numpy as np
 import pytest
 import stim
 
 from lightstim.simulation.decoder_backend import DecoderConfig, SimulationPipeline, list_decoders
+from lightstim.simulation.decoder_backend._accounting import count_batch
+from lightstim.simulation.decoder_backend.dem_matrices import dem_to_matrices
+from lightstim.simulation.decoder_backend.external import ExternalDecoder
+from lightstim.simulation.decoder_backend.registry import register_decoder
 from lightstim.simulation.simulator import ExperimentTask, QECSimulator
 
 
@@ -68,6 +73,45 @@ def test_legacy_nvidia_gpu_backend_is_disabled():
         simulator.run_batch([ExperimentTask(_simple_observable_circuit())])
 
 
+def test_relay_bp_registered_and_runs():
+    """Relay-BP (sinter-native, Pattern A) registers and decodes when installed."""
+    pytest.importorskip("relay_bp")
+
+    assert "relay-bp" in list_decoders()
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("relay-bp"),
+        max_shots=200,
+        max_errors=10_000,
+        batch_size=100,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.1))
+    assert stats.shots > 0
+
+
+def test_tesseract_registered_and_runs():
+    """Tesseract (sinter-native, Pattern A, lazy import) registers and decodes.
+
+    importorskip imports tesseract_decoder; if the installed wheel doesn't match
+    your CPU it may fail to import here — build tesseract_decoder from source in
+    that case.
+    """
+    pytest.importorskip("tesseract_decoder")
+
+    assert "tesseract" in list_decoders()
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("tesseract", params={"det_beam": 40}),
+        max_shots=200,
+        max_errors=10_000,
+        batch_size=100,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.1))
+    assert stats.shots > 0
+
+
 def test_list_decoders_deduplicates_canonical_names():
     names = list_decoders()
 
@@ -91,3 +135,276 @@ def test_post_selection_can_reject_all_shots_without_decoding():
     assert stats.post_selected_shots == 0
     assert stats.errors == 0
     assert stats.post_selection_rate == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# ExternalDecoder facade
+# --------------------------------------------------------------------------- #
+#
+# For _simple_observable_circuit the DEM has one error mechanism that flips the
+# single detector and the single observable, so H and obs_matrix are both the
+# 1x1 identity. A perfect decoder therefore just echoes the syndrome: as a
+# "correction" it equals the error column, and as "observables" it equals the
+# flipped observable.
+
+
+class _PerfectSingleExternal(ExternalDecoder):
+    """Correction output via decode_single only — exercises the single->batch bridge."""
+
+    output_type = "correction"
+
+    def decode_single(self, syndrome):
+        return syndrome.astype(np.uint8), None  # flag=None => converged
+
+
+class _PerfectBatchExternal(ExternalDecoder):
+    """Correction output via decode_batch only."""
+
+    output_type = "correction"
+
+    def decode_batch(self, syndromes):
+        return syndromes.astype(np.uint8), None
+
+
+class _ObservablesExternal(ExternalDecoder):
+    """Direct observable-flip output — skips the obs_matrix multiply."""
+
+    output_type = "observables"
+
+    def decode_single(self, syndrome):
+        return syndrome.astype(np.uint8), None
+
+
+class _FlakyExternal(ExternalDecoder):
+    """Predicts perfectly but flags *every* shot as a failed decode."""
+
+    output_type = "observables"
+
+    def decode_batch(self, syndromes):
+        n = syndromes.shape[0]
+        return syndromes.astype(np.uint8), np.zeros(n, dtype=bool)  # all failed
+
+
+register_decoder("test-ext-single", _PerfectSingleExternal)
+register_decoder("test-ext-batch", _PerfectBatchExternal)
+register_decoder("test-ext-obs", _ObservablesExternal)
+register_decoder("test-ext-flaky", _FlakyExternal)
+
+
+@pytest.mark.parametrize(
+    "name", ["test-ext-single", "test-ext-batch", "test-ext-obs"]
+)
+def test_external_decoder_registered_and_corrects(name):
+    assert name in list_decoders()
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig(name),
+        max_shots=500,
+        max_errors=10_000,
+        batch_size=250,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.2))
+    # Echo decoder is exact for this code: zero residual logical errors.
+    assert stats.shots >= 500
+    assert stats.errors == 0
+
+
+def test_external_decoder_missing_output_type_raises():
+    class _NoOutputType(ExternalDecoder):
+        def decode_single(self, syndrome):
+            return syndrome, None
+
+    with pytest.raises(ValueError, match="output_type"):
+        _NoOutputType().compile_decoder_for_dem(
+            dem=_simple_observable_circuit().detector_error_model()
+        )
+
+
+def test_external_decoder_no_decode_method_raises():
+    class _NoDecode(ExternalDecoder):
+        output_type = "correction"
+
+    with pytest.raises(NotImplementedError, match="decode_batch or decode_single"):
+        _NoDecode().compile_decoder_for_dem(
+            dem=_simple_observable_circuit().detector_error_model()
+        )
+
+
+def test_failure_flag_policy_error_counts_every_shot():
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("test-ext-flaky", on_decode_failure="error"),
+        max_shots=300,
+        max_errors=10_000,
+        batch_size=300,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.2))
+    # Predictions are perfect, but every shot is flagged failed => all count as errors.
+    assert stats.post_selected_shots == stats.shots
+    assert stats.errors == stats.post_selected_shots
+    assert stats.logical_error_rate == 1.0
+
+
+def test_failure_flag_policy_discard_empties_denominator():
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("test-ext-flaky", on_decode_failure="discard"),
+        max_shots=300,
+        max_errors=10_000,
+        batch_size=300,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.2))
+    assert stats.shots >= 300
+    assert stats.post_selected_shots == 0
+    assert stats.errors == 0
+
+
+def test_failure_flag_policy_ignore_trusts_prediction():
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("test-ext-flaky", on_decode_failure="ignore"),
+        max_shots=300,
+        max_errors=10_000,
+        batch_size=300,
+        num_workers=1,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.2))
+    assert stats.post_selected_shots == stats.shots
+    assert stats.errors == 0
+
+
+def test_failure_flag_policy_error_multiprocess():
+    """Same 'error' policy through the multi-worker code path in worker.py."""
+    pipeline = SimulationPipeline(
+        decoder_config=DecoderConfig("test-ext-flaky", on_decode_failure="error"),
+        max_shots=400,
+        max_errors=10_000,
+        batch_size=100,
+        num_workers=2,
+        print_progress=False,
+    )
+    stats = pipeline.run(_simple_observable_circuit(error_probability=0.2))
+    assert stats.post_selected_shots > 0
+    assert stats.errors == stats.post_selected_shots
+
+
+# --------------------------------------------------------------------------- #
+# count_batch flag accounting (unit-level)
+# --------------------------------------------------------------------------- #
+
+
+def _pack(bits: np.ndarray) -> np.ndarray:
+    return np.packbits(bits.astype(np.uint8), axis=1, bitorder="little")
+
+
+def test_count_batch_flags_error_policy():
+    obs = np.array([[0], [0], [0]], dtype=np.uint8)
+    pred = _pack(np.array([[0], [0], [0]], dtype=np.uint8))  # all predictions correct
+    flags = np.array([True, False, True])  # shot 1 failed
+    kept, errors = count_batch(
+        obs_filtered=obs,
+        pred_packed=pred,
+        post_select_corrected_observable_indices=None,
+        target_observable_indices=None,
+        flags=flags,
+        on_decode_failure="error",
+    )
+    assert kept == 3
+    assert errors == 1  # only the failed shot
+
+
+def test_count_batch_flags_discard_policy():
+    obs = np.array([[0], [0], [0]], dtype=np.uint8)
+    pred = _pack(np.array([[1], [0], [0]], dtype=np.uint8))  # shot 0 is a real error
+    flags = np.array([True, False, False])  # shots 1,2 failed
+    kept, errors = count_batch(
+        obs_filtered=obs,
+        pred_packed=pred,
+        post_select_corrected_observable_indices=None,
+        target_observable_indices=None,
+        flags=flags,
+        on_decode_failure="discard",
+    )
+    assert kept == 1  # failed shots dropped from denominator
+    assert errors == 1  # the surviving shot 0 mispredicts
+
+
+def test_dem_to_matrices_repeated_targets_cancel():
+    """stim treats a target listed an even number of times as parity (cancel),
+    so dem_to_matrices must XOR rather than assign."""
+    dem = stim.DetectorErrorModel(
+        """
+        error(0.1) D0 D0 D1 L0 L0
+        error(0.2) D1 D2 L1
+        """
+    )
+    H, obs, priors = dem_to_matrices(dem)
+    # col 0: D0 listed twice -> cancels; D1 stays; L0 twice -> cancels.
+    assert H[:, 0].tolist() == [0, 1, 0]
+    assert obs[:, 0].tolist() == [0, 0]
+    # col 1: ordinary single targets.
+    assert H[:, 1].tolist() == [0, 1, 1]
+    assert obs[:, 1].tolist() == [0, 1]
+    assert priors.tolist() == [0.1, 0.2]
+
+
+def test_dem_to_matrices_circuit_dem_is_binary():
+    """Regression: circuit-generated DEMs (no repeated targets) stay 0/1."""
+    circuit = stim.Circuit.generated(
+        "surface_code:rotated_memory_z", distance=3, rounds=3,
+        after_clifford_depolarization=5e-3,
+    )
+    H, obs, _ = dem_to_matrices(circuit.detector_error_model())
+    assert set(np.unique(H).tolist()) <= {0, 1}
+    assert set(np.unique(obs).tolist()) <= {0, 1}
+
+
+def test_count_batch_failed_shot_survives_post_decode_ps_under_error_policy():
+    """A decode-failed shot that post-decode PS would reject must still count as a
+    logical error (and stay in the denominator) under on_decode_failure='error' —
+    not silently vanish to (kept=0, errors=0)."""
+    obs = np.array([[1], [0]], dtype=np.uint8)            # shot0 obs=1, shot1 obs=0
+    pred = _pack(np.array([[0], [0]], dtype=np.uint8))    # corrected: shot0=1 (rejected), shot1=0
+    flags = np.array([False, True])                       # shot0 failed to decode
+
+    kept, errors = count_batch(
+        obs_filtered=obs,
+        pred_packed=pred,
+        post_select_corrected_observable_indices=[0],
+        target_observable_indices=None,
+        flags=flags,
+        on_decode_failure="error",
+    )
+    assert (kept, errors) == (2, 1)  # failed shot0 counted; converged shot1 kept, no error
+
+    # discard heralds the failed shot away; ignore trusts the prediction (PS rejects shot0).
+    discard = count_batch(
+        obs_filtered=obs, pred_packed=pred,
+        post_select_corrected_observable_indices=[0], target_observable_indices=None,
+        flags=flags, on_decode_failure="discard",
+    )
+    ignore = count_batch(
+        obs_filtered=obs, pred_packed=pred,
+        post_select_corrected_observable_indices=[0], target_observable_indices=None,
+        flags=flags, on_decode_failure="ignore",
+    )
+    assert discard == (1, 0)
+    assert ignore == (1, 0)
+
+
+def test_count_batch_no_flags_matches_plain_counting():
+    obs = np.array([[0], [1], [0]], dtype=np.uint8)
+    pred = _pack(np.array([[0], [0], [0]], dtype=np.uint8))  # shot 1 mispredicted
+    kept, errors = count_batch(
+        obs_filtered=obs,
+        pred_packed=pred,
+        post_select_corrected_observable_indices=None,
+        target_observable_indices=None,
+        flags=None,
+        on_decode_failure="error",
+    )
+    assert kept == 3
+    assert errors == 1

--- a/tutorials/how-to-add-new-decoders.ipynb
+++ b/tutorials/how-to-add-new-decoders.ipynb
@@ -1,0 +1,598 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0934ac30",
+   "metadata": {},
+   "source": [
+    "# How to add a new decoder to LightStim\n",
+    "\n",
+    "LightStim's decoder backend is a small **registry** of [`sinter.Decoder`](https://github.com/quantumlib/Stim/tree/main/glue/sample) subclasses. Each decoder is registered under a *name* + *backend* (`cpu` / `gpu` / `fpga`), and at runtime\n",
+    "\n",
+    "```python\n",
+    "DecoderConfig(name=\"\u2026\", backend=\"\u2026\", params={\u2026})\n",
+    "```\n",
+    "\n",
+    "looks it up. Every consumer \u2014 the simulation pipeline, the HTTP server, the notebooks, the benchmark scripts \u2014 goes through `DecoderConfig`, so once a decoder is registered it is usable *everywhere* by name.\n",
+    "\n",
+    "This tutorial walks through **three integration patterns**, with one runnable example each. Pick the one that matches your decoder:\n",
+    "\n",
+    "| Pattern | When to use | Example here |\n",
+    "|---|---|---|\n",
+    "| **A. Register a sinter decoder** | Upstream already implements `sinter.Decoder` | PyMatching (built-in) \u00b7 **Relay-BP** |\n",
+    "| **B. Custom decoder from a DEM** | Not sinter-compatible; you want full control | **Tesseract** (shown as custom) |\n",
+    "| **C. `ExternalDecoder` facade** | Not sinter-compatible; you want the easy path | ldpc BP (correction) \u00b7 Tesseract (observables) |\n",
+    "\n",
+    "> The code cells are **defensive**: if an optional decoder library isn't installed (or a decoder errors), the cell prints why and continues, so the notebook runs end-to-end in any environment. PyMatching is a hard dependency; **Relay-BP**, **ldpc**, and **Tesseract** are optional. (A prebuilt Tesseract wheel may not match every CPU; if `import tesseract_decoder` fails, build it from source.)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3fc30a3",
+   "metadata": {},
+   "source": [
+    "## The contract\n",
+    "\n",
+    "Every decoder is a `sinter.Decoder` that implements `compile_decoder_for_dem(dem) -> sinter.CompiledDecoder`, and the compiled decoder implements `decode_shots_bit_packed(...)` \u2014 **bit-packed detector data in, bit-packed observable predictions out** (little-endian / LSB-first).\n",
+    "\n",
+    "LightStim adds three helpers around that:\n",
+    "\n",
+    "- **`register_decoder(name, cls, aliases=[\u2026], backend=\"cpu\")`** \u2014 put a decoder class in the registry.\n",
+    "- **`list_decoders()`** \u2014 the registered (canonical) names.\n",
+    "- **`DecoderConfig` / `SimulationPipeline`** \u2014 the user-facing run API.\n",
+    "\n",
+    "Let's set up a demo experiment and a tiny benchmark helper we'll reuse for every pattern.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "25821ee5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "decoders registered at import: ['bposd', 'mwpf', 'pymatching', 'relay-bp']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- make 'lightstim' importable from a source checkout ---\n",
+    "# (no-op if you've run `pip install -e .` in this kernel's environment)\n",
+    "import pathlib\n",
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    import lightstim  # noqa: F401\n",
+    "except ModuleNotFoundError:\n",
+    "    for _p in [pathlib.Path.cwd(), *pathlib.Path.cwd().parents]:\n",
+    "        if (_p / \"lightstim\" / \"__init__.py\").exists():\n",
+    "            sys.path.insert(0, str(_p))\n",
+    "            break\n",
+    "    else:\n",
+    "        raise\n",
+    "\n",
+    "import math\n",
+    "import numpy as np\n",
+    "import sinter\n",
+    "import stim\n",
+    "\n",
+    "from lightstim.simulation.decoder_backend import (\n",
+    "    DecoderConfig,\n",
+    "    SimulationPipeline,\n",
+    "    list_decoders,\n",
+    ")\n",
+    "from lightstim.simulation.decoder_backend.registry import register_decoder\n",
+    "\n",
+    "print(\"decoders registered at import:\", list_decoders())\n",
+    "\n",
+    "\n",
+    "def demo_circuit(distance: int = 5, p: float = 1e-3) -> stim.Circuit:\n",
+    "    \"\"\"A rotated surface-code Z-memory experiment with circuit-level noise.\n",
+    "\n",
+    "    Used for Patterns A & B, whose decoders (PyMatching, BP+OSD, Relay-BP)\n",
+    "    build their graph / check matrix straight from the DEM and so handle the\n",
+    "    surface code's hyperedges. NOTE: at d=5, p=1e-3 the logical error rate is\n",
+    "    tiny (well below 1e-4), so a short run usually sees 0 errors - raise\n",
+    "    max_shots for a real estimate.\n",
+    "    \"\"\"\n",
+    "    return stim.Circuit.generated(\n",
+    "        \"surface_code:rotated_memory_z\",\n",
+    "        distance=distance,\n",
+    "        rounds=distance,\n",
+    "        after_clifford_depolarization=p,\n",
+    "        before_round_data_depolarization=p,\n",
+    "        before_measure_flip_probability=p,\n",
+    "        after_reset_flip_probability=p,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def benchmark(name, params=None, circuit=None, max_shots=200_000, **pipeline_kw):\n",
+    "    \"\"\"Run one decoder through the pipeline and print its logical error rate.\n",
+    "\n",
+    "    Defensive: skips gracefully if the decoder isn't registered or errors out.\n",
+    "    \"\"\"\n",
+    "    if name not in list_decoders():\n",
+    "        print(f\"  {name:14s} not registered (optional library missing) - skipped\")\n",
+    "        return None\n",
+    "    try:\n",
+    "        stats = SimulationPipeline(\n",
+    "            decoder_config=DecoderConfig(name=name, params=params or {}),\n",
+    "            max_shots=max_shots,\n",
+    "            max_errors=100,\n",
+    "            batch_size=5_000,\n",
+    "            num_workers=4,\n",
+    "            print_progress=False,\n",
+    "            **pipeline_kw,\n",
+    "        ).run(circuit if circuit is not None else demo_circuit())\n",
+    "        print(\n",
+    "            f\"  {name:14s} LER={stats.logical_error_rate:.3e}  \"\n",
+    "            f\"({stats.errors}/{stats.post_selected_shots} shots)\"\n",
+    "        )\n",
+    "        return stats\n",
+    "    except Exception as exc:\n",
+    "        print(f\"  {name:14s} unavailable: {type(exc).__name__}: {exc}\")\n",
+    "        return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f015c20a",
+   "metadata": {},
+   "source": [
+    "## Pattern A \u2014 register a sinter-native decoder\n",
+    "\n",
+    "**When:** the upstream library already implements `sinter.Decoder`. There is nothing to write \u2014 you just put the class in the registry under a LightStim name.\n",
+    "\n",
+    "### A1. PyMatching (built-in)\n",
+    "\n",
+    "PyMatching ships as a `sinter.Decoder` and LightStim registers it out of the box. Use it by name:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "387ed34c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  pymatching     LER=2.500e-04  (50/200000 shots)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=50, seconds=0.5259534910146613, decoder='pymatching', json_metadata={})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "benchmark(\"pymatching\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "478ee53f",
+   "metadata": {},
+   "source": [
+    "### A2. Relay-BP \u2014 the highlighted example\n",
+    "\n",
+    "[Relay-BP](https://github.com/trmue/relay) ships sinter-compatible decoders via `relay_bp.stim`. `SinterDecoder_RelayBP` **is** a `sinter.Decoder` (it implements both `compile_decoder_for_dem` and `decode_via_files`), so we register the class **directly** \u2014 the purest Pattern A, exactly like the built-in `mwpf` decoder.\n",
+    "\n",
+    "`sinter_decoders(**kw)` returns `{\"relay-bp\": SinterDecoder_RelayBP(...), \"mem-bp\": ..., \"msl-bp\": ...}`; here we want the class itself so LightStim can construct it per-`DecoderConfig`.\n",
+    "\n",
+    "> LightStim also ships this as a built-in module (`decoders/relay_bp.py`), so if `relay_bp` is installed it's *already* registered as `\"relay-bp\"`. The cell below shows the **user-side** path \u2014 registering it from your own code, no library edit needed.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "115e808a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "registered 'relay-bp': True\n",
+      "  relay-bp       LER=1.450e-04  (29/200000 shots)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=29, seconds=9.036197791981976, decoder='relay-bp', json_metadata={})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# install relay-bp with: pip install relay_bp[stim]\n",
+    "try:\n",
+    "    from relay_bp.stim import SinterDecoder_RelayBP\n",
+    "\n",
+    "    register_decoder(\n",
+    "        \"relay-bp\",\n",
+    "        SinterDecoder_RelayBP,\n",
+    "        aliases=[\"relay_bp\", \"relaybp\"],\n",
+    "        backend=\"cpu\",\n",
+    "    )\n",
+    "    print(\"registered 'relay-bp':\", \"relay-bp\" in list_decoders())\n",
+    "except ImportError:\n",
+    "    print(\"relay_bp not installed - skipping registration\")\n",
+    "\n",
+    "# Relay-BP knobs flow straight through DecoderConfig(params=...) to\n",
+    "# SinterDecoder_RelayBP. gamma_dist_interval is sensitive - tune per code/DEM.\n",
+    "benchmark(\n",
+    "    \"relay-bp\",\n",
+    "    params={\n",
+    "        \"gamma0\": 0.1,\n",
+    "        \"pre_iter\": 80,\n",
+    "        \"num_sets\": 60,\n",
+    "        \"set_max_iter\": 60,\n",
+    "        \"gamma_dist_interval\": (-0.24, 0.66),\n",
+    "        \"stop_nconv\": 1,\n",
+    "    },\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea47bd7a",
+   "metadata": {},
+   "source": [
+    "**Even simpler:** if the upstream library is *fully* sinter-native (class instantiable with no required args), registration is a one-liner with no example circuit needed \u2014 e.g. the built-in MWPF decoder is literally:\n",
+    "\n",
+    "```python\n",
+    "from mwpf import SinterMWPFDecoder\n",
+    "register_decoder(\"mwpf\", SinterMWPFDecoder)\n",
+    "```\n",
+    "\n",
+    "**Need different param names or defaults?** Give your wrapper a custom `__init__(**params)` that renames or defaults kwargs before constructing the inner decoder \u2014 registration is otherwise identical. That's all the built-in `bposd` wrapper does, to share one parameter vocabulary across its CPU and GPU BP+OSD backends. For a brand-new decoder you usually *don't* need this \u2014 just register it and let users pass its native params.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd2e9ec5",
+   "metadata": {},
+   "source": [
+    "## Pattern B \u2014 custom decoder from a DEM (full control)\n",
+    "\n",
+    "**When:** the upstream library is **not** sinter-compatible and you want to own the `sinter.CompiledDecoder` lifecycle yourself \u2014 build your decoder from the DEM (or its matrices) and write the unpack \u2192 decode \u2192 pack loop.\n",
+    "\n",
+    "We illustrate it with [**Tesseract**](https://github.com/quantumlib/tesseract-decoder), Google's beam-search most-likely-error decoder. It builds straight from a `stim.DetectorErrorModel` and returns **observable flips** directly (no correction-matrix multiply needed):\n",
+    "\n",
+    "```python\n",
+    "config  = tesseract.TesseractConfig(dem=dem, det_beam=50)\n",
+    "decoder = config.compile_decoder()\n",
+    "flipped_observables = decoder.decode(syndrome)   # bool[n_dets] -> bool[n_obs]\n",
+    "```\n",
+    "\n",
+    "> **Note \u2014 Tesseract is actually sinter-native.** It ships `TesseractSinterDecoder` and `make_tesseract_sinter_decoders_dict`, so in real use you'd register it with **Pattern A** in one line (just like Relay-BP). We deliberately use its lower-level `compile_decoder()` / `decode()` API here *only to illustrate Pattern B* \u2014 wrapping a non-sinter decoder in your own `CompiledDecoder`.\n",
+    "\n",
+    "The three parts: (1) build the decoder from the DEM, (2) a custom `CompiledDecoder` that unpacks the syndromes, loops `decode`, and packs the observable flips, (3) a top-level `sinter.Decoder`. Since Tesseract is hyperedge-aware, this runs on the surface-code DEM directly (no graphlike restriction).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "52e8a8e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "registered 'tesseract': True\n",
+      "  tesseract      LER=6.000e-05  (12/200000 shots)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=12, seconds=45.589343569998164, decoder='tesseract', json_metadata={})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from tesseract_decoder import tesseract\n",
+    "\n",
+    "    class _TesseractCompiled(sinter.CompiledDecoder):\n",
+    "        def __init__(self, decoder, n_dets, n_obs):\n",
+    "            self._d = decoder\n",
+    "            self._n_dets = n_dets\n",
+    "            self._n_obs = n_obs\n",
+    "\n",
+    "        def decode_shots_bit_packed(self, *, bit_packed_detection_event_data):\n",
+    "            # unpack -> (n_shots, n_dets) bool\n",
+    "            syndromes = np.unpackbits(\n",
+    "                bit_packed_detection_event_data, axis=1, bitorder=\"little\"\n",
+    "            )[:, : self._n_dets].astype(bool)\n",
+    "            # Tesseract decodes one syndrome at a time, returning observable flips.\n",
+    "            preds = np.array(\n",
+    "                [self._d.decode(s) for s in syndromes], dtype=np.uint8\n",
+    "            ).reshape(len(syndromes), self._n_obs)\n",
+    "            # pack back, trimmed to the exact observable-byte width\n",
+    "            return np.packbits(preds, axis=1, bitorder=\"little\")[:, : math.ceil(self._n_obs / 8)]\n",
+    "\n",
+    "    class TesseractDecoder(sinter.Decoder):\n",
+    "        def __init__(self, **params):\n",
+    "            self._params = params                       # e.g. det_beam, beam_climbing\n",
+    "\n",
+    "        def compile_decoder_for_dem(self, *, dem):\n",
+    "            config = tesseract.TesseractConfig(dem=dem, **self._params)\n",
+    "            return _TesseractCompiled(\n",
+    "                config.compile_decoder(), dem.num_detectors, dem.num_observables\n",
+    "            )\n",
+    "\n",
+    "    register_decoder(\"tesseract\", TesseractDecoder)\n",
+    "    print(\"registered 'tesseract':\", \"tesseract\" in list_decoders())\n",
+    "except ImportError:\n",
+    "    print(\"tesseract_decoder not installed - skipping\")\n",
+    "\n",
+    "# Tesseract is a beam-search MLE decoder (slower per shot), so keep the shot count modest.\n",
+    "benchmark(\"tesseract\", params={\"det_beam\": 50})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ceade56",
+   "metadata": {},
+   "source": [
+    "## Pattern C \u2014 the `ExternalDecoder` facade (recommended for non-sinter decoders)\n",
+    "\n",
+    "**When:** same as Pattern B, but you'd rather *not* touch bit-packing, the sinter classes, or the worker plumbing.\n",
+    "\n",
+    "Subclass `ExternalDecoder`, declare `output_type`, build your decoder in `setup` (you receive the `dem` and its matrices `H`, `obs_matrix`, `priors`), and implement **one** of `decode_single` / `decode_batch` (LightStim bridges the other) on plain **unpacked** arrays.\n",
+    "\n",
+    "`output_type` is the key knob \u2014 it declares *what your decode returns*:\n",
+    "\n",
+    "- **`\"correction\"`** \u2014 a correction over the *error mechanisms* (length `n_err`); LightStim multiplies it by the observable matrix to get the logical flips. Natural for BP / matching-style decoders.\n",
+    "- **`\"observables\"`** \u2014 the logical-observable flips directly (length `n_obs`); no matrix multiply. Natural for MLE / neural / lookup decoders.\n",
+    "\n",
+    "We show one of each.\n",
+    "\n",
+    "### Example 1 \u2014 `output_type=\"correction\"`: plain BP from `ldpc`\n",
+    "\n",
+    "[`ldpc`](https://github.com/quantumgizmos/ldpc)'s `BpDecoder` is a non-sinter belief-propagation decoder: build it from the check matrix `H` + priors, and `decode(syndrome)` returns a correction over error mechanisms. BP can **fail to converge** \u2014 we pass its `.converge` flag straight to LightStim (see *Failure flags* below). BP handles the surface code's hyperedges, so it runs on the demo DEM directly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ff0af6d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "registered 'ldpc-bp': True\n",
+      "  ldpc-bp        LER=3.155e-02  (631/20000 shots)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SimulationStats(shots=20000, post_selected_shots=20000, errors=631, seconds=1.5319177219935227, decoder='ldpc-bp', json_metadata={})"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from lightstim.simulation.decoder_backend.external import ExternalDecoder\n",
+    "\n",
+    "try:\n",
+    "    from ldpc import BpDecoder\n",
+    "\n",
+    "    class BpExternal(ExternalDecoder):\n",
+    "        # Return a correction over error mechanisms; LightStim multiplies by the\n",
+    "        # observable matrix for us.\n",
+    "        output_type = \"correction\"\n",
+    "\n",
+    "        def setup(self, *, H, priors, **_):\n",
+    "            self._bp = BpDecoder(\n",
+    "                H, error_channel=list(priors), max_iter=100, bp_method=\"min_sum\"\n",
+    "            )\n",
+    "\n",
+    "        def decode_single(self, syndrome):\n",
+    "            correction = self._bp.decode(syndrome)\n",
+    "            # BP may not converge - pass the convergence flag (False = failed).\n",
+    "            return correction.astype(np.uint8), bool(self._bp.converge)\n",
+    "\n",
+    "    register_decoder(\"ldpc-bp\", BpExternal)\n",
+    "    print(\"registered 'ldpc-bp':\", \"ldpc-bp\" in list_decoders())\n",
+    "except ImportError:\n",
+    "    print(\"ldpc not installed - skipping\")\n",
+    "\n",
+    "# Plain BP (no OSD) is a weak surface-code decoder and often fails to converge;\n",
+    "# with on_decode_failure=\"error\" (default) those shots count as logical errors.\n",
+    "benchmark(\"ldpc-bp\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d061cadf",
+   "metadata": {},
+   "source": [
+    "### Example 2 \u2014 `output_type=\"observables\"`: Tesseract\n",
+    "\n",
+    "[Tesseract](https://github.com/quantumlib/tesseract-decoder) returns **observable flips** directly, so `output_type=\"observables\"` and there's no matrix multiply. It's the *same* decoder as Pattern B \u2014 but via the facade it's a few lines, no hand-written `CompiledDecoder`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5fa34ccf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "registered 'tesseract-ext': True\n",
+      "  tesseract-ext  LER=6.000e-05  (12/200000 shots)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=12, seconds=45.58869765899726, decoder='tesseract-ext', json_metadata={})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from tesseract_decoder import tesseract\n",
+    "\n",
+    "    class TesseractExternal(ExternalDecoder):\n",
+    "        # Tesseract returns observable flips directly (not a correction over errors).\n",
+    "        output_type = \"observables\"\n",
+    "\n",
+    "        def setup(self, *, dem, **_):\n",
+    "            # self.params holds DecoderConfig(params=...), e.g. det_beam.\n",
+    "            self._d = tesseract.TesseractConfig(dem=dem, **self.params).compile_decoder()\n",
+    "\n",
+    "        def decode_single(self, syndrome):\n",
+    "            return self._d.decode(syndrome.astype(bool)).astype(np.uint8), None\n",
+    "\n",
+    "    register_decoder(\"tesseract-ext\", TesseractExternal)\n",
+    "    print(\"registered 'tesseract-ext':\", \"tesseract-ext\" in list_decoders())\n",
+    "except ImportError:\n",
+    "    print(\"tesseract_decoder not installed - skipping\")\n",
+    "\n",
+    "# Same predictions as the Pattern B 'tesseract' decoder - the facade owns the packing.\n",
+    "benchmark(\"tesseract-ext\", params={\"det_beam\": 50})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0dc9354",
+   "metadata": {},
+   "source": [
+    "### Failure flags (`on_decode_failure`)\n",
+    "\n",
+    "The `ldpc-bp` decoder above returns a real per-shot `converge` flag (`False` = BP didn't converge). What LightStim does with a `False` is a `DecoderConfig` policy:\n",
+    "\n",
+    "- `\"error\"` *(default)* \u2014 count the shot as a logical error,\n",
+    "- `\"discard\"` \u2014 herald it: drop the shot from the denominator,\n",
+    "- `\"ignore\"` \u2014 trust the returned prediction anyway.\n",
+    "\n",
+    "(Return `None`/`True` to mean \"always succeeded\", as the Tesseract example does.) Here's the *same* `ldpc-bp` decoder under all three policies \u2014 note how `discard` reveals that BP, *when it converges*, is essentially error-free at this noise level:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "508f29b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  on_decode_failure=error    -> kept= 20000 errors=  667 LER=3.335e-02\n",
+      "  on_decode_failure=discard  -> kept= 19333 errors=    0 LER=0.000e+00\n",
+      "  on_decode_failure=ignore   -> kept= 20000 errors=   57 LER=2.850e-03\n"
+     ]
+    }
+   ],
+   "source": [
+    "if \"ldpc-bp\" not in list_decoders():\n",
+    "    print(\"ldpc not installed - skipping failure-flag demo\")\n",
+    "else:\n",
+    "    for policy in (\"error\", \"discard\", \"ignore\"):\n",
+    "        stats = SimulationPipeline(\n",
+    "            decoder_config=DecoderConfig(\"ldpc-bp\", on_decode_failure=policy),\n",
+    "            max_shots=20_000, max_errors=10**9, batch_size=5_000,\n",
+    "            num_workers=1, print_progress=False,\n",
+    "        ).run(demo_circuit())\n",
+    "        print(\n",
+    "            f\"  on_decode_failure={policy:8s} -> kept={stats.post_selected_shots:6d} \"\n",
+    "            f\"errors={stats.errors:5d} LER={stats.logical_error_rate:.3e}\"\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4db0436a",
+   "metadata": {},
+   "source": [
+    "## Making it permanent\n",
+    "\n",
+    "The cells above register decoders *at runtime* from the notebook \u2014 perfect for experiments. To ship a decoder as a **built-in** (usable by name everywhere, including the server and benchmarks), add it to the library:\n",
+    "\n",
+    "1. **One new file** in `lightstim/simulation/decoder_backend/decoders/`, ending with a `register_decoder(...)` call (wrap the upstream import in `try/except ImportError`).\n",
+    "2. **One soft-import hook** in `decoders/__init__.py`, behind an `importlib.util.find_spec(\"your_lib\")` guard, so users without the library don't hit an `ImportError` at startup.\n",
+    "3. **One smoke test** in `tests/test_simulation_backend_quality.py` (gate optional deps with `pytest.importorskip`).\n",
+    "\n",
+    "The built-in Relay-BP integration (`decoders/relay_bp.py`) is exactly this \u2014 ~15 lines.\n",
+    "\n",
+    "### Where things live\n",
+    "\n",
+    "| File | What it is |\n",
+    "|---|---|\n",
+    "| `decoder_backend/registry.py` | `register_decoder()`, `get_decoder()`, `list_decoders()` |\n",
+    "| `decoder_backend/decoders/__init__.py` | soft-import dispatcher |\n",
+    "| `decoder_backend/decoders/{pymatching,mwpf,relay_bp}.py` | Pattern A references |\n",
+    "| `decoder_backend/decoders/bposd.py` | sinter wrapper that renames params (see Pattern A note) |\n",
+    "| `decoder_backend/decoders/cudaqx.py` | Pattern B reference (DEM matrix + GPU) |\n",
+    "| `decoder_backend/external.py` | Pattern C \u2014 `ExternalDecoder` facade |\n",
+    "| `decoder_backend/dem_matrices.py` | shared `dem_to_matrices()` |\n",
+    "| `decoder_backend/config.py` | `DecoderConfig` (incl. `on_decode_failure`) |\n",
+    "\n",
+    "### Gotchas\n",
+    "\n",
+    "- **Bit order is little-endian** (`bitorder=\"little\"`) for both syndromes in and predictions out. Pattern C handles this for you.\n",
+    "- **Failure flags** ride an in-process side channel and require LightStim's `SimulationPipeline`, not a raw `sinter.collect`.\n",
+    "\n",
+    "See `skills/extend-new-decoder/SKILL.md` for the full reference.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.10.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Makes adding a decoder to the simulation backend a documented, first-class workflow, and ships the framework + two new built-ins to back it up.

Two parts:
1. **`extend-new-decoder` skill** — a guide (with the right abstractions and gotchas) for integrating any decoder, routed into the skills system.
2. **External-decoder framework + built-ins** — the code the skill points at: a friendly facade for non-sinter decoders, shared helpers, Relay-BP and Tesseract backends, and two correctness fixes.

## What's new

### Framework
- **`ExternalDecoder` facade** (`external.py`) — subclass, declare `output_type` (`"correction"` | `"observables"`), build your decoder in `setup()`, and implement **one** of `decode_single` / `decode_batch` (the other is bridged) on plain *unpacked* arrays. LightStim owns bit-packing and the observable-matrix multiply.
- **Per-shot failure flags** — a decoder that can fail (e.g. BP non-convergence) returns a boolean flag; `DecoderConfig.on_decode_failure` (`"error"` | `"discard"` | `"ignore"`) decides what `False` means.
- **Shared helpers** — `dem_matrices.py` (`dem_to_matrices`, lifted out of `cudaqx`) and `_accounting.py` (`count_batch`), which de-duplicates the denominator/error counting that `pipeline.py` and `worker.py` previously copied.

### Built-in decoders
- **Relay-BP** (`decoders/relay_bp.py`) — registers `relay_bp`'s `SinterDecoder_RelayBP` (Pattern A).
- **Tesseract** (`decoders/tesseract.py`) — registers Google's beam-search MLE decoder via a **lazy wrapper**: the native import is deferred to construction, so a prebuilt wheel that doesn't match the host CPU only affects the Tesseract decoder rather than `import lightstim`.
- Both wired into `decoders/__init__.py` discovery and the `decoders` extra.

### Fixes
- **`dem_to_matrices`** now XORs target contributions (parity) instead of assigning, so repeated targets cancel per stim's semantics. No-op for circuit-generated DEMs; corrects hand-written/external DEMs.
- **`count_batch`** — under `on_decode_failure="error"`, a failed decode now stays in the denominator even when post-decode post-selection would reject its (untrusted) corrected observables. Previously such shots silently vanished, underestimating the LER.

### Docs
- `tutorials/how-to-add-new-decoders.ipynb` — three integration patterns with runnable examples (PyMatching, Relay-BP; ldpc BP for `output_type="correction"` + the failure-flag policies; Tesseract for `output_type="observables"`).
- `SKILL.md` Pattern D (`ExternalDecoder`) and clarified when parameter translation (Pattern B) actually applies.
- README / simulation README / `pyproject` / requirements updated for Relay-BP + Tesseract.

## Testing
- New coverage in `tests/test_simulation_backend_quality.py`: `ExternalDecoder` output types, single↔batch bridge, all three flag policies, `count_batch` accounting (incl. the failed-shot-under-PS regression), `dem_to_matrices` parity, and gated Relay-BP/Tesseract smoke tests.
- Full backend suite green.

## Notes
- Relay-BP / Tesseract are optional (`pip install -e ".[decoders]"`).
- Tesseract's prebuilt wheel is a native extension that may not match every CPU; build from source if it fails to import (the repo's `CMakeLists.txt` uses `-march=native`). The lazy import means this never breaks `import lightstim` or the other decoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
