### PR TITLE
fix(decoders): defer cudaq_qec import; stop forking nvidia-smi from every CPU worker

### DIFF
--- a/lightstim/simulation/decoder_backend/decoders/__init__.py
+++ b/lightstim/simulation/decoder_backend/decoders/__init__.py
@@ -32,12 +32,13 @@ else:
     _log.debug("mwpf not installed; skipping MWPF decoder")
 
 # cudaq_qec — optional NVIDIA GPU backend.
-if importlib.util.find_spec("cudaq_qec") is not None:
-    try:
-        from . import cudaqx  # noqa: F401 — registers nv-qldpc-decoder + bposd/gpu
-    except ImportError as exc:
-        _log.debug("cudaq_qec import failed: %s", exc)
-else:
-    _log.debug("cudaq_qec not installed; skipping GPU decoder")
+# Import cudaqx unconditionally: it no longer eager-imports cudaq_qec at module
+# scope. The actual `import cudaq_qec` is deferred to first use of the GPU
+# decoder, which avoids forking nvidia-smi (and grabbing the NVML global lock)
+# in every CPU-decoder worker.
+try:
+    from . import cudaqx  # noqa: F401 — registers nv-qldpc-decoder + bposd/gpu
+except ImportError as exc:
+    _log.debug("cudaqx import failed: %s", exc)
 
 __all__ = ["PyMatchingDecoder"]

--- a/lightstim/simulation/decoder_backend/decoders/cudaqx.py
+++ b/lightstim/simulation/decoder_backend/decoders/cudaqx.py
@@ -224,17 +224,18 @@ class CudaQxDecoder(sinter.Decoder):
 
 
 # ---------------------------------------------------------------------------
-# Registration (skipped if cudaq_qec not installed)
+# Registration (no eager cudaq_qec import)
 # ---------------------------------------------------------------------------
+# We register the decoder unconditionally. The actual `import cudaq_qec`
+# is deferred to `CudaQxDecoder.compile_decoder_for_dem` (the lazy import
+# at the top of that method), so every multiprocessing worker that uses
+# a CPU decoder avoids paying the cudaq_qec startup cost — which in turn
+# forks nvidia-smi twice and grabs an NVML global lock. With many
+# concurrent workers this used to hang the GPU driver.
+#
+# GPU decoder users still get a clear ImportError at first use if
+# cudaq_qec is not installed.
 
-_CUDAQX_AVAILABLE = False
-try:
-    import cudaq_qec  # noqa: F401
-    _CUDAQX_AVAILABLE = True
-except ImportError:
-    pass
-
-if _CUDAQX_AVAILABLE:
-    register_decoder("nv-qldpc-decoder", CudaQxDecoder, backend="gpu")
-    # GPU override for the "bposd" name so DecoderConfig(name="bposd", backend="gpu") works
-    register_decoder("bposd", CudaQxDecoder, backend="gpu")
+register_decoder("nv-qldpc-decoder", CudaQxDecoder, backend="gpu")
+# GPU override for the "bposd" name so DecoderConfig(name="bposd", backend="gpu") works
+register_decoder("bposd", CudaQxDecoder, backend="gpu")

--- a/tests/test_simulation_backend_quality.py
+++ b/tests/test_simulation_backend_quality.py
@@ -15,6 +15,38 @@ def _simple_observable_circuit(error_probability: float = 0.0) -> stim.Circuit:
     return circuit
 
 
+@pytest.mark.smoke
+def test_cpu_decoder_does_not_import_cudaq_qec():
+    """CPU decoders must not eagerly import cudaq_qec.
+
+    Regression for the NVML lock contention bug where every multiprocessing
+    worker that grabbed a CPU decoder also pulled in cudaq_qec, which forks
+    two nvidia-smi probes per import. Hundreds of concurrent workers could
+    saturate the NVML global lock and hang the driver. cudaq_qec must stay
+    lazy — only loaded when the user actually requests a GPU decoder.
+    """
+    import subprocess
+    import sys
+
+    script = (
+        "import sys; "
+        "from lightstim.simulation.decoder_backend.registry import get_decoder; "
+        "d = get_decoder('pymatching', backend='cpu'); "
+        "print('cudaq_qec_imported=' + ('yes' if 'cudaq_qec' in sys.modules else 'no'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "cudaq_qec_imported=no" in result.stdout, (
+        f"cudaq_qec was imported by the CPU path:\nstdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
 def test_multiprocess_unknown_decoder_raises_in_parent():
     pipeline = SimulationPipeline(
         decoder_config=DecoderConfig("definitely_missing"),


### PR DESCRIPTION
## Summary

Every multiprocessing worker that grabbed a CPU decoder was also pulling in `cudaq_qec` (the NVIDIA GPU decoder library), which on import forks two `nvidia-smi` probes. With many concurrent workers this saturated the NVML global lock and hung the GPU driver.

**Concrete failure mode reported** (paraphrased from the bug report that surfaced this):

> Running with `--num-workers 60`, three `run_memory.py` runs in parallel ≈ 360 concurrent `nvidia-smi` calls. NVML lock contended, 263 processes stuck in D state, everyone's `nvidia-smi` and monitoring dashboards hang. `dmesg` shows no `Xid` — driver is alive, just locked. `/tmp` accumulated 276 `.cmd.capture.*` files from the forks.

## Root cause

Trace with `strace -ff -e trace=execve`:

```
get_decoder("pymatching", "cpu")
  → registry.py:45  from . import decoders          ← lazy-loads decoder modules
  → decoders/__init__.py  find_spec("cudaq_qec") → not None  
  → from . import cudaqx                            ← eager
  → cudaqx.py line ~232  try: import cudaq_qec     ← module-scope import
  → cudaq_qec internal init forks:
        sh -c "nvidia-smi >/dev/null 2>&1"
        sh -c "nvidia-smi -L 2>/dev/null | wc -..."
```

The top-level `try: import cudaq_qec` in `cudaqx.py` existed only to gate `register_decoder` calls. But `CudaQxDecoder` already has its real `import cudaq_qec` deferred to inside `compile_decoder_for_dem` (it has been lazy there from the start). So the top-level import was redundant — and exactly the thing that triggered NVML contention.

## Fix

- `cudaqx.py`: drop the top-level `try: import cudaq_qec`. `register_decoder("nv-qldpc-decoder", ...)` runs unconditionally — registration is just a dict insertion that doesn't need the library.
- `decoders/__init__.py`: drop the `importlib.util.find_spec("cudaq_qec")` gate. Now `cudaqx` is imported unconditionally — but since `cudaqx` no longer touches `cudaq_qec` at module scope, that's free.

Net effect:
- Workers using PyMatching / BPOSD / MWPF: **zero** `nvidia-smi` forks, **zero** `cudaq_qec` import work.
- Workers using `nv-qldpc-decoder` (GPU): `cudaq_qec` is loaded on first `compile_decoder_for_dem` call — i.e., once per worker, in the main process or the typically-`num_workers=1` GPU worker. Bahavior unchanged for GPU users.

## Verification

```text
1. strace get_decoder('pymatching') → no execve("nvidia-smi"). Bug is gone.
2. list_decoders() still returns ['bposd', 'mwpf', 'nv-qldpc-decoder', 'pymatching'].
3. GPU decoder instantiation does not trigger nvidia-smi either; it's deferred to compile.
4. Full `pytest -m "not slow"` passes locally.
```

## Regression test

Added `tests/test_simulation_backend_quality.py::test_cpu_decoder_does_not_import_cudaq_qec` (marked `smoke`). It spawns a subprocess that imports the registry, calls `get_decoder('pymatching', backend='cpu')`, and asserts `'cudaq_qec' not in sys.modules` afterward. This catches any future change that re-introduces the eager import.

## Test plan

- [x] strace confirms zero `nvidia-smi` execve for CPU path
- [x] strace confirms zero `nvidia-smi` execve for GPU decoder *instantiation* (only compile triggers it)
- [x] `list_decoders()` still includes `nv-qldpc-decoder`
- [x] Pipeline smoke (`tests/test_pipeline.py -m smoke`) passes
- [x] Full suite (`pytest -m "not slow"`) passes locally
- [x] New regression test passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)