### PR TITLE
docs(README): add 'Project status' section noting active development + how to pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ LightStim is a modular Quantum Error Correction (QEC) framework built on [Stim](
 - Analyze and visualize logical error rates
 - Inspect circuits interactively in a browser (DEM 3D, Circuit Timeline, DetSlice animator)
 
+## Project status
+
+LightStim is under active development alongside the paper and community
+contributions. New decoders, QEC codes, protocols, and correctness fixes
+land regularly — see the
+[Releases](https://github.com/QuTone/LightStim/releases) page for a
+running summary.
+
+- **Pulling the latest `main`** is recommended for everyday use; CI keeps
+  it green and changes are documented in commit messages.
+- For **paper-reproducibility runs**, pin to a release tag —
+  e.g. `git checkout v0.1.1` or
+  `pip install git+https://github.com/QuTone/LightStim.git@v0.1.1`.
+- To get notified about new releases, click *Watch → Custom → Releases*
+  at the top of the repo page.
+
 ## Repository layout
 
 ```text


### PR DESCRIPTION
## Summary

Adds a small **Project status** section between the feature bullets and the repository layout, so first-time readers see that:

- LightStim is under active development (decoders, codes, protocols, fixes land regularly)
- Pulling latest `main` is fine for everyday use
- For paper-reproducibility runs, pin to a release tag (`git checkout v0.1.1` or `pip install git+...@v0.1.1`)
- They can follow new releases via *Watch → Custom → Releases*

Motivation: the last week has merged several substantive PRs (SE scheduling, citation widget, NVML lock fix, the upcoming decoder framework), and we want users to know it's worth keeping current without making the project look unstable.

Kept the tone factual (no "STAR US 🌟" energy); the goal is to set the right expectation for both reviewers and contributors.

## Test plan

- [x] No code change; just a README section above "Repository layout"
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)