### PR TITLE
feat(protocols): logical Pauli — physical application vs Pauli-frame tracking (§7.1)

### DIFF
--- a/benchmarks/logical_ops/README.md
+++ b/benchmarks/logical_ops/README.md
@@ -16,6 +16,7 @@ surface code under circuit-level noise:
 | `CNOT_LS_ZZ_XX` | Lattice Surgery CNOT (ZZ-XX protocol) | same 5 sub-experiments |
 | `CNOT_LS_XX_ZZ` | Lattice Surgery CNOT (XX-ZZ protocol) | same 5 sub-experiments |
 | `memory` | Z-basis memory baseline (rounds=d) | memory_Z (1) |
+| `pauli` | Logical Pauli: physical application vs Pauli-frame tracking (rounds=d) | P{X\|Z}_{physical\|frame}_L{N} |
 
 All results are written to a single combined CSV with per-task checkpointing —
 safe to interrupt and resume.
@@ -48,12 +49,44 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
 | `--gate` | all | Gate(s) to run: `H S CNOT_trans CNOT_LS_ZZ_XX CNOT_LS_XX_ZZ memory` |
 | `--distances` | `3 5 7` | Code distances |
 | `--p-values` | `5e-4 1e-3 2e-3 5e-3 1e-2` | Physical error rates |
-| `--rounds` | `2` | SE rounds for gate benchmarks (memory always uses rounds=d) |
+| `--rounds` | `2` | SE rounds for gate benchmarks (memory and pauli always use rounds=d) |
+| `--num-layers` | `0 1 2 4 8` | Pauli layer counts N to sweep (pauli gate only) |
 | `--decoder` | `pymatching` for memory/LS CNOT; `bposd` for other gates | Decoder |
 | `--max-shots` | `1e9` | Max shots per task |
 | `--max-errors` | `100` | Stop after this many errors |
 | `--num-workers` | `8` | Parallel workers |
 | `--quick` | off | Fast test mode |
+
+## The `pauli` experiment (Handbook §7.1)
+
+Validates that physically applying a logical Pauli costs logical fidelity while
+Pauli-frame tracking is free. A memory-like circuit (rounds = d) gets N
+consecutive logical Pauli layers inserted at the midpoint:
+
+- **physical** — the Pauli string is applied as real gates; circuit-level noise
+  adds single-qubit depolarizing on the string qubits.
+- **frame** — the same layers tagged `noiseless` (skipped by noise injection):
+  the circuit-model equivalent of a classical Pauli-frame update.
+
+The two arms build gate-for-gate identical clean circuits, so
+LER(physical) − LER(frame) isolates exactly the extra error locations of
+physical application. Plotting LER vs N gives the per-layer cost as a slope:
+positive for physical, zero for frame. X̄ runs in Z-basis memory and Z̄ in
+X-basis memory (the anticommuting pairings).
+
+Note: idle noise in this codebase is lumped once per SE round, so the layer
+tick carries gate noise on the weight-d string support only — no spectator
+idling, no extended duration. The measured per-layer cost is therefore a
+lower bound on the real physical cost of applying the operator.
+
+```bash
+PYTHONPATH=. python benchmarks/logical_ops/run_logical_ops.py \
+    --gate pauli --distances 3 5 7 --num-layers 0 1 2 4 8
+```
+
+The plot script writes a dedicated figure for this experiment
+(`results/logical_pauli_plot.png`): LER vs p at the largest N, and LER vs N
+at the median p — physical solid, frame dashed.
 
 ## How to plot results
 

--- a/benchmarks/logical_ops/plot_logical_ops.py
+++ b/benchmarks/logical_ops/plot_logical_ops.py
@@ -80,6 +80,93 @@ def _plot_gate_panel(ax: plt.Axes, df_gate: pd.DataFrame, gate: str) -> None:
     bold_ticks(ax)
 
 
+def parse_pauli_subexperiments(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Expand 'pauli' gate sub_experiment labels (P{X|Z}_{physical|frame}_L{N})
+    into dedicated columns: pauli ('X'/'Z'), mode ('physical'/'frame'),
+    layers (int N).
+    """
+    parsed = df["sub_experiment"].str.extract(
+        r"^P(?P<pauli>[XZ])_(?P<mode>physical|frame)_L(?P<layers>\d+)$"
+    )
+    out = df.copy()
+    out["pauli"] = parsed["pauli"]
+    out["mode"] = parsed["mode"]
+    out["layers"] = parsed["layers"].astype(int)
+    return out
+
+
+def _plot_pauli_figure(df_pauli: pd.DataFrame, out_path: Path) -> None:
+    """
+    Dedicated §7.1 figure — physical vs frame must NOT be averaged together.
+
+    Left:  LER vs p at the largest layer count N (solid=physical, dashed=frame).
+    Right: LER vs N at a fixed p (median of swept values) — the per-layer cost
+           appears as a positive slope for physical and zero slope for frame.
+    LER is averaged over the PX/PZ pairings (symmetric sub-experiments).
+    """
+    df = parse_pauli_subexperiments(df_pauli)
+    df = (
+        df.groupby(["d", "p", "mode", "layers"])["logical_error_rate"]
+        .mean()
+        .reset_index()
+    )
+
+    fig, (ax_p, ax_n) = plt.subplots(
+        1, 2, figsize=(11, 4.5), constrained_layout=True
+    )
+    distances = sorted(df["d"].unique())
+    n_max = int(df["layers"].max())
+    p_values = sorted(df["p"].unique())
+    p_fixed = p_values[len(p_values) // 2]
+
+    style = {"physical": ("-", "physical"), "frame": ("--", "frame")}
+
+    for i, d in enumerate(distances):
+        color = PALETTE_DISTANCE.get(int(d), f"C{i % 10}")
+        marker = _MARKERS[i % len(_MARKERS)]
+        for mode, (ls, mode_label) in style.items():
+            sub = df[(df["d"] == d) & (df["mode"] == mode)
+                     & (df["layers"] == n_max)].sort_values("p")
+            if not sub.empty:
+                ax_p.plot(
+                    sub["p"], sub["logical_error_rate"],
+                    ls=ls, marker=marker, color=color, lw=2, ms=6,
+                    markeredgecolor="k", markeredgewidth=0.4,
+                    label=f"d={d} {mode_label}",
+                )
+            sub = df[(df["d"] == d) & (df["mode"] == mode)
+                     & (df["p"] == p_fixed)].sort_values("layers")
+            if not sub.empty:
+                ax_n.plot(
+                    sub["layers"], sub["logical_error_rate"],
+                    ls=ls, marker=marker, color=color, lw=2, ms=6,
+                    markeredgecolor="k", markeredgewidth=0.4,
+                    label=f"d={d} {mode_label}",
+                )
+
+    ax_p.set_xscale("log")
+    ax_p.set_yscale("log")
+    ax_p.set_xlabel("Physical error rate $p$", fontsize=11)
+    ax_p.set_ylabel("Logical error rate", fontsize=11)
+    ax_p.set_title(f"Logical Pauli, N={n_max} layers", fontsize=12, fontweight="bold")
+
+    ax_n.set_yscale("log")
+    ax_n.set_xlabel("Pauli layers $N$", fontsize=11)
+    ax_n.set_ylabel("Logical error rate", fontsize=11)
+    ax_n.set_title(f"Logical Pauli, p={p_fixed:g}", fontsize=12, fontweight="bold")
+
+    for ax in (ax_p, ax_n):
+        ax.legend(fontsize=8, framealpha=0.85, loc="upper left", ncols=2)
+        ax.grid(True, which="both", ls="--", alpha=0.4)
+        bold_ticks(ax)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out_path}")
+
+
 def main():
     ap = argparse.ArgumentParser(
         description=__doc__,
@@ -119,6 +206,17 @@ def main():
     if df.empty:
         print("No data after filtering — nothing to plot.")
         return
+
+    # The 'pauli' gate gets a dedicated figure: averaging its physical/frame
+    # sub-experiments together (as the generic panel does) would erase the
+    # very comparison the experiment makes.
+    if "pauli" in df["gate"].unique():
+        pauli_out = (Path(args.output).with_name("logical_pauli_plot.png")
+                     if args.output else SCRIPT_DIR / "results" / "logical_pauli_plot.png")
+        _plot_pauli_figure(df[df["gate"] == "pauli"], pauli_out)
+        df = df[df["gate"] != "pauli"]
+        if df.empty:
+            return
 
     gates = sorted(df["gate"].unique())
     n = len(gates)

--- a/benchmarks/logical_ops/run_logical_ops.py
+++ b/benchmarks/logical_ops/run_logical_ops.py
@@ -16,6 +16,9 @@ Supported gates
     TwoPatchLS_XX Two-patch lattice surgery XX measurement (1 sub-experiment)
     TwoPatchLS_ZZ Two-patch lattice surgery ZZ measurement (1 sub-experiment)
     memory        Z and X basis memory baseline (rounds=d); plot scripts average.
+    pauli         §7.1 logical Pauli: physical application vs Pauli-frame
+                  tracking. Memory-like (rounds=d) with N mid-circuit logical
+                  Pauli layers; sub-experiments P{X|Z}_{physical|frame}_L{N}.
 
 For state injection benchmarks, see benchmarks/state_injection/.
 
@@ -70,6 +73,7 @@ from lightstim.protocols.fold_transversal import (
 from lightstim.protocols.cnot_trans import CNOTTransExperiment
 from lightstim.protocols.cnot_ls import CNOTLSExperiment
 from lightstim.protocols.memory import MemoryExperiment
+from lightstim.protocols.logical_pauli import build_pauli_memory_circuit
 from lightstim.protocols.ghz import GHZExperiment
 from lightstim.protocols.two_patch_ls import TwoPatchLSExperiment
 from lightstim.noise.config import NoiseConfig
@@ -82,7 +86,7 @@ from lightstim.qec_code.surface_code.unrotated import (
 
 # ── Available gates ───────────────────────────────────────────────────────────
 
-ALL_GATES = ["H", "S_oneway", "S_roundtrip", "CNOT_trans", "CNOT_LS_ZZ_XX", "CNOT_LS_XX_ZZ", "GHZ", "TwoPatchLS_XX", "TwoPatchLS_ZZ", "memory"]
+ALL_GATES = ["H", "S_oneway", "S_roundtrip", "CNOT_trans", "CNOT_LS_ZZ_XX", "CNOT_LS_XX_ZZ", "GHZ", "TwoPatchLS_XX", "TwoPatchLS_ZZ", "memory", "pauli"]
 
 # CNOT sub-experiments (shared between transversal and LS variants)
 # (label, init_control, init_target, meas_control, meas_target)
@@ -355,7 +359,48 @@ def _build_two_patch_ls_tasks(distances, p_values, rounds, interaction_type):
     return tasks
 
 
-def build_tasks(gate: str, distances, p_values, rounds: int):
+def _build_pauli_tasks(distances, p_values, num_layers_list):
+    """Handbook §7.1 — logical Pauli: physical application vs Pauli-frame tracking.
+
+    Memory-like circuit (rounds=d) with N consecutive mid-circuit logical
+    Pauli layers. X̄ runs in Z-basis memory, Z̄ in X-basis memory (the
+    anticommuting, frame-relevant pairings). 'frame' inserts the same layers
+    tagged noiseless (zero physical cost), so the two arms differ only in the
+    noise on the layers: LER(physical) − LER(frame) isolates the cost of
+    applying the operator physically. LER vs N gives the per-layer cost as a
+    slope (positive for physical, zero for frame).
+    """
+    tasks = []
+    pauli_basis = [("X", "Z"), ("Z", "X")]
+    for (pauli, basis), mode, n_layers, d, p in product(
+            pauli_basis, ["physical", "frame"], num_layers_list, distances, p_values):
+        noise = NoiseConfig(p_meas=p, p_reset=p, p_1q=p, p_2q=p, p_idle=p)
+        with contextlib.redirect_stdout(io.StringIO()):
+            circuit = build_pauli_memory_circuit(
+                code_patch_class=UnrotatedSurfaceCode,
+                extraction_block_class=UnrotatedSurfaceCodeExtractionBlock,
+                code_params={"distance": d},
+                pauli=pauli, mode=mode, num_layers=n_layers,
+                rounds=d, basis=basis,
+                noise_params=noise, noise_model="circuit_level",
+            )
+        meta = {
+            "gate": "pauli",
+            "sub_experiment": f"P{pauli}_{mode}_L{n_layers}",
+            "init_basis": basis,
+            "measure_basis": basis,
+            "d": d,
+            "rounds": d,
+            "p": p,
+        }
+        tasks.append((circuit, meta))
+    return tasks
+
+
+DEFAULT_NUM_LAYERS = [0, 1, 2, 4, 8]
+
+
+def build_tasks(gate: str, distances, p_values, rounds: int, num_layers_list=None):
     """Dispatch to the appropriate circuit builder for a given gate."""
     if gate == "H":
         return _build_h_tasks(distances, p_values, rounds)
@@ -377,6 +422,11 @@ def build_tasks(gate: str, distances, p_values, rounds: int):
         return _build_two_patch_ls_tasks(distances, p_values, rounds, "ZZ")
     if gate == "memory":
         return _build_memory_tasks(distances, p_values)
+    if gate == "pauli":
+        return _build_pauli_tasks(
+            distances, p_values,
+            num_layers_list if num_layers_list is not None else DEFAULT_NUM_LAYERS,
+        )
     raise ValueError(f"Unknown gate: {gate!r}. Available: {ALL_GATES}")
 
 
@@ -507,7 +557,11 @@ def main():
     )
     ap.add_argument(
         "--rounds", type=int, default=2,
-        help="SE rounds for gate benchmarks (default: 2). Memory always uses rounds=d.",
+        help="SE rounds for gate benchmarks (default: 2). Memory and pauli always use rounds=d.",
+    )
+    ap.add_argument(
+        "--num-layers", nargs="+", type=int, default=DEFAULT_NUM_LAYERS,
+        help=f"Pauli layer counts N to sweep for the 'pauli' gate (default: {DEFAULT_NUM_LAYERS})",
     )
     ap.add_argument(
         "--decoder", choices=["cpu_bposd", "gpu_bposd", "pymatching", "mwpf"], default=None,
@@ -562,14 +616,15 @@ def main():
         # Choose decoder: explicit flag > sensible default per gate
         if args.decoder is not None:
             decoder_name = args.decoder
-        elif gate == "memory" or gate.startswith("CNOT_LS_"):
+        elif gate in ("memory", "pauli") or gate.startswith("CNOT_LS_"):
             decoder_name = "pymatching"
         else:
             decoder_name = "cpu_bposd"
 
         print(f"Decoder    : {decoder_name}")
 
-        tasks = build_tasks(gate, distances, p_values, args.rounds)
+        tasks = build_tasks(gate, distances, p_values, args.rounds,
+                            num_layers_list=args.num_layers)
         print(f"Tasks      : {len(tasks)}")
 
         _run_tasks(

--- a/lightstim/ir/operation.py
+++ b/lightstim/ir/operation.py
@@ -50,6 +50,44 @@ class CSSLogicalOpSet(LogicalOpSet):
             builder.apply_unitary_block(unitary_block=circuit)
 
 
+    def logical_pauli(self, builder: CircuitBuilder, patch: QECPatch,
+                      pauli: str = "X", logical_index: int = 0,
+                      noiseless: bool = False):
+        """
+        Applies a logical Pauli operator by physically applying its Pauli
+        string across the patch.
+
+        With noiseless=True the layer is tagged 'noiseless' so noise-injection
+        rules skip it — the circuit-level equivalent of tracking the operator
+        classically in a Pauli frame (zero physical overhead). With
+        noiseless=False the string qubits pick up gate noise, modeling a
+        genuine physical application of the operator.
+
+        Args:
+            pauli: 'X' or 'Z' — which logical operator type to apply.
+            logical_index: which operator of that type, for patches with k > 1
+                logical qubits.
+            noiseless: tag the layer so noise injection skips it.
+        """
+        pauli = pauli.upper()
+        candidates = [op for op in patch.logical_ops if op["type"] == pauli]
+        if not candidates:
+            raise ValueError(f"Patch has no logical '{pauli}' operator record.")
+        if not (0 <= logical_index < len(candidates)):
+            raise ValueError(
+                f"logical_index {logical_index} out of range: patch has "
+                f"{len(candidates)} logical '{pauli}' operator(s).")
+        record = candidates[logical_index]
+
+        # The record's Pauli string may mix X/Y/Z physical gates even for a
+        # 'X'/'Z'-type logical operator; emit one instruction per gate kind.
+        block = stim.Circuit()
+        for gate in ("X", "Y", "Z"):
+            targets = sorted(q for q, p in record["pauli"].items() if p == gate)
+            if targets:
+                block.append(gate, targets)
+        builder.apply_unitary_block(block, noiseless=noiseless)
+
     def prepare_logical_z(self, builder: CircuitBuilder,patch: QECPatch):
         """
         Prepares the logical Z state for all logical qubits in a CSS code patch.

--- a/lightstim/protocols/logical_pauli.py
+++ b/lightstim/protocols/logical_pauli.py
@@ -1,0 +1,117 @@
+# protocols/logical_pauli.py
+
+"""
+Logical Pauli memory experiment (Surface Code Handbook §7.1).
+
+A memory experiment with logical Pauli operator layer(s) inserted mid-circuit:
+
+  init(basis) → SE×⌈r/2⌉ → P̄ layer ×N → SE×⌊r/2⌋ → readout(basis)
+
+Two modes build tick-identical clean circuits:
+
+  physical — the Pauli string is applied as real gates; circuit-level noise
+             injection adds single-qubit gate noise on the string qubits.
+  frame    — the same layer is tagged 'noiseless' (skipped by noise
+             injection): the circuit-model equivalent of tracking the
+             operator classically in a Pauli frame, at zero physical cost.
+
+The LER difference between the two modes therefore isolates exactly the
+extra error locations introduced by applying the operator physically —
+within this repo's noise convention, where idle noise is lumped once per
+SE round: the layer tick adds gate noise on the weight-d string support
+only, with no spectator idling and no extension of the experiment
+duration. Under a time-step-resolved noise model the physical arm would
+also accrue spectator idle noise during each layer, so the measured
+per-layer cost is a lower bound on the real physical cost.
+num_layers stacks N consecutive layers (one tick each) to amplify the
+per-layer cost: LER vs N has positive slope for 'physical' and zero slope
+for 'frame'.
+"""
+
+import stim
+from typing import Literal, Optional, Type
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.logical_executor import LogicalExecutor
+from lightstim.ir.operation import CSSLogicalOpSet
+from lightstim.noise.config import NoiseConfig
+
+
+def build_pauli_memory_circuit(
+    code_patch_class: Type,
+    extraction_block_class: Type,
+    code_params: dict,
+    pauli: Literal["X", "Z"] = "X",
+    mode: Literal["physical", "frame"] = "physical",
+    num_layers: int = 1,
+    rounds: int = 3,
+    basis: Literal["Z", "X"] = "Z",
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+) -> stim.Circuit:
+    """
+    Build a memory circuit with mid-circuit logical Pauli layer(s).
+
+    Args:
+        code_patch_class:        QECPatch subclass (e.g. RotatedSurfaceCode).
+        extraction_block_class:  Matching SE block class.
+        code_params:             Constructor kwargs for the patch (e.g. {"distance": 3}).
+        pauli:                   Which logical operator to apply ('X' or 'Z').
+        mode:                    'physical' (noisy gates) or 'frame' (noiseless tag).
+        num_layers:              Number of consecutive Pauli layers (one tick each).
+        rounds:                  Total SE rounds, split ⌈r/2⌉ before / ⌊r/2⌋ after the layers.
+        basis:                   Memory basis for init and readout.
+        noise_params:            Optional NoiseConfig; None returns the clean circuit.
+        noise_model:             Noise model strategy string.
+
+    Returns:
+        stim.Circuit
+    """
+    if mode not in ("physical", "frame"):
+        raise ValueError(f"mode must be 'physical' or 'frame', got {mode!r}")
+    if num_layers < 0:
+        raise ValueError(f"num_layers must be >= 0, got {num_layers}")
+    basis = basis.upper()
+
+    system = QECSystem()
+    patch = system.add_patch(code_patch_class(**code_params), name="patch")
+
+    tracker = SyndromeTracker(
+        num_qubits=system.num_qubits,
+        expected_num_logicals=system.num_logicals,
+    )
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+
+    executor = LogicalExecutor(builder)
+    executor.register_op_set(code_patch_class, CSSLogicalOpSet())
+
+    builder.write_coordinates()
+    builder.initialize(
+        {q: basis for q in system.data_indices},
+        system.num_qubits,
+    )
+
+    se_block = extraction_block_class(system)
+    rounds_before = rounds - rounds // 2
+    rounds_after = rounds // 2
+
+    builder.apply_syndrome_extraction(se_block.circuit, rounds=rounds_before)
+
+    for _ in range(num_layers):
+        executor.apply_logical_operation(
+            "logical_pauli", [patch],
+            pauli=pauli, noiseless=(mode == "frame"),
+        )
+
+    if rounds_after > 0:
+        builder.apply_syndrome_extraction(se_block.circuit, rounds=rounds_after)
+
+    builder.apply_data_readout({q: basis for q in system.data_indices})
+
+    if noise_params is not None:
+        return builder.build_noisy_circuit(noise_params, noise_model)
+    return builder.circuit

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -230,6 +230,77 @@ class TestLogicalOps:
         assert c.num_detectors > 0; assert_noiseless(c)
 
 
+@pytest.mark.smoke
+class TestLogicalPauliMemory:
+    """Handbook §7.1 — logical Pauli: physical application vs Pauli-frame tracking.
+
+    Both modes must build tick-identical clean circuits; 'physical' differs
+    from 'frame' only by the noise channels on the inserted Pauli layer(s),
+    so any LER difference is attributable to those extra error locations.
+    """
+
+    def _build(self, mode, pauli="X", basis="Z", num_layers=1, rounds=3,
+               noise_params=None, code="rotated"):
+        from lightstim.protocols.logical_pauli import build_pauli_memory_circuit
+        if code == "rotated":
+            from lightstim.qec_code.surface_code.rotated import (
+                RotatedSurfaceCode, RotatedSurfaceCodeExtractionBlock)
+            patch_cls, block_cls = RotatedSurfaceCode, RotatedSurfaceCodeExtractionBlock
+        else:
+            from lightstim.qec_code.surface_code.unrotated import (
+                UnrotatedSurfaceCode, UnrotatedSurfaceCodeExtractionBlock)
+            patch_cls, block_cls = UnrotatedSurfaceCode, UnrotatedSurfaceCodeExtractionBlock
+        return build_quiet(lambda: build_pauli_memory_circuit(
+            code_patch_class=patch_cls,
+            extraction_block_class=block_cls,
+            code_params={"distance": 3},
+            pauli=pauli, mode=mode, num_layers=num_layers,
+            rounds=rounds, basis=basis,
+            noise_params=noise_params,
+        ))
+
+    @pytest.mark.parametrize("mode", ["physical", "frame"])
+    @pytest.mark.parametrize("pauli,basis", [("X", "Z"), ("Z", "Z"), ("X", "X"), ("Z", "X")])
+    def test_noiseless_invariants(self, mode, pauli, basis):
+        """Logical string commutes with all stabilizers (zero detectors); the
+        deterministic observable flip must be absorbed (zero observable errors)."""
+        c = self._build(mode, pauli=pauli, basis=basis)
+        assert_valid_circuit(c); assert_noiseless(c); assert_dem_valid(c)
+
+    def test_unrotated_noiseless(self):
+        c = self._build("physical", code="unrotated")
+        assert_valid_circuit(c); assert_noiseless(c); assert_dem_valid(c)
+
+    def test_multi_layer_noiseless(self):
+        c = self._build("physical", num_layers=4)
+        assert_valid_circuit(c); assert_noiseless(c); assert_dem_valid(c)
+
+    def test_arms_differ_only_in_pauli_layer_noise(self):
+        """The premise of the §7.1 LER comparison, asserted mechanically:
+        stripped of noise (and of the 'noiseless' tag), the two arms are
+        gate-for-gate identical; with noise, physical has exactly one extra
+        DEPOLARIZE1 instruction per inserted layer."""
+        import stim
+        from lightstim.noise.config import NoiseConfig
+        noise = NoiseConfig(p_idle=1e-3, p_1q=1e-3, p_2q=1e-3, p_meas=1e-3, p_reset=1e-3)
+        n_layers = 2
+        c_phys = self._build("physical", num_layers=n_layers, noise_params=noise)
+        c_frame = self._build("frame", num_layers=n_layers, noise_params=noise)
+
+        def strip_tags(c):
+            return stim.Circuit(str(c).replace("[noiseless]", ""))
+
+        assert strip_tags(c_phys.without_noise()) == strip_tags(c_frame.without_noise()), \
+            "clean circuits of the two arms must be identical"
+
+        def count_dep1(c):
+            return sum(1 for inst in c.flattened() if inst.name == "DEPOLARIZE1")
+
+        assert count_dep1(c_phys) == count_dep1(c_frame) + n_layers, \
+            "physical arm must add exactly one DEPOLARIZE1 per Pauli layer"
+        assert_dem_valid(c_phys); assert_dem_valid(c_frame)
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # LOGICAL CIRCUITS
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_run_logical_ops.py
+++ b/tests/test_run_logical_ops.py
@@ -1,0 +1,60 @@
+"""
+Tests for the §7.1 logical-Pauli tasks in benchmarks/logical_ops/run_logical_ops.py.
+
+Unit-level only (no simulation): task construction, metadata schema,
+checkpoint-key uniqueness.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "benchmarks" / "logical_ops"))
+
+from run_logical_ops import ALL_GATES, _ck_key, build_tasks
+
+
+@pytest.mark.smoke
+class TestPauliTasks:
+
+    def test_pauli_gate_registered(self):
+        assert "pauli" in ALL_GATES
+
+    def test_build_pauli_tasks_shape_and_meta(self):
+        tasks = build_tasks("pauli", distances=[3], p_values=[1e-3], rounds=2,
+                            num_layers_list=[0, 2])
+        # 2 pauli/basis pairings × 2 modes × 2 layer counts × 1 d × 1 p
+        assert len(tasks) == 8
+
+        subs = {m["sub_experiment"] for _, m in tasks}
+        assert subs == {
+            "PX_physical_L0", "PX_physical_L2", "PX_frame_L0", "PX_frame_L2",
+            "PZ_physical_L0", "PZ_physical_L2", "PZ_frame_L0", "PZ_frame_L2",
+        }
+
+        for circuit, meta in tasks:
+            assert circuit.num_detectors > 0
+            assert meta["gate"] == "pauli"
+            assert meta["rounds"] == meta["d"], "pauli experiment is memory-like: rounds = d"
+
+        keys = {_ck_key(m) for _, m in tasks}
+        assert len(keys) == len(tasks), "checkpoint keys must be unique per task"
+
+
+@pytest.mark.smoke
+class TestPauliPlotParsing:
+
+    def test_parse_pauli_subexperiments(self):
+        import pandas as pd
+        from plot_logical_ops import parse_pauli_subexperiments
+        df = pd.DataFrame({
+            "sub_experiment": ["PX_physical_L0", "PZ_frame_L8"],
+            "logical_error_rate": [0.1, 0.2],
+        })
+        out = parse_pauli_subexperiments(df)
+        assert list(out["pauli"]) == ["X", "Z"]
+        assert list(out["mode"]) == ["physical", "frame"]
+        assert list(out["layers"]) == [0, 8]


### PR DESCRIPTION
## Summary

Experimental validation for Surface Code Handbook §7.1 (Logical Pauli Operations): physically applying a logical Pauli operator costs logical fidelity, while tracking it classically in a Pauli frame is free.

## Design

A memory-like circuit (rounds = d) with N consecutive logical Pauli layers inserted at the midpoint:

- **physical** — the logical X̄/Z̄ string is applied as real gates; circuit-level noise adds single-qubit depolarizing on the string qubits.
- **frame** — the same layers tagged `noiseless` (skipped by noise injection): the circuit-level equivalent of a classical Pauli-frame update.

The two arms build gate-for-gate identical clean circuits (asserted by a test), so LER(physical) − LER(frame) isolates the extra error locations of physical application. LER vs N gives the per-layer cost as a slope: positive for physical, zero for frame. X̄ runs in Z-basis memory and Z̄ in X-basis memory (the anticommuting, frame-relevant pairings).

## Changes

- `lightstim/ir/operation.py` — new `CSSLogicalOpSet.logical_pauli`: applies the patch's registered logical operator string as a physical gate layer; generic across rotated/unrotated/toric (only depends on `logical_ops` metadata + `apply_unitary_block`).
- `lightstim/protocols/logical_pauli.py` — `build_pauli_memory_circuit(mode='physical'|'frame', num_layers=N, ...)`; both modes share one code path, differing only in the layer's `noiseless` flag.
- `benchmarks/logical_ops/run_logical_ops.py` — new `pauli` gate with `--num-layers` sweep (default `0 1 2 4 8`). CSV schema unchanged: variant encoded in `sub_experiment` as `P{X|Z}_{physical|frame}_L{N}`.
- `benchmarks/logical_ops/plot_logical_ops.py` — dedicated figure (LER vs p at largest N; LER vs N at median p); physical/frame are never averaged together.
- `tests/test_protocols.py`, `tests/test_run_logical_ops.py` — 8 noiseless invariant cases (zero detectors, deterministic observables), multi-layer and unrotated variants, structural arm-equality assertion (`without_noise()` circuits identical; noisy diff = exactly one `DEPOLARIZE1` per layer), runner and plot-parsing unit tests.

## Verification

- 14 new tests pass; full not-slow suite passes (`pytest tests/ -m "not slow"`).
- Quick run (unrotated, d=3, p=3e-3, MWPM, ~550 errors/point):

| arm | N=0 | N=8 |
|---|---|---|
| X̄ physical | 6.99e-3 | 8.61e-3 (+23%) |
| X̄ frame | 7.15e-3 | 7.06e-3 (flat) |
| Z̄ physical | 7.20e-3 | 1.02e-2 (+42%) |
| Z̄ frame | 7.26e-3 | 7.75e-3 (flat within error bars) |

## Caveat (documented in docstring + README)

Idle noise in this codebase is lumped once per SE round, so the inserted layer tick carries gate noise on the weight-d string support only — no spectator idling, no extended duration. The measured per-layer cost is therefore a lower bound on the real physical cost of applying the operator.
