### PR TITLE
fix(simulation): report decoded (not reserved) shots in multi-process progress

### DIFF
--- a/lightstim/simulation/decoder_backend/pipeline.py
+++ b/lightstim/simulation/decoder_backend/pipeline.py
@@ -160,7 +160,8 @@ class SimulationPipeline:
         # Multi-process
         # Use shared-memory synchronized primitives directly.
         # This avoids Manager proxy IPC overhead under high worker counts.
-        shots_counter = mp.Value("q", 0)
+        shots_counter = mp.Value("q", 0)      # reserved work (caps overshoot)
+        completed_counter = mp.Value("q", 0)  # decoded work (drives progress/stats)
         post_counter = mp.Value("q", 0)
         errors_counter = mp.Value("q", 0)
         lock = mp.Lock()
@@ -188,6 +189,7 @@ class SimulationPipeline:
                     wid,
                     wid if self.config.decoder.backend != "cpu" else None,
                     self.config.decoder.on_decode_failure,
+                    completed_counter,
                 ),
             )
             p.start()
@@ -195,7 +197,7 @@ class SimulationPipeline:
 
         while any(p.is_alive() for p in procs):
             snapshot = self._build_snapshot(
-                shots=shots_counter.value,
+                shots=completed_counter.value,
                 kept=post_counter.value,
                 errors=errors_counter.value,
                 start=start,
@@ -209,7 +211,7 @@ class SimulationPipeline:
 
         elapsed = time.perf_counter() - start
         final_snapshot = self._build_snapshot(
-            shots=shots_counter.value,
+            shots=completed_counter.value,
             kept=post_counter.value,
             errors=errors_counter.value,
             start=start,
@@ -217,7 +219,7 @@ class SimulationPipeline:
         )
         reporter.emit(final_snapshot, final=True)
         return SimulationStats(
-            shots=shots_counter.value,
+            shots=completed_counter.value,
             post_selected_shots=post_counter.value,
             errors=errors_counter.value,
             seconds=elapsed,

--- a/lightstim/simulation/decoder_backend/worker.py
+++ b/lightstim/simulation/decoder_backend/worker.py
@@ -31,12 +31,17 @@ def _decode_worker_cpu(
     worker_id: int = 0,
     gpu_id: Optional[int] = None,
     on_decode_failure: str = "error",
+    completed_counter=None,
 ) -> None:
     """
     Single worker process: reserve shots -> sample -> post-select -> decode.
     Updates shared counters (shots_counter, post_counter, errors_counter) under lock.
-    shots_counter tracks reserved/completed work units, preventing large overshoot
-    when many workers race near max_shots.
+
+    ``shots_counter`` reserves work units up front (before decoding) to cap total
+    shots and prevent large overshoot when many workers race near max_shots.
+    ``completed_counter`` (optional) counts shots only *after* they have been
+    sampled and decoded, so progress reporting reflects finished — not merely
+    reserved — work. At termination the two are equal.
     """
     from ._accounting import count_batch
     from .registry import get_decoder
@@ -71,6 +76,11 @@ def _decode_worker_cpu(
         )
         kept = det_filtered.shape[0]
         if kept == 0:
+            # These shots were still sampled/processed — count them as completed
+            # (they just contribute nothing after post-selection).
+            if completed_counter is not None:
+                with lock:
+                    completed_counter.value += shots_to_take
             continue
 
         # sinter.Decoder expects little-endian bit packing.
@@ -90,3 +100,5 @@ def _decode_worker_cpu(
         with lock:
             post_counter.value += batch_kept
             errors_counter.value += batch_errors
+            if completed_counter is not None:
+                completed_counter.value += shots_to_take


### PR DESCRIPTION
## What & why

In the multi-process decode path (`SimulationPipeline` with `num_workers > 1`), the shared `shots_counter` was incremented when a worker **reserved** a batch — before sampling and decoding — and that same counter drove both the live progress display and the final `SimulationStats.shots`.

The result was a misleading progress report: with N workers and batch size B, the shot count jumped to `N × B` in the first moment and then **froze** with `errors=0` and a ballooning ETA until whole batches finished decoding. It was especially visible with a slow decoder — e.g. plain BP on a high-rate QLDPC code — where a single batch can take minutes, so the counter appeared stuck even though decoding was progressing normally.

## Change

Split the two roles the counter was overloading:

- `shots_counter` stays the **reservation** counter — it still caps total work and prevents overshoot when workers race near `max_shots`.
- A new `completed_counter` counts shots **only after** a batch has been sampled and decoded, including the post-selected-to-empty path.

Progress snapshots and `SimulationStats.shots` now read `completed_counter`. Because `completed == reserved` at termination, **final totals are unchanged** — only the intermediate progress is now accurate. Single-process mode already counted completed shots, so it's untouched.

## Files

- `lightstim/simulation/decoder_backend/worker.py`
- `lightstim/simulation/decoder_backend/pipeline.py`

20 insertions, 6 deletions.

## Testing

- `pytest tests/ -m "not slow"` — passes, verified on a clean checkout of this branch; existing multi-process pipeline tests cover the accounting path.
- Behavioral check: progress now shows `shots=0` while batches are still decoding, then advances in step with `errors`/`LER`, with a sane ETA.

## Scope

Isolated bug fix, no API or output-shape changes; final reported numbers are identical to before.