### PR TITLE
Add rotated surface-code logical S protocol

### DIFF
--- a/benchmarks/logical_ops/README.md
+++ b/benchmarks/logical_ops/README.md
@@ -1,17 +1,19 @@
 # Logical Operations Benchmark
 
-General-purpose benchmark for logical gate performance on the unrotated surface code.
+General-purpose benchmark for logical gate performance on surface codes.
 Sweeps gate types × distances × physical error rates, saves results to CSV, and plots LER vs p.
 
 ## What this benchmark does
 
-Measures the logical error rate (LER) of six logical operations implemented on the unrotated
-surface code under circuit-level noise:
+Measures the logical error rate (LER) of logical operations under
+circuit-level noise:
 
 | Gate | Protocol | Sub-experiments |
 |------|----------|-----------------|
 | `H` | Fold-transversal Hadamard | Z→X and X→Z (2) |
-| `S` | Fold-transversal S via S·S† roundtrip | S_roundtrip (1) |
+| `S_oneway` | Unrotated fold-transversal S | noisy S, noiseless S†+MX (1) |
+| `S_roundtrip` | Unrotated fold-transversal S·S† | S_roundtrip (1) |
+| `S_rotated` | Rotated-code mid-cycle dynamical S/S† | noisy roundtrip and two gate-only +Y checks (3) |
 | `CNOT_trans` | Transversal CNOT | ZZ_ZZ, ZX_ZX, XZ_XX, XZ_ZZ, XX_XX (5) |
 | `CNOT_LS_ZZ_XX` | Lattice Surgery CNOT (ZZ-XX protocol) | same 5 sub-experiments |
 | `CNOT_LS_XX_ZZ` | Lattice Surgery CNOT (XX-ZZ protocol) | same 5 sub-experiments |
@@ -29,6 +31,14 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py
 # Single gate:
 PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py --gate H
 
+# Rotated-code logical S, production grid and historical BP+OSD settings:
+PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
+    --gate S_rotated --decoder gpu_bposd \
+    --distances 3 5 7 \
+    --p-values 5e-4 1e-3 2e-3 3e-3 5e-3 7e-3 1e-2 \
+    --max-shots 1000000000 --max-errors 100 \
+    --batch-size 50000 --num-workers 1
+
 # Custom distances and p values:
 PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
     --gate CNOT_trans --distances 3 5 7 9 --p-values 1e-4 1e-3 1e-2
@@ -45,7 +55,7 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--gate` | all | Gate(s) to run: `H S CNOT_trans CNOT_LS_ZZ_XX CNOT_LS_XX_ZZ memory` |
+| `--gate` | all | Gate(s) to run; use `--help` for the complete list |
 | `--distances` | `3 5 7` | Code distances |
 | `--p-values` | `5e-4 1e-3 2e-3 5e-3 1e-2` | Physical error rates |
 | `--rounds` | `2` | SE rounds for gate benchmarks (memory always uses rounds=d) |
@@ -53,6 +63,7 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
 | `--max-shots` | `1e9` | Max shots per task |
 | `--max-errors` | `100` | Stop after this many errors |
 | `--num-workers` | `8` | Parallel workers |
+| `--batch-size` | `1000` | Sampling batch size |
 | `--quick` | off | Fast test mode |
 
 ## How to plot results
@@ -72,6 +83,19 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_ops/plot_logical_ops.py \
 
 Output: `results/logical_ops_plot.png` — one subplot per gate, LER vs p on log-log axes,
 one curve per distance.
+
+`S_rotated` is expanded into three panels rather than averaged: the noisy
+S→S† full-circuit roundtrip, the gate-only +Y→S†→+X experiment, and the
+gate-only +Y→S→−X experiment. The deterministic −X reference removes the need
+for a physical logical-Pauli correction. Its single-gate default checkpoint is
+`results/rotated_s_results.csv`.
+
+The production sweep uses the existing decoder configuration from
+`run_logical_ops.py`: min-sum BP, 1000 iterations, OSD-CS order 10, and dynamic
+min-sum scaling (`ms_scaling_factor=0`). The command above uses the seven-point
+physical-error grid shared with the unrotated logical-S experiment and stops
+after 100 logical errors. `--quick` is only a circuit/pipeline smoke test; its
+low-error points are not benchmark data.
 
 ## Related benchmarks
 

--- a/benchmarks/logical_ops/plot_logical_ops.py
+++ b/benchmarks/logical_ops/plot_logical_ops.py
@@ -42,8 +42,14 @@ _MARKERS = ["o", "s", "^", "D", "v", "P", "*", "X"]
 _DEFAULT_INPUT  = SCRIPT_DIR / "results" / "logical_ops_results.csv"
 _DEFAULT_OUTPUT = SCRIPT_DIR / "results" / "logical_ops_plot.png"
 
+_ROTATED_S_TITLES = {
+    "S_then_S_DAG": r"Rotated S$\rightarrow$S$^\dagger$ roundtrip",
+    "S_DAG_plusY_to_X": r"Rotated S$^\dagger$: $+Y\rightarrow +X$",
+    "S_plusY_to_minusX": r"Rotated S: $+Y\rightarrow -X$",
+}
 
-def _plot_gate_panel(ax: plt.Axes, df_gate: pd.DataFrame, gate: str) -> None:
+
+def _plot_gate_panel(ax: plt.Axes, df_gate: pd.DataFrame, title: str) -> None:
     """
     Plot one panel (one gate): one curve per distance.
 
@@ -74,10 +80,56 @@ def _plot_gate_panel(ax: plt.Axes, df_gate: pd.DataFrame, gate: str) -> None:
     ax.set_yscale("log")
     ax.set_xlabel("Physical error rate $p$", fontsize=11)
     ax.set_ylabel("Logical error rate", fontsize=11)
-    ax.set_title(gate, fontsize=12, fontweight="bold")
+    ax.set_title(title, fontsize=12, fontweight="bold")
     ax.legend(fontsize=9, framealpha=0.85, loc="upper left")
     ax.grid(True, which="both", ls="--", alpha=0.4)
     bold_ticks(ax)
+
+
+def _panel_specs(df: pd.DataFrame) -> list[tuple[str, pd.DataFrame]]:
+    """Return plot panels without averaging unlike rotated-S experiments."""
+    panels = []
+    for gate in sorted(df["gate"].unique()):
+        df_gate = df[df["gate"] == gate]
+        if gate != "S_rotated":
+            panels.append((gate, df_gate))
+            continue
+        for sub_experiment in _ROTATED_S_TITLES:
+            df_sub = df_gate[
+                df_gate["sub_experiment"] == sub_experiment
+            ]
+            if not df_sub.empty:
+                panels.append(
+                    (_ROTATED_S_TITLES[sub_experiment], df_sub)
+                )
+    return panels
+
+
+def plot_results(df: pd.DataFrame) -> plt.Figure:
+    """Build the logical-operations figure for an already-filtered table."""
+    if df.empty:
+        raise ValueError("No data to plot.")
+
+    panels = _panel_specs(df)
+    n = len(panels)
+    ncols = min(n, 3)
+    nrows = (n + ncols - 1) // ncols
+    fig, axes = plt.subplots(
+        nrows, ncols,
+        figsize=(5.5 * ncols, 4.5 * nrows),
+        constrained_layout=True,
+        squeeze=False,
+    )
+
+    for idx, (title, df_panel) in enumerate(panels):
+        row, col = divmod(idx, ncols)
+        _plot_gate_panel(axes[row][col], df_panel, title)
+
+    for idx in range(n, nrows * ncols):
+        row, col = divmod(idx, ncols)
+        axes[row][col].set_visible(False)
+
+    return fig
 
 
 def main():
@@ -120,29 +172,7 @@ def main():
         print("No data after filtering — nothing to plot.")
         return
 
-    gates = sorted(df["gate"].unique())
-    n = len(gates)
-
-    # Layout: up to 3 columns
-    ncols = min(n, 3)
-    nrows = (n + ncols - 1) // ncols
-    fig, axes = plt.subplots(
-        nrows, ncols,
-        figsize=(5.5 * ncols, 4.5 * nrows),
-        constrained_layout=True,
-        squeeze=False,
-    )
-
-    for idx, gate in enumerate(gates):
-        row, col = divmod(idx, ncols)
-        ax = axes[row][col]
-        df_gate = df[df["gate"] == gate]
-        _plot_gate_panel(ax, df_gate, gate)
-
-    # Hide unused axes
-    for idx in range(n, nrows * ncols):
-        row, col = divmod(idx, ncols)
-        axes[row][col].set_visible(False)
+    fig = plot_results(df)
 
     if args.output:
         out = Path(args.output)

--- a/benchmarks/logical_ops/run_logical_ops.py
+++ b/benchmarks/logical_ops/run_logical_ops.py
@@ -1,7 +1,7 @@
 """
 General logical operations benchmark runner for LightStim.
 
-Sweeps gate types × distances × physical error rates for the unrotated surface code.
+Sweeps gate types × distances × physical error rates for surface codes.
 Results are saved to a combined CSV with per-task checkpointing (append-on-complete).
 
 Supported gates
@@ -9,6 +9,7 @@ Supported gates
     H             Fold-transversal Hadamard (2 sub-experiments: Z→X and X→Z)
     S_oneway      1-way S: noisy S, noiseless S†+MX. LER ≈ LER_per_S.
     S_roundtrip   2-way S: noisy S and S†. LER_per_gate ≈ total_LER / 2.
+    S_rotated     Rotated-code mid-cycle S/S† (roundtrip and +Y checks)
     CNOT_trans    Transversal CNOT (5 sub-experiments)
     CNOT_LS_ZZ_XX Lattice Surgery CNOT, ZZ-XX protocol (5 sub-experiments)
     CNOT_LS_XX_ZZ Lattice Surgery CNOT, XX-ZZ protocol (5 sub-experiments)
@@ -67,6 +68,10 @@ from lightstim.protocols.fold_transversal import (
     build_s_oneway_circuit,
     build_s_roundtrip_circuit,
 )
+from lightstim.protocols.rotated_logical_s import (
+    build_rotated_s_two_way_circuit,
+    build_rotated_s_y_injection_circuit,
+)
 from lightstim.protocols.cnot_trans import CNOTTransExperiment
 from lightstim.protocols.cnot_ls import CNOTLSExperiment
 from lightstim.protocols.memory import MemoryExperiment
@@ -82,7 +87,19 @@ from lightstim.qec_code.surface_code.unrotated import (
 
 # ── Available gates ───────────────────────────────────────────────────────────
 
-ALL_GATES = ["H", "S_oneway", "S_roundtrip", "CNOT_trans", "CNOT_LS_ZZ_XX", "CNOT_LS_XX_ZZ", "GHZ", "TwoPatchLS_XX", "TwoPatchLS_ZZ", "memory"]
+ALL_GATES = [
+    "H",
+    "S_oneway",
+    "S_roundtrip",
+    "S_rotated",
+    "CNOT_trans",
+    "CNOT_LS_ZZ_XX",
+    "CNOT_LS_XX_ZZ",
+    "GHZ",
+    "TwoPatchLS_XX",
+    "TwoPatchLS_ZZ",
+    "memory",
+]
 
 # CNOT sub-experiments (shared between transversal and LS variants)
 # (label, init_control, init_target, meas_control, meas_target)
@@ -158,6 +175,54 @@ def _build_s_roundtrip_tasks(distances, p_values, rounds):
             "d": d,
             "rounds": rounds,
             "p": p,
+        }
+        tasks.append((circuit, meta))
+    return tasks
+
+
+def _build_rotated_s_tasks(distances, p_values, rounds):
+    """Rotated-code dynamical S: roundtrip plus two gate-only checks.
+
+    The two-way circuit follows the historical S benchmark and makes
+    preparation, padding, both gates, and readout noisy. The one-way circuits
+    inject +Y, pad, and read out noiselessly so that only the selected
+    mid-cycle S-SE round is noisy.
+    """
+    tasks = []
+    sub_experiments = [
+        ("S_then_S_DAG", "X", 2),
+        ("S_DAG_plusY_to_X", "+Y", 1),
+        ("S_plusY_to_minusX", "+Y", 1),
+    ]
+    for (sub, init_b, noisy_gate_count), d, p in product(
+        sub_experiments,
+        distances,
+        p_values,
+    ):
+        noise = NoiseConfig(p_meas=p, p_reset=p, p_1q=p, p_2q=p, p_idle=p)
+        with contextlib.redirect_stdout(io.StringIO()):
+            if sub == "S_then_S_DAG":
+                circuit = build_rotated_s_two_way_circuit(
+                    distance=d,
+                    rounds=rounds,
+                    noise_params=noise,
+                )
+            else:
+                circuit = build_rotated_s_y_injection_circuit(
+                    distance=d,
+                    gate="S_DAG" if sub == "S_DAG_plusY_to_X" else "S",
+                    padding_rounds=rounds,
+                    noise_params=noise,
+                )
+        meta = {
+            "gate": "S_rotated",
+            "sub_experiment": sub,
+            "init_basis": init_b,
+            "measure_basis": "X",
+            "d": d,
+            "rounds": rounds,
+            "p": p,
+            "noisy_gate_count": noisy_gate_count,
         }
         tasks.append((circuit, meta))
     return tasks
@@ -363,6 +428,8 @@ def build_tasks(gate: str, distances, p_values, rounds: int):
         return _build_s_oneway_tasks(distances, p_values, rounds)
     if gate == "S_roundtrip":
         return _build_s_roundtrip_tasks(distances, p_values, rounds)
+    if gate == "S_rotated":
+        return _build_rotated_s_tasks(distances, p_values, rounds)
     if gate == "CNOT_trans":
         return _build_cnot_trans_tasks(distances, p_values, rounds)
     if gate == "CNOT_LS_ZZ_XX":
@@ -430,7 +497,8 @@ def _load_done_keys(path: Path) -> set:
 
 def _run_tasks(task_list, decoder_cfg: DecoderConfig,
                max_shots: int, max_errors: int,
-               num_workers: int, output_path: Path) -> None:
+               num_workers: int, output_path: Path,
+               *, batch_size: int = 1_000) -> None:
     """
     Run a list of (circuit, metadata) tuples with per-task checkpointing.
     Already-completed tasks (by checkpoint key) are skipped on resume.
@@ -453,7 +521,7 @@ def _run_tasks(task_list, decoder_cfg: DecoderConfig,
         decoder_config=decoder_cfg,
         max_shots=max_shots,
         max_errors=max_errors,
-        batch_size=1_000,
+        batch_size=batch_size,
         num_workers=num_workers,
         print_progress=True,
     )
@@ -516,13 +584,17 @@ def main():
     ap.add_argument("--max-shots",   type=int, default=1_000_000_000)
     ap.add_argument("--max-errors",  type=int, default=100)
     ap.add_argument("--num-workers", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=1_000)
     ap.add_argument(
         "--quick", action="store_true",
         help="Quick mode: distances=[3,5], 2 p-values, max_shots=100k, max_errors=20",
     )
     ap.add_argument(
         "--output", default=None,
-        help="Output CSV path (default: results/logical_ops_results.csv)",
+        help=(
+            "Output CSV path. Defaults to results/rotated_s_results.csv for "
+            "an S_rotated-only run and results/logical_ops_results.csv otherwise."
+        ),
     )
     args = ap.parse_args()
 
@@ -539,11 +611,15 @@ def main():
         max_errors = args.max_errors
 
     gates_to_run = args.gate if args.gate else ALL_GATES
-    output_path  = Path(args.output) if args.output else \
-        SCRIPT_DIR / "results" / "logical_ops_results.csv"
+    if args.output:
+        output_path = Path(args.output)
+    elif gates_to_run == ["S_rotated"]:
+        output_path = SCRIPT_DIR / "results" / "rotated_s_results.csv"
+    else:
+        output_path = SCRIPT_DIR / "results" / "logical_ops_results.csv"
 
     print("=" * 60)
-    print("Logical Operations Benchmark — Unrotated Surface Code")
+    print("Logical Operations Benchmark — Surface Codes")
     print(f"Mode       : {'quick' if args.quick else 'full'}")
     print(f"Gates      : {gates_to_run}")
     print(f"Distances  : {distances}")
@@ -578,6 +654,7 @@ def main():
             max_shots, max_errors,
             args.num_workers,
             output_path,
+            batch_size=args.batch_size,
         )
 
     print("\n" + "=" * 60)

--- a/benchmarks/logical_ops/run_logical_ops.py
+++ b/benchmarks/logical_ops/run_logical_ops.py
@@ -56,6 +56,7 @@ import io
 import sys
 import time
 from itertools import product
+from numbers import Real
 from pathlib import Path
 
 import pandas as pd
@@ -479,11 +480,22 @@ _RESULT_COLS = frozenset({
 
 
 def _ck_key(row: dict) -> tuple:
-    """Stable checkpoint key from input-only fields (floats normalized to 6-digit sci)."""
-    return tuple(
-        f"{v:.6e}" if isinstance(v, float) else str(v)
-        for k, v in sorted(row.items()) if k not in _RESULT_COLS
-    )
+    """Stable checkpoint key from input-only fields.
+
+    CSV round-trips can promote optional integer fields to floats and represent
+    missing fields as NaN. Normalize those cases so a persisted task still
+    matches the metadata produced by a fresh benchmark run.
+    """
+    key = []
+    for field, value in sorted(row.items()):
+        if field in _RESULT_COLS or pd.isna(value):
+            continue
+        if isinstance(value, Real) and not isinstance(value, bool):
+            value = f"{float(value):.12g}"
+        else:
+            value = str(value)
+        key.append((field, value))
+    return tuple(key)
 
 
 def _load_done_keys(path: Path) -> set:
@@ -491,6 +503,48 @@ def _load_done_keys(path: Path) -> set:
         return set()
     df = pd.read_csv(path)
     return {_ck_key(r) for r in df.to_dict("records")}
+
+
+def _ensure_csv_schema(path: Path, rows) -> None:
+    """Add newly introduced fields to an existing results CSV."""
+    if not path.exists():
+        return
+
+    df = pd.read_csv(path)
+    missing = []
+    for row in rows:
+        for field in row:
+            if field not in df.columns and field not in missing:
+                missing.append(field)
+    if not missing:
+        return
+
+    columns = list(df.columns)
+    insert_at = next(
+        (i for i, field in enumerate(columns) if field in _RESULT_COLS),
+        len(columns),
+    )
+    for field in missing:
+        df.insert(insert_at, field, pd.NA)
+        insert_at += 1
+    df.to_csv(path, index=False)
+
+
+def _append_result_row(path: Path, row: dict) -> None:
+    """Append one result while preserving the CSV's column alignment."""
+    _ensure_csv_schema(path, [row])
+    exists = path.exists()
+    columns = (
+        list(pd.read_csv(path, nrows=0).columns)
+        if exists
+        else list(row)
+    )
+    pd.DataFrame([row], columns=columns).to_csv(
+        path,
+        mode="a",
+        header=not exists,
+        index=False,
+    )
 
 
 # ── Runner ────────────────────────────────────────────────────────────────────
@@ -505,6 +559,7 @@ def _run_tasks(task_list, decoder_cfg: DecoderConfig,
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
+    _ensure_csv_schema(output_path, (metadata for _, metadata in task_list))
     done_keys = _load_done_keys(output_path)
     if done_keys:
         print(f"  Checkpoint: {len(done_keys)} task(s) already done, skipping.")
@@ -545,9 +600,7 @@ def _run_tasks(task_list, decoder_cfg: DecoderConfig,
             "decoder": stats.decoder,
         }
         # Persist immediately — a kill/OOM never loses this result
-        pd.DataFrame([row]).to_csv(
-            output_path, mode="a", header=not output_path.exists(), index=False,
-        )
+        _append_result_row(output_path, row)
         print(f"  -> LER={stats.logical_error_rate:.2e} "
               f"({stats.errors} errors, {stats.shots:,} shots, {elapsed:.1f}s)", flush=True)
 

--- a/lightstim/protocols/rotated_logical_s.py
+++ b/lightstim/protocols/rotated_logical_s.py
@@ -1,0 +1,213 @@
+"""Logical S experiments for the rotated surface code.
+
+The logical phase gate is the dynamical fold-transversal protocol inserted
+halfway through one syndrome-extraction round (arXiv:2412.01391).
+
+Two verification circuits are provided:
+
+``build_rotated_s_two_way_circuit``
+    Noisy ``S`` followed by noisy ``S†``.  The round-trip preserves ``|+>``.
+    As in the historical unrotated benchmark, preparation, padding, and
+    readout are also noisy, so this is a full-circuit consistency metric rather
+    than an isolated per-gate estimate.
+
+``build_rotated_s_y_injection_circuit``
+    A gate-only experiment.  A logical ``+Y`` state is injected and padded
+    noiselessly, the selected dynamical phase gate is noisy, and the
+    deterministic ``+X`` (for ``S†``) or ``-X`` (for ``S``) result is read
+    out noiselessly.  No physical Pauli correction is needed because the
+    sampler measures flips relative to the noiseless reference.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional, Tuple
+
+import stim
+
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.logical_executor import LogicalExecutor
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.noise.config import NoiseConfig
+from lightstim.qec_code.surface_code.rotated import (
+    RotatedSurfaceCode,
+    RotatedSurfaceCodeExtractionBlock,
+    RotatedSurfaceCodeLogicalOpSet,
+)
+
+PhaseGate = Literal["S", "S_DAG"]
+
+
+def _setup(
+    distance: int,
+) -> Tuple[
+    QECSystem,
+    RotatedSurfaceCode,
+    CircuitBuilder,
+    LogicalExecutor,
+]:
+    patch_local = RotatedSurfaceCode(distance=distance)
+    system = QECSystem()
+    patch = system.add_patch(patch_local, name="patch")
+
+    tracker = SyndromeTracker(
+        num_qubits=system.num_qubits,
+        expected_num_logicals=system.num_logicals,
+    )
+    builder = CircuitBuilder(
+        tracker=tracker,
+        system_config=system,
+        if_detector=True,
+    )
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+
+    executor = LogicalExecutor(builder)
+    executor.register_op_set(
+        RotatedSurfaceCode,
+        RotatedSurfaceCodeLogicalOpSet(
+            extraction_block_class=RotatedSurfaceCodeExtractionBlock,
+        ),
+    )
+    builder.write_coordinates()
+    return system, patch, builder, executor
+
+
+def _fully_noiseless_extraction_round(
+    system: QECSystem,
+) -> stim.Circuit:
+    """Return an SE round whose gates *and* idle boundary are noiseless.
+
+    ``CircuitBuilder.apply_syndrome_extraction(noiseless=True)`` tags the
+    quantum instructions as noiseless, but deliberately preserves structural
+    tags.  Consequently an ``SE_start`` TICK would still receive ``p_idle``
+    from the circuit-level noise injector.  Replacing that marker locally
+    keeps gate-only experiments from leaking idle noise into their injection
+    and padding rounds.
+    """
+    ordinary = RotatedSurfaceCodeExtractionBlock(system).circuit
+    result = stim.Circuit()
+    for instruction in ordinary:
+        if not isinstance(instruction, stim.CircuitInstruction):
+            raise ValueError("Expected an explicit syndrome-extraction round.")
+        tag = (
+            "noiseless"
+            if instruction.name == "TICK" and instruction.tag == "SE_start"
+            else instruction.tag
+        )
+        result.append(
+            instruction.name,
+            instruction.targets_copy(),
+            instruction.gate_args_copy(),
+            tag=tag,
+        )
+    return result
+
+
+def build_rotated_s_two_way_circuit(
+    distance: int,
+    rounds: int = 2,
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+) -> stim.Circuit:
+    """Build ``|+> -> S -> S† -> MX`` with both phase gates noisy.
+
+    Ordinary syndrome-extraction padding is placed before, between, and after
+    the two dynamical S-SE rounds.  Initialization, padding, both gates, and
+    readout all receive ``noise_params`` when supplied.
+    """
+    if rounds < 0:
+        raise ValueError(f"rounds must be non-negative, got {rounds}.")
+
+    system, patch, builder, executor = _setup(distance)
+    builder.initialize(
+        {qubit: "X" for qubit in system.data_indices},
+        system.num_qubits,
+    )
+
+    ordinary = RotatedSurfaceCodeExtractionBlock(system).circuit
+    builder.apply_syndrome_extraction(ordinary, rounds=rounds)
+    executor.apply_logical_operation("fold_transversal_s", [patch])
+    builder.apply_syndrome_extraction(ordinary, rounds=rounds)
+    executor.apply_logical_operation("fold_transversal_s_dag", [patch])
+    builder.apply_syndrome_extraction(ordinary, rounds=rounds)
+    builder.apply_data_readout(
+        {qubit: "X" for qubit in system.data_indices},
+    )
+
+    if noise_params is None:
+        return builder.circuit
+    return builder.build_noisy_circuit(noise_params, noise_model)
+
+
+def build_rotated_s_y_injection_circuit(
+    distance: int,
+    gate: PhaseGate = "S_DAG",
+    padding_rounds: int = 2,
+    noise_params: Optional[NoiseConfig] = None,
+    noise_model: str = "circuit_level",
+    injection_protocol: Literal["corner", "middle"] = "corner",
+) -> stim.Circuit:
+    """Build a gate-only ``+Y -> S/S† -> ∓X`` verification circuit.
+
+    The same injected ``+Y`` state is used for both gates.  ``S_DAG`` produces
+    deterministic ``+X`` and ``S`` produces deterministic ``-X``.  The
+    injection, identity-SE padding, and final X readout are noiseless.  When
+    ``noise_params`` is supplied, only the selected dynamical S-SE round
+    receives circuit-level noise.
+    """
+    gate = gate.upper()
+    if gate not in ("S", "S_DAG"):
+        raise ValueError(f"gate must be 'S' or 'S_DAG', got {gate!r}.")
+    if padding_rounds < 0:
+        raise ValueError(
+            f"padding_rounds must be non-negative, got {padding_rounds}."
+        )
+
+    system, patch, builder, executor = _setup(distance)
+    executor.apply_logical_operation(
+        "state_injection",
+        [patch],
+        inject_state="Y",
+        protocol=injection_protocol,
+        rounds=0,
+        post_select_coords=set(),
+        noiseless_init=True,
+    )
+
+    noiseless_round = _fully_noiseless_extraction_round(system)
+    # One projection round completes the noiseless product-state injection.
+    builder.apply_syndrome_extraction(
+        noiseless_round,
+        rounds=1,
+        noiseless=True,
+    )
+    builder.apply_syndrome_extraction(
+        noiseless_round,
+        rounds=padding_rounds,
+        noiseless=True,
+    )
+    executor.apply_logical_operation(
+        "fold_transversal_s" if gate == "S" else "fold_transversal_s_dag",
+        [patch],
+    )
+    builder.apply_syndrome_extraction(
+        noiseless_round,
+        rounds=padding_rounds,
+        noiseless=True,
+    )
+    builder.apply_data_readout(
+        {qubit: "X" for qubit in system.data_indices},
+        noiseless=True,
+    )
+
+    if noise_params is None:
+        return builder.circuit
+    return builder.build_noisy_circuit(noise_params, noise_model)
+
+
+__all__ = [
+    "build_rotated_s_two_way_circuit",
+    "build_rotated_s_y_injection_circuit",
+]

--- a/lightstim/qec_code/surface_code/rotated/operation.py
+++ b/lightstim/qec_code/surface_code/rotated/operation.py
@@ -3,11 +3,12 @@
 """
 Logical operation set for Rotated Surface Code.
 
-Provides state_injection and logical_unencode as LogicalOpSet methods,
-callable via LogicalExecutor.apply_logical_operation().
+Provides state injection, logical unencoding, and logical Clifford gates as
+LogicalOpSet methods, callable via
+LogicalExecutor.apply_logical_operation().
 """
 
-from typing import Literal, Tuple, Dict, Any, Type
+from typing import Literal, Tuple, Dict, Any, Type, List
 
 from lightstim.ir.operation import CSSLogicalOpSet
 from lightstim.ir.builder import CircuitBuilder
@@ -17,7 +18,178 @@ import stim
 
 
 # ------------------------------------------------------------------------------
-# Module-level helpers
+# Module-level helpers — dynamical fold-transversal S
+# ------------------------------------------------------------------------------
+
+def _get_half_cycle_fold_yx_parts(
+    system: Any,
+    patch: QECPatch,
+) -> Tuple[List[int], List[int], List[Tuple[int, int]]]:
+    """Return the fold-transversal layer for the rotated-code half-cycle.
+
+    Two CNOT layers into the standard four-layer rotated surface-code syndrome
+    extraction circuit, the data and interior syndrome qubits form an
+    unrotated surface code.  In LightStim's coordinate frame, the fold axis of
+    arXiv:2412.01391 is the local ``y=x`` diagonal.
+
+    Boundary syndrome qubits are excluded: they are the unentangled boundary
+    qubits outside the half-cycle unrotated-code bulk.  On the fold diagonal,
+    data qubits receive S and syndrome qubits receive S†.  Off the diagonal,
+    mirrored bulk qubits are paired by CZ.
+    """
+    if not isinstance(patch, RotatedSurfaceCode):
+        raise TypeError(
+            f"Expected RotatedSurfaceCode patch, got {type(patch).__name__}"
+        )
+    if patch.distance_z != patch.distance_x:
+        raise ValueError(
+            "Dynamical fold-transversal S requires a square patch "
+            f"(distance_z == distance_x). Got "
+            f"{patch.distance_z} != {patch.distance_x}."
+        )
+
+    distance = patch.distance_z
+    sx, sy = patch.shift
+    target_syndromes = {
+        stabilizer["syn_idx"]
+        for stabilizer in patch.stabilizers
+        if stabilizer.get("syn_idx") is not None
+    }
+    active_syndromes = set(system.active_syndrome_indices)
+    missing_syndromes = sorted(target_syndromes - active_syndromes)
+    if missing_syndromes:
+        raise ValueError(
+            "Dynamical fold-transversal S requires the patch's ordinary "
+            "syndrome ancillas to be active. Missing global qubit indices "
+            f"{missing_syndromes}."
+        )
+
+    fold_qubits = set(patch.data_indices) | target_syndromes
+    diagonal_data: List[int] = []
+    diagonal_syndromes: List[int] = []
+    mirror_pairs: List[Tuple[int, int]] = []
+
+    # The bulk occupies local coordinates 1..2d-1 on both axes. Syndrome
+    # ancillas with a local coordinate 0 or 2d are the unentangled boundary
+    # qubits excluded by the paper's protocol.
+    bulk_min = 1
+    bulk_max = 2 * distance - 1
+
+    for qubit in sorted(fold_qubits):
+        gx, gy = system.qubit_coords[qubit]
+        lx = gx - sx
+        ly = gy - sy
+        if not (
+            bulk_min <= lx <= bulk_max
+            and bulk_min <= ly <= bulk_max
+        ):
+            continue
+
+        if lx == ly:
+            if qubit in patch.data_indices:
+                diagonal_data.append(qubit)
+            else:
+                diagonal_syndromes.append(qubit)
+            continue
+
+        if lx > ly:
+            continue
+
+        reflected_coord = QECPatch.snap_coord((ly + sx, lx + sy))
+        reflected_qubit = system.index_map.get(reflected_coord)
+        if reflected_qubit is None or reflected_qubit not in fold_qubits:
+            raise ValueError(
+                f"Half-cycle mirror qubit at {reflected_coord} not found "
+                f"for qubit {qubit} at {(gx, gy)}."
+            )
+        mirror_pairs.append((qubit, reflected_qubit))
+
+    return diagonal_data, diagonal_syndromes, mirror_pairs
+
+
+def _build_half_cycle_fold_s(
+    system: Any,
+    patch: QECPatch,
+    *,
+    inverse: bool,
+) -> stim.Circuit:
+    """Build the physical fold-transversal S or S† layer."""
+    diagonal_data, diagonal_syndromes, mirror_pairs = (
+        _get_half_cycle_fold_yx_parts(system, patch)
+    )
+
+    circuit = stim.Circuit()
+    if mirror_pairs:
+        circuit.append(
+            "CZ",
+            [qubit for pair in mirror_pairs for qubit in pair],
+        )
+    if diagonal_data:
+        circuit.append(
+            "S_DAG" if inverse else "S",
+            sorted(diagonal_data),
+        )
+    if diagonal_syndromes:
+        circuit.append(
+            "S" if inverse else "S_DAG",
+            sorted(diagonal_syndromes),
+        )
+    return circuit
+
+
+def _insert_fold_after_second_cnot_layer(
+    syndrome_extraction: stim.Circuit,
+    fold_layer: stim.Circuit,
+) -> stim.Circuit:
+    """Insert ``fold_layer`` at the four-CNOT schedule's half-cycle."""
+    result = stim.Circuit()
+    cnot_layers = 0
+    moment_has_cnot = False
+    inserted = False
+
+    for instruction in syndrome_extraction:
+        if not isinstance(instruction, stim.CircuitInstruction):
+            raise ValueError(
+                "Dynamical fold-transversal S requires an explicit, "
+                "non-REPEAT syndrome-extraction round."
+            )
+
+        result.append(
+            instruction.name,
+            instruction.targets_copy(),
+            instruction.gate_args_copy(),
+            tag=instruction.tag,
+        )
+
+        if instruction.name in ("CX", "CNOT"):
+            moment_has_cnot = True
+        if instruction.name != "TICK":
+            continue
+
+        if moment_has_cnot:
+            cnot_layers += 1
+            moment_has_cnot = False
+        if cnot_layers == 2 and not inserted:
+            result += fold_layer
+            result.append("TICK")
+            inserted = True
+
+    if moment_has_cnot:
+        cnot_layers += 1
+    if cnot_layers != 4:
+        raise ValueError(
+            "Dynamical fold-transversal S requires exactly four CNOT "
+            f"layers in one syndrome-extraction round; found {cnot_layers}."
+        )
+    if not inserted:
+        raise ValueError(
+            "Could not find the half-cycle boundary after the second CNOT layer."
+        )
+    return result
+
+
+# ------------------------------------------------------------------------------
+# Module-level helpers — state injection
 # ------------------------------------------------------------------------------
 
 def _get_injection_site(
@@ -135,7 +307,7 @@ class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
     Logical operation set for Rotated Surface Code.
 
     Implements state injection, logical unencode, and surface-code-specific
-    gates as composable operations for use with LogicalExecutor.
+    Clifford gates as composable operations for use with LogicalExecutor.
     """
 
     def __init__(self, extraction_block_class: Type):
@@ -147,6 +319,86 @@ class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
         super().__init__()
         self.name = "RotatedSurfaceCode"
         self.extraction_block_class = extraction_block_class
+
+    # ------------------------------------------------------------------
+    # Dynamical fold-transversal phase gates
+    # ------------------------------------------------------------------
+
+    def _apply_dynamical_fold_s(
+        self,
+        builder: CircuitBuilder,
+        patch: QECPatch,
+        *,
+        inverse: bool,
+        noiseless: bool,
+    ) -> None:
+        """Apply one complete S-SE or S†-SE round.
+
+        The full round is deliberately passed through
+        ``apply_syndrome_extraction`` as one measurement block.  This lets the
+        tracker propagate the terminal syndrome measurements through the
+        mid-cycle CZ/S/S† layer, apply the ancilla resets, and construct the
+        mixed X/Z detectors automatically.
+        """
+        if self.extraction_block_class is None:
+            raise ValueError(
+                "extraction_block_class is required for the dynamical "
+                "fold-transversal S protocol."
+            )
+
+        ordinary_round = self.extraction_block_class(builder.system).circuit
+        fold_layer = _build_half_cycle_fold_s(
+            builder.system,
+            patch,
+            inverse=inverse,
+        )
+        dynamical_round = _insert_fold_after_second_cnot_layer(
+            ordinary_round,
+            fold_layer,
+        )
+        builder.apply_syndrome_extraction(
+            circuit_chunk=dynamical_round,
+            rounds=1,
+            noiseless=noiseless,
+        )
+
+    def fold_transversal_s(
+        self,
+        builder: CircuitBuilder,
+        patch: QECPatch,
+        noiseless: bool = False,
+    ) -> None:
+        """Implement logical S as one dynamical S-SE round.
+
+        Protocol (arXiv:2412.01391):
+
+        1. Reset the syndrome ancillas and run CNOT layers 1–2.
+        2. On the half-cycle unrotated-code state, apply mirrored CZ pairs,
+           S on diagonal data qubits, and S† on diagonal syndrome qubits.
+        3. Run CNOT layers 3–4 and measure the syndrome ancillas.
+
+        Logical action: Z_L -> Z_L and X_L -> Y_L.
+        """
+        self._apply_dynamical_fold_s(
+            builder,
+            patch,
+            inverse=False,
+            noiseless=noiseless,
+        )
+
+    def fold_transversal_s_dag(
+        self,
+        builder: CircuitBuilder,
+        patch: QECPatch,
+        noiseless: bool = False,
+    ) -> None:
+        """Implement logical S† as the inverse dynamical S-SE round."""
+        self._apply_dynamical_fold_s(
+            builder,
+            patch,
+            inverse=True,
+            noiseless=noiseless,
+        )
 
     # ------------------------------------------------------------------
     # State preparation / teardown

--- a/lightstim/qec_code/surface_code/rotated/operation.py
+++ b/lightstim/qec_code/surface_code/rotated/operation.py
@@ -188,6 +188,26 @@ def _insert_fold_after_second_cnot_layer(
     return result
 
 
+def _disable_extraction_idle_noise(circuit: stim.Circuit) -> stim.Circuit:
+    """Retag an explicit SE round so noiseless mode also excludes idle noise."""
+    result = stim.Circuit()
+    for instruction in circuit:
+        if not isinstance(instruction, stim.CircuitInstruction):
+            raise ValueError("Expected an explicit syndrome-extraction round.")
+        tag = (
+            "noiseless"
+            if instruction.name == "TICK" and instruction.tag == "SE_start"
+            else instruction.tag
+        )
+        result.append(
+            instruction.name,
+            instruction.targets_copy(),
+            instruction.gate_args_copy(),
+            tag=tag,
+        )
+    return result
+
+
 # ------------------------------------------------------------------------------
 # Module-level helpers — state injection
 # ------------------------------------------------------------------------------
@@ -356,6 +376,8 @@ class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
             ordinary_round,
             fold_layer,
         )
+        if noiseless:
+            dynamical_round = _disable_extraction_idle_noise(dynamical_round)
         builder.apply_syndrome_extraction(
             circuit_chunk=dynamical_round,
             rounds=1,

--- a/notebooks/LogicalOps/logical_S_rotated.ipynb
+++ b/notebooks/LogicalOps/logical_S_rotated.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0681fdf1",
+   "metadata": {},
+   "source": [
+    "# Logical S and S† — Rotated Surface Code\n",
+    "\n",
+    "This notebook presents the dynamical logical phase-gate protocol from\n",
+    "[arXiv:2412.01391](https://arxiv.org/abs/2412.01391). In one modified\n",
+    "syndrome-extraction round, CNOT layers 1–2 first morph the rotated code into\n",
+    "the half-cycle unrotated-code state. The fold-transversal operation is then\n",
+    "applied before CNOT layers 3–4 and the ancilla measurements return the state\n",
+    "to the rotated code. LightStim treats that complete modified round as one\n",
+    "logical $\\bar S$-SE or $\\bar S^\\dagger$-SE round.\n",
+    "\n",
+    "The three diagrams below cover the benchmark configurations used by LightStim:\n",
+    "\n",
+    "| Configuration | State transformation | Purpose |\n",
+    "|---|---|---|\n",
+    "| Two-way | $\\lvert+\\rangle_L \\xrightarrow{\\bar S} \\lvert+Y\\rangle_L \\xrightarrow{\\bar S^\\dagger} \\lvert+\\rangle_L \\xrightarrow{M_X} +1$ | Full-circuit round trip |\n",
+    "| One-way $\\bar S^\\dagger$ | $\\lvert+Y\\rangle_L \\xrightarrow{\\bar S^\\dagger} \\lvert+\\rangle_L \\xrightarrow{M_X} +1$ | Isolated $\\bar S^\\dagger$-SE round |\n",
+    "| One-way $\\bar S$ | $\\lvert+Y\\rangle_L \\xrightarrow{\\bar S} \\lvert-\\rangle_L \\xrightarrow{M_X} -1$ | Isolated $\\bar S$-SE round |\n",
+    "\n",
+    "The notebook builds noiseless circuits so the diagrams show only the protocol\n",
+    "schedule. Supplying `noise_params` to the same builders produces the benchmark\n",
+    "circuits; simulation, decoding, and result data belong in `benchmarks/logical_ops`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95bd5411",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = Path(\"../..\").resolve()\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "\n",
+    "from lightstim.protocols.rotated_logical_s import (\n",
+    "    build_rotated_s_two_way_circuit,\n",
+    "    build_rotated_s_y_injection_circuit,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9546b7",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "- `DISTANCE = 3` keeps the spatial diagrams compact.\n",
+    "- `TWO_WAY_ROUNDS = 1` places one ordinary SE round before the first\n",
+    "  $\\bar S$-SE round, between the two phase-gate rounds, and after the\n",
+    "  $\\bar S^\\dagger$-SE round.\n",
+    "- `INJECTION_PADDING_ROUNDS = 1` adds one ordinary noiseless SE round before\n",
+    "  and after the selected phase-gate round. The injection builder also performs\n",
+    "  one initial noiseless projection SE round.\n",
+    "- `INJECTION_PROTOCOL` can be changed from `\"corner\"` to `\"middle\"`.\n",
+    "\n",
+    "The same builders accept larger distances and padding depths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d8a8950",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DISTANCE = 3\n",
+    "TWO_WAY_ROUNDS = 1\n",
+    "INJECTION_PADDING_ROUNDS = 1\n",
+    "INJECTION_PROTOCOL = \"corner\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbb510e8",
+   "metadata": {},
+   "source": [
+    "## 1. Two-way logical S/S† round trip\n",
+    "\n",
+    "Initialize $\\lvert+\\rangle_L$, perform one ordinary SE round, the\n",
+    "$\\bar S$-SE round, one ordinary SE round, the $\\bar S^\\dagger$-SE round,\n",
+    "and one final ordinary SE round before logical-X readout. The logical state\n",
+    "returns to $\\lvert+\\rangle_L$, so the noiseless result is $M_X=+1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8d42208",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_way = build_rotated_s_two_way_circuit(\n",
+    "    distance=DISTANCE,\n",
+    "    rounds=TWO_WAY_ROUNDS,\n",
+    ")\n",
+    "two_way.without_noise().diagram(\"detslice-with-ops-svg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6ef06ef",
+   "metadata": {},
+   "source": [
+    "## 2. One-way S†: injected +Y to deterministic +X\n",
+    "\n",
+    "Inject $\\lvert+Y\\rangle_L$, perform the noiseless projection and padding\n",
+    "SE rounds, apply the $\\bar S^\\dagger$-SE round, add the final noiseless\n",
+    "padding round, and measure logical X. Since\n",
+    "$\\bar S^\\dagger\\lvert+Y\\rangle_L=\\lvert+\\rangle_L$, the noiseless result\n",
+    "is $M_X=+1$. When noise is supplied, only the $\\bar S^\\dagger$-SE round is\n",
+    "noisy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b25cb978",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_dag_y_to_plus = build_rotated_s_y_injection_circuit(\n",
+    "    distance=DISTANCE,\n",
+    "    gate=\"S_DAG\",\n",
+    "    padding_rounds=INJECTION_PADDING_ROUNDS,\n",
+    "    injection_protocol=INJECTION_PROTOCOL,\n",
+    ")\n",
+    "s_dag_y_to_plus.without_noise().diagram(\"detslice-with-ops-svg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c532178",
+   "metadata": {},
+   "source": [
+    "## 3. One-way S: injected +Y to deterministic −X\n",
+    "\n",
+    "Inject $\\lvert+Y\\rangle_L$, perform the noiseless projection and padding\n",
+    "SE rounds, apply the $\\bar S$-SE round, add the final noiseless padding\n",
+    "round, and measure logical X. Since\n",
+    "$\\bar S\\lvert+Y\\rangle_L=\\lvert-\\rangle_L$, the noiseless result is\n",
+    "$M_X=-1$. No physical logical-Z correction is required. When noise is\n",
+    "supplied, only the $\\bar S$-SE round is noisy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37ed562d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_y_to_minus = build_rotated_s_y_injection_circuit(\n",
+    "    distance=DISTANCE,\n",
+    "    gate=\"S\",\n",
+    "    padding_rounds=INJECTION_PADDING_ROUNDS,\n",
+    "    injection_protocol=INJECTION_PROTOCOL,\n",
+    ")\n",
+    "s_y_to_minus.without_noise().diagram(\"detslice-with-ops-svg\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.10.12.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -3,8 +3,8 @@
 Demonstration notebooks for LightStim protocols. Each notebook corresponds to a
 protocol in `lightstim/protocols/` and shows:
 
-1. A **circuit visualization** (small scale: d=3, 1-2 SE rounds)
-2. A **small numerical result** (hardcoded d=3/5, not a full sweep)
+1. A **protocol diagram** (small scale: d=3, 1-2 SE rounds)
+2. Optionally, a **small numerical result** (hardcoded d=3/5, not a full sweep)
 
 Sweep experiments belong in `benchmarks/`, not here.
 
@@ -43,6 +43,7 @@ notebooks/
 | `logical_CNOT_LS.ipynb` | `protocols/cnot_ls.py` | Logical CNOT via lattice surgery (ZZ + XX) |
 | `logical_CNOT_trans.ipynb` | `protocols/cnot_trans.py` | Transversal CNOT between two surface-code patches |
 | `logical_H_S.ipynb` | `protocols/fold_transversal.py` | Fold-transversal H and S gates |
+| `logical_S_rotated.ipynb` | `protocols/rotated_logical_s.py` | Mid-cycle dynamical S; two-way and noiseless-Y one-way diagrams |
 | `state_injection.ipynb` | `protocols/state_injection.py` | Non-FT magic-state injection (rotated SC) |
 | `two_patch_LS.ipynb` | `protocols/two_patch_ls.py` | Two-patch ZZ lattice surgery coupler |
 | `multi_patch_LS.ipynb` | *(in-progress)* | Multi-patch lattice surgery; unrotated SC N-patch coupler |

--- a/tests/test_rotated_logical_s.py
+++ b/tests/test_rotated_logical_s.py
@@ -9,13 +9,17 @@ import pathlib
 import sys
 
 import numpy as np
+import pandas as pd
 import pytest
 import stim
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from conftest import assert_dem_valid, assert_noiseless, assert_valid_circuit
 from benchmarks.logical_ops.run_logical_ops import (
+    _append_result_row,
+    _ck_key,
     _decoder_config,
+    _load_done_keys,
     build_tasks,
 )
 from lightstim.ir.builder import CircuitBuilder
@@ -26,6 +30,7 @@ from lightstim.protocols.rotated_logical_s import (
     build_rotated_s_two_way_circuit,
     build_rotated_s_y_injection_circuit,
 )
+from lightstim.protocols.state_injection import StateInjectionExperiment
 from lightstim.qec_code.surface_code.rotated import (
     RotatedSurfaceCode,
     RotatedSurfaceCodeExtractionBlock,
@@ -369,6 +374,25 @@ def test_y_injection_noise_is_confined_to_target_s_round():
 
 
 @pytest.mark.smoke
+def test_state_injection_noiseless_s_dag_excludes_idle_noise():
+    circuit = StateInjectionExperiment(
+        distance=3,
+        rounds=0,
+        inject_state="Y",
+        noise_params=NoiseConfig(p_idle=1e-3),
+    ).build()
+
+    assert all(
+        instruction.name != "DEPOLARIZE1"
+        for instruction in circuit.flattened()
+    )
+    assert all(
+        instruction.name != "TICK" or instruction.tag != "SE_start"
+        for instruction in circuit.flattened()
+    )
+
+
+@pytest.mark.smoke
 def test_logical_ops_runner_builds_all_rotated_s_experiments():
     tasks = build_tasks(
         "S_rotated",
@@ -392,6 +416,51 @@ def test_logical_ops_runner_builds_all_rotated_s_experiments():
     } == {1, 2}
     assert all(metadata["gate"] == "S_rotated" for _, metadata in tasks)
     assert all(circuit.num_observables == 1 for circuit, _ in tasks)
+
+
+@pytest.mark.smoke
+def test_mixed_gate_checkpoint_csv_round_trip(tmp_path):
+    output_path = tmp_path / "logical_ops.csv"
+    common_result = {
+        "shots": 100,
+        "post_selected_shots": 100,
+        "post_selection_rate": 0.0,
+        "errors": 1,
+        "logical_error_rate": 0.01,
+        "seconds": 0.1,
+        "decoder": "test",
+    }
+    h_metadata = {
+        "gate": "H",
+        "sub_experiment": "H_ZtoX",
+        "init_basis": "Z",
+        "measure_basis": "X",
+        "d": 3,
+        "rounds": 2,
+        "p": 1e-3,
+    }
+    rotated_s_metadata = {
+        "gate": "S_rotated",
+        "sub_experiment": "S_DAG_plusY_to_X",
+        "init_basis": "+Y",
+        "measure_basis": "X",
+        "d": 3,
+        "rounds": 2,
+        "p": 1e-3,
+        "noisy_gate_count": 1,
+    }
+
+    _append_result_row(output_path, {**h_metadata, **common_result})
+    _append_result_row(output_path, {**rotated_s_metadata, **common_result})
+
+    persisted = pd.read_csv(output_path)
+    assert list(persisted["gate"]) == ["H", "S_rotated"]
+    assert pd.isna(persisted.loc[0, "noisy_gate_count"])
+    assert persisted.loc[1, "noisy_gate_count"] == 1
+    assert _load_done_keys(output_path) == {
+        _ck_key(h_metadata),
+        _ck_key(rotated_s_metadata),
+    }
 
 
 @pytest.mark.smoke

--- a/tests/test_rotated_logical_s.py
+++ b/tests/test_rotated_logical_s.py
@@ -1,0 +1,410 @@
+"""Dynamical logical S/S† on the rotated surface code.
+
+The protocol is the mid-cycle fold-transversal construction from
+arXiv:2412.01391.  These tests cover both its physical schedule and the
+Builder/Tracker integration added for retained-data Color Code circuits.
+"""
+
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+import stim
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from conftest import assert_dem_valid, assert_noiseless, assert_valid_circuit
+from benchmarks.logical_ops.run_logical_ops import (
+    _decoder_config,
+    build_tasks,
+)
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.rotated_logical_s import (
+    build_rotated_s_two_way_circuit,
+    build_rotated_s_y_injection_circuit,
+)
+from lightstim.qec_code.surface_code.rotated import (
+    RotatedSurfaceCode,
+    RotatedSurfaceCodeExtractionBlock,
+    RotatedSurfaceCodeLogicalOpSet,
+)
+from lightstim.qec_code.surface_code.rotated.operation import (
+    _build_half_cycle_fold_s,
+    _get_half_cycle_fold_yx_parts,
+    _insert_fold_after_second_cnot_layer,
+)
+
+
+def _make_system(distance=3, offset=(0.0, 0.0)):
+    system = QECSystem()
+    patch = system.add_patch(
+        RotatedSurfaceCode(distance=distance),
+        name="patch",
+        offset=offset,
+    )
+    tracker = SyndromeTracker(system.num_qubits, system.num_logicals)
+    builder = CircuitBuilder(tracker, system)
+    op_set = RotatedSurfaceCodeLogicalOpSet(
+        extraction_block_class=RotatedSurfaceCodeExtractionBlock
+    )
+    return system, patch, tracker, builder, op_set
+
+
+def _logical_vector(patch, pauli_type, num_qubits):
+    vector = np.zeros(2 * num_qubits, dtype=np.uint8)
+    logical = next(
+        logical
+        for logical in patch.logical_ops
+        if logical["type"] == pauli_type
+    )
+    for qubit, pauli in logical["pauli"].items():
+        if pauli in ("X", "Y"):
+            vector[qubit] = 1
+        if pauli in ("Z", "Y"):
+            vector[num_qubits + qubit] = 1
+    return vector
+
+
+def _symplectic_product(lhs, rhs, num_qubits):
+    return int(
+        (
+            lhs[:num_qubits] @ rhs[num_qubits:]
+            + lhs[num_qubits:] @ rhs[:num_qubits]
+        )
+        % 2
+    )
+
+
+def _observable_reference_parity(circuit):
+    """Return raw noiseless parity of observable zero's annotations."""
+    measurement_count = 0
+    observable_measurements = []
+    for instruction in circuit.flattened():
+        if instruction.name == "OBSERVABLE_INCLUDE":
+            if instruction.gate_args_copy() == [0.0]:
+                observable_measurements.extend(
+                    measurement_count + target.value
+                    for target in instruction.targets_copy()
+                    if target.is_measurement_record_target
+                )
+            continue
+
+        single_instruction = stim.Circuit()
+        single_instruction.append(
+            instruction.name,
+            instruction.targets_copy(),
+            instruction.gate_args_copy(),
+            tag=instruction.tag,
+        )
+        measurement_count += single_instruction.num_measurements
+
+    reference = circuit.reference_sample()
+    return int(reference[observable_measurements].sum() % 2)
+
+
+def _detector_measurement_qubits(circuit):
+    measurement_qubits = []
+    detector_qubits = []
+    measurement_gates = {
+        "M",
+        "MZ",
+        "MX",
+        "MY",
+        "MR",
+        "MRZ",
+        "MRX",
+        "MRY",
+    }
+
+    for instruction in circuit.flattened():
+        if instruction.name in measurement_gates:
+            measurement_qubits.extend(
+                target.value
+                for target in instruction.targets_copy()
+                if target.is_qubit_target
+            )
+        elif instruction.name == "DETECTOR":
+            detector_qubits.append({
+                measurement_qubits[len(measurement_qubits) + target.value]
+                for target in instruction.targets_copy()
+                if target.is_measurement_record_target
+            })
+
+    return detector_qubits
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("offset", [(0.0, 0.0), (10.0, 20.0)])
+def test_half_cycle_fold_uses_data_and_syndrome_qubits(offset):
+    system, patch, _, _, _ = _make_system(distance=3, offset=offset)
+    diagonal_data, diagonal_syndromes, mirror_pairs = (
+        _get_half_cycle_fold_yx_parts(system, patch)
+    )
+    dx, dy = offset
+
+    assert {
+        system.qubit_coords[qubit]
+        for qubit in diagonal_data
+    } == {
+        (1 + dx, 1 + dy),
+        (3 + dx, 3 + dy),
+        (5 + dx, 5 + dy),
+    }
+    assert {
+        system.qubit_coords[qubit]
+        for qubit in diagonal_syndromes
+    } == {
+        (2 + dx, 2 + dy),
+        (4 + dx, 4 + dy),
+    }
+    assert any(
+        a in system.active_syndrome_indices
+        or b in system.active_syndrome_indices
+        for a, b in mirror_pairs
+    )
+
+    fold = _build_half_cycle_fold_s(system, patch, inverse=False)
+    assert [instruction.name for instruction in fold] == [
+        "CZ",
+        "S",
+        "S_DAG",
+    ]
+
+
+@pytest.mark.smoke
+def test_fold_is_inserted_between_cnot_layers_two_and_three():
+    system, patch, _, _, _ = _make_system(distance=3)
+    ordinary = RotatedSurfaceCodeExtractionBlock(system).circuit
+    fold = _build_half_cycle_fold_s(system, patch, inverse=False)
+    dynamical = _insert_fold_after_second_cnot_layer(ordinary, fold)
+
+    cnot_layers = 0
+    cnot_layers_at_fold = []
+    for instruction in dynamical:
+        if instruction.name in ("CX", "CNOT"):
+            cnot_layers += 1
+        elif instruction.name in ("CZ", "S", "S_DAG"):
+            cnot_layers_at_fold.append(cnot_layers)
+
+    assert cnot_layers == 4
+    assert cnot_layers_at_fold == [2, 2, 2]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("distance", [3, 5])
+def test_tracker_accepts_mid_cycle_cz_and_tracks_logical_s(distance):
+    system, patch, tracker, builder, op_set = _make_system(distance=distance)
+    builder.write_coordinates()
+    builder.initialize(
+        {qubit: "X" for qubit in patch.data_indices},
+        system.num_qubits,
+    )
+    ordinary = RotatedSurfaceCodeExtractionBlock(system)
+    builder.apply_syndrome_extraction(ordinary.circuit, rounds=2)
+
+    op_set.fold_transversal_s(builder, patch)
+
+    num_qubits = system.num_qubits
+    logical_x = _logical_vector(patch, "X", num_qubits)
+    logical_z = _logical_vector(patch, "Z", num_qubits)
+    tracked_logical = tracker.logicals.matrix[0]
+
+    # A logical Y representative anti-commutes with both canonical X_L and Z_L.
+    assert _symplectic_product(
+        tracked_logical, logical_x, num_qubits
+    ) == 1
+    assert _symplectic_product(
+        tracked_logical, logical_z, num_qubits
+    ) == 1
+
+    # The following ordinary round must also be processed correctly: its X
+    # detectors inherit the X/Z record mixing created by the S-SE round.
+    builder.apply_syndrome_extraction(ordinary.circuit, rounds=1)
+    op_set.fold_transversal_s_dag(builder, patch)
+    builder.apply_data_readout(
+        {qubit: "X" for qubit in patch.data_indices}
+    )
+
+    assert_valid_circuit(builder.circuit)
+    assert_noiseless(builder.circuit)
+    assert_dem_valid(builder.circuit)
+    assert _observable_reference_parity(builder.circuit) == 0
+    assert any(
+        qubits & set(system.active_syndrome_indices_x)
+        and qubits & set(system.active_syndrome_indices_z)
+        for qubits in _detector_measurement_qubits(builder.circuit)
+    )
+
+
+@pytest.mark.smoke
+def test_s_squared_has_the_logical_z_phase():
+    system, patch, _, builder, op_set = _make_system(distance=3)
+    builder.initialize(
+        {qubit: "X" for qubit in patch.data_indices},
+        system.num_qubits,
+    )
+    ordinary = RotatedSurfaceCodeExtractionBlock(system)
+    builder.apply_syndrome_extraction(ordinary.circuit, rounds=2)
+
+    op_set.fold_transversal_s(builder, patch)
+    op_set.fold_transversal_s(builder, patch)
+    builder.apply_data_readout(
+        {qubit: "X" for qubit in patch.data_indices}
+    )
+
+    # S^2|+> = Z|+> = |->. The tracker is intentionally phase-free, while
+    # Stim's raw reference sample retains this deterministic logical sign.
+    assert _observable_reference_parity(builder.circuit) == 1
+    assert_noiseless(builder.circuit)
+
+
+@pytest.mark.smoke
+def test_noisy_dynamical_s_round_builds_hypergraph_dem():
+    system, patch, _, builder, op_set = _make_system(distance=3)
+    builder.initialize(
+        {qubit: "X" for qubit in patch.data_indices},
+        system.num_qubits,
+    )
+    ordinary = RotatedSurfaceCodeExtractionBlock(system)
+    builder.apply_syndrome_extraction(ordinary.circuit, rounds=3)
+    op_set.fold_transversal_s(builder, patch)
+    builder.apply_syndrome_extraction(ordinary.circuit, rounds=2)
+    op_set.fold_transversal_s_dag(builder, patch)
+    builder.apply_data_readout(
+        {qubit: "X" for qubit in patch.data_indices}
+    )
+
+    noise = NoiseConfig(
+        p_1q=1e-3,
+        p_2q=1e-3,
+        p_meas=1e-3,
+        p_reset=1e-3,
+        p_idle=1e-3,
+    )
+    noisy = builder.build_noisy_circuit(
+        noise,
+        noise_model="circuit_level",
+    )
+    dem = noisy.detector_error_model()
+
+    assert dem.num_detectors == noisy.num_detectors
+    assert dem.num_observables == noisy.num_observables == 1
+    assert "error(" in str(dem)
+    assert "DEPOLARIZE2" in str(noisy)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("distance", [3, 5])
+def test_rotated_s_two_way_experiment_is_noiseless(distance):
+    circuit = build_rotated_s_two_way_circuit(
+        distance=distance,
+        rounds=2,
+    )
+
+    assert_valid_circuit(circuit)
+    assert_noiseless(circuit)
+    assert circuit.detector_error_model().num_observables == 1
+    assert _observable_reference_parity(circuit) == 0
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("gate", "expected_reference_parity"),
+    [("S_DAG", 0), ("S", 1)],
+)
+def test_noiseless_y_injection_has_deterministic_x_result(
+    gate,
+    expected_reference_parity,
+):
+    circuit = build_rotated_s_y_injection_circuit(
+        distance=3,
+        gate=gate,
+        padding_rounds=2,
+    )
+
+    assert_valid_circuit(circuit)
+    assert_noiseless(circuit)
+    assert _observable_reference_parity(circuit) == expected_reference_parity
+    assert all(
+        instruction.name != "Z"
+        for instruction in circuit.flattened()
+    )
+
+
+@pytest.mark.smoke
+def test_y_injection_noise_is_confined_to_target_s_round():
+    p = 1e-3
+    circuit = build_rotated_s_y_injection_circuit(
+        distance=3,
+        gate="S_DAG",
+        padding_rounds=2,
+        noise_params=NoiseConfig(
+            p_1q=p,
+            p_2q=p,
+            p_meas=p,
+            p_reset=p,
+            p_idle=p,
+        ),
+    )
+
+    # The target dynamical S-SE round retains one SE_start idle marker.  Every
+    # injection/padding round uses a noiseless marker and therefore receives no
+    # idle noise.
+    assert sum(
+        instruction.name == "TICK" and instruction.tag == "SE_start"
+        for instruction in circuit.flattened()
+    ) == 1
+    assert sum(
+        instruction.name == "DEPOLARIZE1"
+        for instruction in circuit.flattened()
+    ) > 0
+    assert sum(
+        instruction.name == "DEPOLARIZE2"
+        for instruction in circuit.flattened()
+    ) > 0
+    assert circuit.detector_error_model().num_observables == 1
+
+
+@pytest.mark.smoke
+def test_logical_ops_runner_builds_all_rotated_s_experiments():
+    tasks = build_tasks(
+        "S_rotated",
+        distances=[3],
+        p_values=[1e-3],
+        rounds=2,
+    )
+
+    assert len(tasks) == 3
+    assert {
+        metadata["sub_experiment"]
+        for _, metadata in tasks
+    } == {
+        "S_then_S_DAG",
+        "S_DAG_plusY_to_X",
+        "S_plusY_to_minusX",
+    }
+    assert {
+        metadata["noisy_gate_count"]
+        for _, metadata in tasks
+    } == {1, 2}
+    assert all(metadata["gate"] == "S_rotated" for _, metadata in tasks)
+    assert all(circuit.num_observables == 1 for circuit, _ in tasks)
+
+
+@pytest.mark.smoke
+def test_logical_ops_runner_keeps_historical_bposd_settings():
+    expected = {
+        "max_iterations": 1000,
+        "osd_order": 10,
+        "bp_method": "min_sum",
+        "ms_scaling_factor": 0,
+        "osd_method": "osd_cs",
+    }
+    cpu = _decoder_config("cpu_bposd")
+    gpu = _decoder_config("gpu_bposd")
+
+    assert cpu.params == expected
+    assert gpu.params == {**expected, "use_osd": True}


### PR DESCRIPTION
## Summary

- implement the rotated-surface-code dynamical logical `S` and `S†` operations from [arXiv:2412.01391](https://arxiv.org/abs/2412.01391) by inserting the fold-transversal CZ/S layer at the half-cycle of one syndrome-extraction round
- add two-way `S → S†` and noiseless-`+Y` one-way verification circuits, including deterministic `+X`/`-X` reference handling without a physical logical-Pauli correction
- register `S_rotated` in the unified logical-operations benchmark, preserve the existing CPU/GPU BP+OSD settings, and plot its three verification experiments separately
- add an output-free protocol-diagram notebook and focused tracker, detector-model, noise-localization, benchmark, and decoder-configuration tests

## Why

This protocol applies CZ gates between data and syndrome qubits in the middle of syndrome extraction. The retained-data Pauli-tracker improvements already on `main` now let LightStim propagate those mid-cycle Clifford operations and construct the mixed X/Z detectors correctly.

## User impact

The rotated logical operation set now exposes `fold_transversal_s` and `fold_transversal_s_dag`. Benchmarks can be built and run with:

```bash
PYTHONPATH=. venv/bin/python benchmarks/logical_ops/run_logical_ops.py \
  --gate S_rotated --decoder gpu_bposd
```

The notebook at `notebooks/LogicalOps/logical_S_rotated.ipynb` contains protocol diagrams only; it has no stored outputs, decoder run, or benchmark data.

## Validation

- `pytest tests/test_rotated_logical_s.py tests/test_protocols.py -q` — passed
- `pytest tests/ --ignore=tests/test_api.py -m "not slow" --timeout=90 -q` — passed
- executed the notebook into `/tmp` and verified all three diagrams without writing outputs back
- rendered the notebook to HTML and verified the Markdown table is 3 columns in every row
- completed an end-to-end CPU BP+OSD smoke run for all three `S_rotated` sub-experiments and generated the three-panel plot

Local full-suite note: `tests/test_api.py::test_api_root` hangs during the existing TestClient initialization in this environment, including when run alone, so that unrelated file was excluded from the local full-suite command.
