### PR TITLE
docs: rewrite decoder guide and restore PyMatching DEM decomposition

### DIFF
--- a/lightstim/simulation/decoder_backend/decoders/ldpc_bp.py
+++ b/lightstim/simulation/decoder_backend/decoders/ldpc_bp.py
@@ -6,7 +6,7 @@ natively), returns the correction over error mechanisms, and reports per-shot
 convergence so ``DecoderConfig(on_decode_failure=...)`` can herald or count
 non-converged shots.
 
-It is registered via the :class:`ExternalDecoder` facade (Pattern D), so
+It is registered via the :class:`ExternalDecoder` facade (Pattern C), so
 bit-packing, the correction→observable multiply, and multi-process workers are
 all handled by :class:`SimulationPipeline`.
 

--- a/lightstim/simulation/decoder_backend/decoders/pymatching.py
+++ b/lightstim/simulation/decoder_backend/decoders/pymatching.py
@@ -1,4 +1,4 @@
-"""PyMatching MWPM decoder (CPU) — wraps pymatching directly."""
+"""PyMatching MWPM decoder (CPU) with Stim graphlike decomposition."""
 from __future__ import annotations
 
 import numpy as np
@@ -24,7 +24,14 @@ try:
             )
 
     class PyMatchingDecoder(sinter.Decoder):
-        """MWPM decoder backed by pymatching."""
+        """MWPM decoder backed by pymatching.
+
+        PyMatching consumes graphlike DEM components. This flag tells the
+        pipeline to ask Stim to decompose decomposable circuit-level hyperedges
+        before compiling the matching graph.
+        """
+
+        decompose_errors = True
 
         def compile_decoder_for_dem(
             self, *, dem: stim.DetectorErrorModel

--- a/lightstim/simulation/decoder_backend/pipeline.py
+++ b/lightstim/simulation/decoder_backend/pipeline.py
@@ -139,8 +139,8 @@ class SimulationPipeline:
             )
             return
 
-        # pymatching now uses decompose_errors=True + enable_correlations=True,
-        # so it handles hyperedges correctly — no warning needed.
+        # PyMatching requests decompose_errors=True, so Stim converts
+        # decomposable hyperedges into graphlike components before compilation.
 
     def _run_custom(
         self,

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -12,518 +12,227 @@ user-invocable: true
 
 # Add a New Decoder
 
-LightStim's decoder backend is a small registry of decoder classes (by
-convention `sinter.Decoder` subclasses, though the pipeline only duck-types
-the interface — see the contract below). Each decoder is registered under a
-name + backend (`cpu`, `gpu`, or `fpga`), then
-`DecoderConfig(name="…", backend="…", params={})` looks it up at runtime.
+LightStim's decoder backend is a registry of decoder classes. Register a class
+under a name + backend (`cpu` / `gpu` / `fpga`), and
+`DecoderConfig(name="…", backend="…", params={…})` finds it at runtime —
+everywhere: pipeline, server, notebooks, benchmarks.
 
-Adding a decoder is **always one new file** in
-`lightstim/simulation/decoder_backend/decoders/`, plus **one line** in
-`decoders/__init__.py` to soft-import it, plus **one smoke test** in
-`tests/test_simulation_backend_quality.py`.
+Adding a decoder is always three things:
 
-This skill walks through four patterns, ordered by complexity. Patterns A/B/C
-are real decoders in the repo; Pattern D is the `ExternalDecoder` facade — the
-recommended path for any decoder that isn't already sinter-compatible. Pick the
-one that matches your situation.
+1. **One new file** in `lightstim/simulation/decoder_backend/decoders/`.
+2. **One soft-import line** in `decoders/__init__.py`.
+3. **One smoke test** in `tests/test_simulation_backend_quality.py`.
+
+A runnable version of everything below (with live benchmarks) is
+`tutorials/how-to-add-new-decoders.ipynb`.
+
+## Which pattern?
+
+| Situation | Pattern |
+|---|---|
+| Upstream library ships a `sinter.Decoder` | **A** — register the class directly |
+| Anything else | **C** — subclass `ExternalDecoder` (recommended) |
+| You need to own the unpack → decode → pack loop yourself | **B** — build from the DEM matrices |
 
 ---
 
-## The contract
+## The contract (duck-typed)
 
-**Pattern D skips this section entirely.** If you subclass `ExternalDecoder`,
-the facade already implements this interface — you only write `setup` plus
-`decode_single`/`decode_batch` on plain unpacked numpy arrays, and never touch
-bit-packing or these method signatures. The contract below is what Patterns
-A–C implement (and what the facade implements *for* you).
-
-The pipeline is **duck-typed** — it never checks `isinstance(..., sinter.Decoder)`.
-A decoder is any object with a `compile_decoder_for_dem` method that takes a
-`stim.DetectorErrorModel` and returns a compiled decoder:
+The pipeline never checks `isinstance(..., sinter.Decoder)`. A decoder is any
+object with:
 
 ```python
-import stim
-
-class MyDecoder:                       # sinter.Decoder base is optional
+class MyDecoder:                       # sinter.Decoder base optional
     def compile_decoder_for_dem(self, *, dem: stim.DetectorErrorModel):
-        ...   # one-time prep per DEM
-```
+        return _MyCompiled(...)        # one-time prep per DEM
 
-The compiled decoder must implement
-`decode_shots_bit_packed(*, bit_packed_detection_event_data: np.ndarray)
--> np.ndarray` — bit-packed in, bit-packed out:
-
-```python
-class _MyCompiledDecoder:              # sinter.CompiledDecoder base is optional
-    def decode_shots_bit_packed(
-        self, *, bit_packed_detection_event_data: np.ndarray
-    ) -> np.ndarray:
-        # input  shape: (n_shots, ceil(n_detectors / 8)), uint8, LSB-first
-        # output shape: (n_shots, ceil(n_observables / 8)), uint8, LSB-first
+class _MyCompiled:                     # sinter.CompiledDecoder base optional
+    def decode_shots_bit_packed(self, *, bit_packed_detection_event_data):
+        # in:  (n_shots, ceil(n_detectors/8))   uint8, LSB-first
+        # out: (n_shots, ceil(n_observables/8)) uint8, LSB-first
         ...
 ```
 
-Subclassing `sinter.Decoder` / `sinter.CompiledDecoder` is still the repo
-convention (the built-in decoders do, and it's required if you also want your
-decoder usable with a raw `sinter.collect` outside LightStim), but the method
-signatures above are the whole contract — `sinter` matching them is why
-sinter-native decoders plug in unchanged (Pattern A).
+Subclassing the sinter bases remains the repo convention (and is required if
+you also want the decoder usable with raw `sinter.collect`); matching this
+signature is why sinter-native decoders plug in unchanged.
 
-If your underlying library already implements `sinter.Decoder` and
-`sinter.CompiledDecoder` correctly (e.g. `stimbposd.SinterDecoder_BPOSD`,
-`mwpf.SinterMWPFDecoder`), **you don't need to write a CompiledDecoder
-yourself** — see Pattern A.
+**Pattern C skips this contract entirely** — the `ExternalDecoder` facade
+implements it for you; you only write methods on plain unpacked arrays.
 
 ---
 
-## Pattern A: thin wrapper around an existing `sinter.Decoder`
-
-**When to use**: the upstream library already implements `sinter.Decoder`.
-You just want it registered under a LightStim name.
-
-**Real example**: `lightstim/simulation/decoder_backend/decoders/mwpf.py`
-(30 lines including imports). It's literally:
+## Pattern A — sinter-native: register directly
 
 ```python
+# decoders/my_decoder.py
 from ..registry import register_decoder
 
 try:
     from mwpf import SinterMWPFDecoder
-    _AVAILABLE = True
+    register_decoder("mwpf", SinterMWPFDecoder)
 except ImportError:
-    _AVAILABLE = False
-
-if _AVAILABLE:
-    register_decoder("mwpf", SinterMWPFDecoder, aliases=[])
+    pass
 ```
 
-That's it. No subclass needed.
+That's the entire built-in `mwpf.py`. `relay_bp.py` and `tesseract.py` are the
+same shape. User params flow straight through `DecoderConfig(params={…})` to
+the upstream class — don't add a translation layer for a single library.
+
+**Need renamed params or defaults?** Give a thin wrapper class an
+`__init__(**params)` that merges defaults and renames keys before constructing
+the inner decoder, and delegate `compile_decoder_for_dem` to it. `bposd.py`
+does this to share one parameter vocabulary between its CPU (`stimbposd`) and
+GPU (`cudaq_qec`) backends.
 
 ---
 
-## Pattern B: wrapper with parameter translation
+## Pattern C — `ExternalDecoder` facade (recommended for non-sinter)
 
-**When to use**: you're registering a sinter-native decoder (Pattern A) and want
-to (a) expose a *unified* parameter vocabulary across several backends of the
-**same** decoder family — the reason this pattern exists in LightStim, where
-`bposd` spans a CPU (`stimbposd`) and a GPU (`cudaqx`) backend that take different
-kwarg names — or (b) set sensible defaults / rename an awkward upstream API.
-
-**When *not* to use**: a brand-new, unrelated decoder. The translation table
-below is tailored to BP+OSD and does **not** generalize. If you're just wrapping
-one library, prefer plain Pattern A and let users pass its native parameter names
-straight through `DecoderConfig(params={...})`; only add a translation layer once
-you have a second backend to keep consistent, or a concrete renaming/default need.
-
-**Real example**:
-`lightstim/simulation/decoder_backend/decoders/bposd.py`. The user passes
-`max_iterations`, `bp_method='min_sum'`, etc., but `stimbposd`'s API uses
-`max_bp_iters` and `bp_method='minimum_sum'`. The wrapper translates:
-
-```python
-class BpOsdCpuDecoder(sinter.Decoder):
-    def __init__(self, **params):
-        translated = _unified_to_cpu({**_DEFAULTS, **params})
-        self._inner = SinterDecoder_BPOSD(**translated)
-
-    def compile_decoder_for_dem(self, *, dem):
-        return self._inner.compile_decoder_for_dem(dem=dem)
-
-if _BPOSD_AVAILABLE:
-    register_decoder("bposd", BpOsdCpuDecoder, aliases=["bp_osd"], backend="cpu")
-```
-
-Key things to copy from this pattern:
-1. `__init__(self, **params)` — accept arbitrary kwargs so users can pass
-   anything through `DecoderConfig(params={...})`.
-2. `_DEFAULTS` dict at module level — defines sensible defaults; user
-   params override them via dict-merge.
-3. A `_translate(params: dict) -> dict` function — rename keys, normalize
-   case, drop irrelevant ones.
-4. Hold the wrapped decoder in `self._inner` and delegate
-   `compile_decoder_for_dem` to it.
-
----
-
-## Pattern C: custom decoder from a DEM matrix (full control)
-
-**When to use**: the upstream library is **not** sinter-compatible and you need
-lower-level control than Pattern D gives — e.g. you want to own the
-`sinter.CompiledDecoder` lifecycle yourself. You parse the DEM into matrices and
-write the decode loop by hand.
-
-**Real example**:
-`lightstim/simulation/decoder_backend/decoders/cudaqx.py` — wraps NVIDIA's
-`cudaq_qec` GPU decoder, which takes raw H matrices, not stim DEMs.
-
-The pattern has three parts:
-
-### 1. DEM → matrices
-
-Convert a `stim.DetectorErrorModel` into the (H, observable matrix,
-priors) triple your decoder needs. **Always reuse the shared helper** rather
-than re-deriving it — `dem_matrices.py` encodes two behaviours that are easy
-to get subtly wrong (parity semantics and duplicate merging, both below):
-
-```python
-from ..dem_matrices import dem_to_matrices
-
-H, obs_matrix, priors = dem_to_matrices(
-    dem,
-    sparse=False,           # True -> scipy CSR, never materialises a dense array
-    merge_duplicates=True,  # default; fuses identical-footprint mechanisms
-)
-```
-
-| | `sparse=False` (default) | `sparse=True` |
-|---|---|---|
-| `H`, `obs_matrix` | dense C-contiguous `uint8` | `scipy.sparse.csr_matrix` |
-| use for | CUDA / C extensions needing row-major | large multi-round LDPC, where dense is many GB and OOMs a worker |
-
-Two behaviours to know about:
-
-**Parity, not assignment.** stim treats a target listed an even number of
-times as cancelling, so `error(0.1) D0 D0 D1` flips only `D1`. The helper
-XORs (`np.add.at(...)` then `& 1`); writing `H[d, e] = 1` instead silently
-produces a wrong matrix. Regression test:
-`test_dem_to_matrices_repeated_targets_cancel`.
-
-**`merge_duplicates` changes the column count.** Mechanisms with identical
-(detector, observable) footprints fuse into one column, with priors combined
-by the XOR rule `p1(1-p2) + p2(1-p1)`. stim does not always do this itself —
-in `z_only` circuits X- and Y-type data errors keep separate columns despite
-identical symptoms, and those degenerate twins measurably degrade BP. So
-**`H.shape[1]` may be smaller than `dem.num_errors`** — derive the error-
-mechanism count from `H.shape[1]`, never from the DEM. Pass
-`merge_duplicates=False` if your decoder must stay column-aligned with the
-original DEM instructions.
-
-### 2. Custom `CompiledDecoder`
-
-Holds your already-prepared decoder instance + the observable matrix.
-Implements the unpack → decode → pack loop:
-
-```python
-class _MyCompiledDecoder(sinter.CompiledDecoder):
-    def __init__(self, inner, obs_matrix, n_detectors):
-        self._inner = inner
-        self._obs_matrix = obs_matrix
-        self._n_dets = n_detectors
-
-    def decode_shots_bit_packed(self, *, bit_packed_detection_event_data):
-        # 1. Unpack syndromes: bit_packed → (n_shots, n_dets) uint8
-        syndromes = np.unpackbits(
-            bit_packed_detection_event_data, axis=1, bitorder="little"
-        )[:, : self._n_dets]
-        # 2. Call your underlying decoder shot-by-shot or batched
-        predictions = self._inner.decode_batch(syndromes)  # (n_shots, n_err) uint8
-        # 3. Compute which observables flipped: obs_flip = predictions @ obs_matrix.T  mod 2
-        obs_flips = (predictions @ self._obs_matrix.T) & 1
-        # 4. Pack back: (n_shots, n_obs) → bit-packed uint8
-        return np.packbits(obs_flips.astype(np.uint8), axis=1, bitorder="little")
-```
-
-### 3. Top-level `sinter.Decoder`
-
-Calls `_dem_to_matrices`, constructs the inner decoder, returns the
-`CompiledDecoder`:
-
-```python
-class MyDecoder(sinter.Decoder):
-    def __init__(self, **params):
-        self._params = params
-
-    def compile_decoder_for_dem(self, *, dem):
-        H, obs_matrix, priors = _dem_to_matrices(dem)
-        inner = my_lib.Decoder(H=H, priors=priors, **self._params)
-        return _MyCompiledDecoder(inner, obs_matrix, dem.num_detectors)
-```
-
----
-
-## Pattern D: `ExternalDecoder` facade (recommended for non-sinter decoders)
-
-**When to use**: the upstream library is **not** sinter-compatible (most
-research-paper decoders, GPU libraries, neural networks) **and** you'd rather
-not touch bit-packing, the observable matrix, or the sinter contract. This is
-the friendliest path — prefer it over Pattern C unless you need full control.
-
-**What you write**: subclass
-`lightstim.simulation.decoder_backend.external.ExternalDecoder`, declare
-`output_type`, build your decoder in `setup`, and implement **one** of
-`decode_batch` / `decode_single`. LightStim handles the rest (bit-packing, the
-correction→observable multiply, parallel workers, and failure-flag accounting).
+Subclass, declare `output_type`, build in `setup`, implement **one** of
+`decode_single` / `decode_batch`. The facade owns bit-packing, the
+observable-matrix multiply, worker plumbing, and failure-flag routing.
 
 ```python
 import numpy as np
-from lightstim.simulation.decoder_backend.external import ExternalDecoder
-from lightstim.simulation.decoder_backend.registry import register_decoder
+from ..external import ExternalDecoder
+from ..registry import register_decoder
 
 class MyDecoder(ExternalDecoder):
-    # REQUIRED. "correction" => you return a correction over error mechanisms
-    # (length n_err) and LightStim computes the observable flips for you.
-    # "observables" => you already return logical-observable flips (length n_obs).
-    output_type = "correction"
+    output_type = "correction"   # REQUIRED, no default — see below
 
-    def setup(self, *, H, obs_matrix, priors, num_detectors, num_observables, dem):
-        # Called ONCE per DEM. Stash whatever you need on self.
-        # self.params holds the DecoderConfig(params=...) dict.
-        # H and obs_matrix are scipy CSR — call .toarray() if your library
-        # needs dense (only safe for small DEMs; see the note below).
+    def setup(self, *, H, obs_matrix, priors, num_detectors,
+              num_observables, dem):
+        # Called once per DEM. self.params holds DecoderConfig(params=...).
+        # H / obs_matrix are scipy CSR; .toarray() only for small DEMs.
         self._inner = my_lib.Decoder(H, priors, **self.params)
 
-    # Implement EITHER decode_single OR decode_batch — LightStim bridges the other.
-    def decode_single(self, syndrome):          # syndrome: (n_dets,) uint8, UNPACKED
+    def decode_single(self, syndrome):        # (n_dets,) uint8, unpacked
         correction, converged = self._inner.run(syndrome)
-        return correction, converged            # flag: True/None = ok, False = failed
-
-    # def decode_batch(self, syndromes):        # syndromes: (n_shots, n_dets) uint8
-    #     preds, flags = self._inner.run_batch(syndromes)
-    #     return preds, flags                   # flags: (n_shots,) bool, or None
+        return correction, converged          # flag: True/None ok, False failed
 
 register_decoder("my-decoder", MyDecoder, backend="cpu")
 ```
 
-### What `setup` receives
+Three knobs:
 
-The facade calls `dem_to_matrices(dem, sparse=True, merge_duplicates=True)`,
-so `H` and `obs_matrix` are **`scipy.sparse.csr_matrix`**, and `n_err`
-(= `H.shape[1]`) is the *merged* mechanism count, which **may be smaller than
-`dem.num_errors`** — see the `merge_duplicates` note in Pattern C. Size your
-`"correction"` output from `H.shape[1]`, not from the DEM.
+- **`output_type`** — `"correction"`: you return a correction over error
+  mechanisms, length `H.shape[1]`, and LightStim computes the observable
+  flips. `"observables"`: you return the logical flips directly, length
+  `n_obs`. Forgetting it raises at compile time.
+- **single vs batch** — implement whichever is natural
+  (`decode_batch(syndromes) -> (preds, flags)`); LightStim bridges the other.
+- **failure flags** — return `False` for shots the decoder failed on (e.g. BP
+  non-convergence), `True`/`None` otherwise.
+  `DecoderConfig(on_decode_failure=...)` decides what a `False` means:
+  `"error"` (default, count as logical error), `"discard"` (herald it out of
+  the denominator), `"ignore"` (trust the prediction).
 
-Sparse is deliberate: these are the decoders that run on large LDPC circuits
-where a dense `(n_detectors, n_error_mechanisms)` matrix can be many GB and
-OOM a worker. If your library needs dense input, `H.toarray()` works but
-reintroduces that cost.
+What `setup` receives: the facade calls
+`dem_to_matrices(dem, sparse=True, merge_duplicates=True)`, so `H` and
+`obs_matrix` are CSR and duplicate-footprint mechanisms are already merged —
+**`H.shape[1]` can be smaller than `dem.num_errors`** (gotcha 2).
 
-### The three axes `ExternalDecoder` formalises
-
-1. **`output_type` (mandatory, no default).** `"correction"` (length `n_err`,
-   LightStim multiplies by the observable matrix) vs `"observables"` (length
-   `n_obs`, used directly). Forgetting it raises at compile time — never a
-   silent wrong-axis bug.
-2. **single vs batch.** Override whichever is natural. LightStim loops a
-   single-shot decoder over a batch, and feeds a batch decoder one-row batches.
-   Don't implement both.
-3. **failure flags.** Return a per-shot `bool` (`False` = the decoder failed to
-   converge, e.g. BP) or `None`/`True` for "always converged". What LightStim
-   does with a `False` is set by `DecoderConfig(on_decode_failure=...)`:
-   - `"error"` (default) — count the shot as a logical error.
-   - `"discard"` — herald the failure: drop it from the denominator.
-   - `"ignore"` — trust the returned prediction anyway.
-
-### What you never touch
-Bit-packing (LSB-first), the `sinter.Decoder`/`CompiledDecoder` classes, the
-`obs @ correction mod 2` step, and worker plumbing. The facade owns all of it.
-DEM→matrix conversion is shared via
-`decoder_backend/dem_matrices.py::dem_to_matrices` if you want it directly.
-
-See `tests/test_simulation_backend_quality.py` for worked examples covering the
-single→batch bridge and all three failure-flag policies.
+Working examples: `decoders/ldpc_bp.py` (correction + real convergence
+flags), and the `tests/test_simulation_backend_quality.py` externals.
 
 ---
 
-## Registration
+## Pattern B — custom decoder from the DEM (full control)
 
-After your decoder file is written, add one call at module bottom:
+Only when you must own the `CompiledDecoder` lifecycle (e.g. GPU memory
+management). Reference implementation: `decoders/cudaqx.py`.
+
+Get matrices from the shared helper — never re-derive the conversion:
 
 ```python
-register_decoder(
-    name="my-decoder",          # canonical name; user types DecoderConfig(name="my-decoder")
-    decoder_class=MyDecoder,
-    aliases=["my_dec", "mwpm2"],  # optional; excluded from list_decoders()
-    backend="cpu",              # or "gpu" or "fpga"
-)
+from ..dem_matrices import dem_to_matrices
+
+H, obs_matrix, priors = dem_to_matrices(dem)              # dense uint8, C-order
+H, obs_matrix, priors = dem_to_matrices(dem, sparse=True) # scipy CSR
 ```
 
-A single name can have multiple backends. E.g. `cudaqx.py` registers both
-the GPU `nv-qldpc-decoder` name and a `bposd` `backend="gpu"` override, so
-`DecoderConfig(name="bposd", backend="cpu")` hits the CPU implementation
-and `backend="gpu"` hits the GPU one.
+Two behaviours it encodes that hand-rolled versions get wrong:
+
+- **Parity, not assignment.** stim cancels a target listed an even number of
+  times (`error(0.1) D0 D0 D1` flips only `D1`); the helper XORs. Writing
+  `H[d, e] = 1` yourself silently builds a wrong matrix.
+- **`merge_duplicates=True` (default) changes the column count.** Mechanisms
+  with identical (detector, observable) footprints fuse into one column,
+  priors combined with the XOR rule `p1(1-p2) + p2(1-p1)` — stim leaves such
+  duplicates in z_only-style circuits and they measurably degrade BP. Pass
+  `merge_duplicates=False` if you need DEM-column alignment.
+
+Then write the compiled decoder: unpack syndromes
+(`np.unpackbits(..., bitorder="little")[:, :n_dets]`), decode, compute
+`(predictions @ obs_matrix.T) & 1` if your decoder returns corrections, and
+`np.packbits(..., bitorder="little")` the result.
 
 ---
 
-## Wire it into discovery
+## Ship it
 
-`lightstim/simulation/decoder_backend/decoders/__init__.py` does
-**soft imports** so missing libraries don't crash the registry. Follow
-the existing pattern — add your module behind an `importlib.util.find_spec`
-guard:
+**Soft-import** in `decoders/__init__.py` so missing libraries never break the
+registry:
 
 ```python
-# In decoders/__init__.py, append:
 if importlib.util.find_spec("my_lib") is not None:
     try:
         from . import my_decoder  # noqa: F401 — registers my-decoder/cpu
     except ImportError as exc:
         _log.debug("my_decoder import failed: %s", exc)
-else:
-    _log.debug("my_lib not installed; skipping my-decoder")
 ```
 
-This is mandatory. If you `import` your module unconditionally and the
-underlying library isn't installed, every LightStim user will hit an
-`ImportError` at startup.
-
-(`ExternalDecoder` subclasses register themselves the same way — there is no
-auto-discovery for them, so add the soft-import hook here too if the decoder
-depends on an optional library.)
-
----
-
-## Smoke test
-
-Add to `tests/test_simulation_backend_quality.py`. The minimum bar: your
-decoder must appear in `list_decoders()` and successfully decode the
-trivial single-qubit observable circuit defined at the top of that file.
+**Smoke test** in `tests/test_simulation_backend_quality.py`:
 
 ```python
 def test_my_decoder_registered_and_runs():
-    from lightstim.simulation.decoder_backend import list_decoders
+    importorskip_safe("my_lib")   # or pytest.importorskip
     assert "my-decoder" in list_decoders()
-
-    pipeline = SimulationPipeline(
+    stats = SimulationPipeline(
         decoder_config=DecoderConfig("my-decoder"),
-        max_shots=100,
-        max_errors=1,
-        batch_size=50,
-        num_workers=1,
-        print_progress=False,
-    )
-    stats = pipeline.run(_simple_observable_circuit(error_probability=0.1))
+        max_shots=200, max_errors=10_000, batch_size=100,
+        num_workers=1, print_progress=False,
+    ).run(_simple_observable_circuit(error_probability=0.1))
     assert stats.shots > 0
 ```
 
-If your decoder needs an optional dependency, gate the test:
-
-```python
-my_lib = pytest.importorskip("my_lib")
-```
-
-so CI doesn't fail when the library isn't installed.
-
----
-
-## Where things live (quick reference)
-
-| File | What it is |
-|---|---|
-| `lightstim/simulation/decoder_backend/registry.py` | The registry — `register_decoder()`, `get_decoder()`, `list_decoders()` |
-| `lightstim/simulation/decoder_backend/decoders/__init__.py` | Soft-import dispatcher — add your import here |
-| `lightstim/simulation/decoder_backend/decoders/pymatching.py` | **Pattern A reference** (30 lines, simplest) |
-| `lightstim/simulation/decoder_backend/decoders/mwpf.py` | **Pattern A reference** (no subclass at all) |
-| `lightstim/simulation/decoder_backend/decoders/bposd.py` | **Pattern B reference** — param translation |
-| `lightstim/simulation/decoder_backend/decoders/cudaqx.py` | **Pattern C reference** — DEM matrix + custom CompiledDecoder + GPU |
-| `lightstim/simulation/decoder_backend/external.py` | **Pattern D** — `ExternalDecoder` facade + adapter |
-| `lightstim/simulation/decoder_backend/dem_matrices.py` | Shared `dem_to_matrices(dem, *, sparse=False, merge_duplicates=True)` → (H, obs_matrix, priors) |
-| `lightstim/simulation/decoder_backend/pcm.py` | Older `dem_to_check_matrices()` → CSC + priors. Merges duplicates by **summing** priors; prefer `dem_to_matrices` for new code |
-| `lightstim/simulation/decoder_backend/_accounting.py` | Shared `count_batch()` — denominator/error counting + failure-flag policy |
-| `lightstim/simulation/decoder_backend/pipeline.py` | Consumer of the registry; you shouldn't need to touch it |
-| `lightstim/simulation/decoder_backend/config.py` | `DecoderConfig` dataclass (incl. `on_decode_failure`) |
-| `tests/test_simulation_backend_quality.py` | Decoder smoke tests live here |
+Run `venv/bin/python -m pytest tests/ -m "not slow" -q` before opening a PR,
+and document any new `params` in `lightstim/simulation/README.md`.
 
 ---
 
 ## Gotchas
 
-### 1. Bit-packing is little-endian (LSB first)
-`bit_packed_detection_event_data` and the predictions you return both
-use `np.unpackbits(..., bitorder="little")` / `np.packbits(...,
-bitorder="little")`. Use big-endian by accident and every observable
-prediction will be wrong but the shape will be right — a silent
-correctness bug. (Pattern D handles this for you.)
-
-### 2. C-contiguous matrices for GPU
-`dem_to_matrices(sparse=False)` returns `order="C"` arrays. Most C++/CUDA
-extensions assume row-major; passing Fortran-ordered arrays silently
-transposes the decode and produces nonsense predictions.
-
-### 3. `H.shape[1]` is the mechanism count, not `dem.num_errors`
-`dem_to_matrices` merges identical-footprint mechanisms by default, so the two
-can differ (a `chen_p96` `z_only` DEM had ~36k duplicate columns). A
-`"correction"`-output decoder sized from `dem.num_errors` will then emit
-wrong-length predictions. Always use `H.shape[1]`, or pass
-`merge_duplicates=False` if you need DEM-column alignment.
-
-### 4. GPU decoders must use `num_workers=1`
-`cudaq_qec` decoders pre-allocate GPU memory in `compile_decoder_for_dem`.
-Running with `num_workers > 1` either OOMs or returns garbage. Document
-this in your decoder's docstring and in the smoke test.
-
-### 5. `sinter.collect` is bypassed for GPU
-If your decoder needs GPU resources, `SimulationPipeline` already handles
-this — see the custom decode loop in `pipeline.py` and `worker.py`. You
-don't need to do anything special, but **do not** rely on
-`sinter.collect` semantics in your `compile_decoder_for_dem`.
-
-### 6. Soft-import discipline
-Inside your decoder file, the `try: import upstream_lib` block must
-catch `ImportError`. Use `pytest.importorskip` in tests. Otherwise a user
-without your library gets a hard import failure when they call
-`SimulationPipeline(...)`, not your decoder.
-
-### 7. Post-selection: usually free
-If your decoder just consumes syndromes and emits predictions,
-post-selection (state injection, distillation) works automatically — the
-pipeline filters shots before they reach you. If you need to inspect the
-post-selection mask, see `lightstim/simulation/decoder_backend/post_select.py`.
-
-### 8. Failure flags need LightStim's pipeline (Pattern D)
-Per-shot failure flags ride a side channel (`compiled.last_flags`) that the
-LightStim pipeline reads in-process. They are **not** carried by the sinter
-bit-packed return, so a decoder that relies on `on_decode_failure` heralding
-must run through `SimulationPipeline`, not a raw `sinter.collect`.
+1. **Bit order is little-endian** (LSB-first) for syndromes in and predictions
+   out. Big-endian gives the right shapes and wrong answers. (Pattern C
+   handles this for you.)
+2. **`H.shape[1]` is the mechanism count, not `dem.num_errors`** — duplicate
+   merging can shrink it (a chen_p96 z_only DEM had ~36k duplicate columns).
+   Sizing a `"correction"` output from the DEM gives wrong-length predictions.
+3. **C-contiguous matrices for GPU/C extensions** — `dem_to_matrices` dense
+   output is `order="C"`; keep it that way or the decode silently transposes.
+4. **GPU decoders need `num_workers=1`** — `cudaq_qec` pre-allocates GPU
+   memory per compile; more workers OOM or corrupt results.
+5. **Failure flags need `SimulationPipeline`** — they ride an in-process side
+   channel (`compiled.last_flags`), not the bit-packed return, so raw
+   `sinter.collect` never sees them.
 
 ---
 
-## End-to-end checklist
+## Where things live
 
-Before opening a PR:
-
-- [ ] One new file in `lightstim/simulation/decoder_backend/decoders/`.
-- [ ] `register_decoder(name, cls, aliases=[...], backend="…")` at module bottom.
-- [ ] Soft-import hook added to `decoders/__init__.py` behind a
-      `importlib.util.find_spec` guard.
-- [ ] Smoke test added to `tests/test_simulation_backend_quality.py` that
-      verifies registration and decodes the trivial circuit.
-- [ ] CI passes: `venv/bin/python -m pytest tests/ -m "not slow" -q`.
-- [ ] If the decoder needs special hardware (GPU/FPGA), document the
-      `num_workers` constraint in the docstring.
-- [ ] If your decoder needs new parameters in `DecoderConfig.params`,
-      document them in `lightstim/simulation/README.md` (the decoder
-      backend reference).
-
----
-
-## Working examples
-
-The simplest possible decoder to extend from is **PyMatching** — read
-`lightstim/simulation/decoder_backend/decoders/pymatching.py` end to end
-(it's 56 lines including imports). For parameter handling, read
-`bposd.py`. For an end-to-end custom decoder with DEM parsing and GPU
-integration, read `cudaqx.py`. For the high-level facade, read `external.py`.
-
-Once your decoder is registered, it's usable from anywhere:
-
-```python
-from lightstim.simulation.decoder_backend import SimulationPipeline, DecoderConfig
-
-pipeline = SimulationPipeline(
-    decoder_config=DecoderConfig(
-        name="my-decoder",
-        backend="cpu",
-        params={"max_iterations": 500},
-    ),
-    max_shots=100_000,
-    max_errors=200,
-    num_workers=4,
-)
-stats = pipeline.run(noisy_circuit)
-print(f"LER: {stats.logical_error_rate:.3e}")
-```
-
-No other code changes are required. The HTTP server, notebooks, and
-benchmark scripts all go through `DecoderConfig`, so they pick up your
-new decoder by name with no further plumbing.
+| File | What it is |
+|---|---|
+| `decoder_backend/registry.py` | `register_decoder()`, `get_decoder()`, `list_decoders()` |
+| `decoder_backend/decoders/__init__.py` | soft-import dispatcher — add your import here |
+| `decoder_backend/decoders/{mwpf,relay_bp,tesseract}.py` | Pattern A references |
+| `decoder_backend/decoders/bposd.py` | Pattern A + param translation |
+| `decoder_backend/decoders/cudaqx.py` | Pattern B reference (DEM matrices + GPU) |
+| `decoder_backend/external.py` | Pattern C — the `ExternalDecoder` facade |
+| `decoder_backend/decoders/ldpc_bp.py` | Pattern C reference (flags, serial BP) |
+| `decoder_backend/decoders/chain.py` | multi-level chain over registered decoders |
+| `decoder_backend/dem_matrices.py` | `dem_to_matrices(dem, *, sparse, merge_duplicates)` |
+| `decoder_backend/pcm.py` | older `dem_to_check_matrices` — merges priors by **summing**; prefer `dem_to_matrices` |
+| `decoder_backend/config.py` | `DecoderConfig` (incl. `on_decode_failure`) |
+| `tutorials/how-to-add-new-decoders.ipynb` | runnable walkthrough of all three patterns |

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -152,36 +152,42 @@ The pattern has three parts:
 ### 1. DEM → matrices
 
 Convert a `stim.DetectorErrorModel` into the (H, observable matrix,
-priors) triple your decoder needs. **Reuse the shared helper** rather than
-re-deriving it: `from ..dem_matrices import dem_to_matrices`. It handles
-flattened DEMs, detector targets, observable targets, and decomposed errors,
-and returns C-contiguous matrices. The equivalent code (shown here for
-reference) is:
+priors) triple your decoder needs. **Always reuse the shared helper** rather
+than re-deriving it — `dem_matrices.py` encodes two behaviours that are easy
+to get subtly wrong (parity semantics and duplicate merging, both below):
 
 ```python
-def _dem_to_matrices(dem: stim.DetectorErrorModel):
-    """Returns (H, obs_matrix, priors) — see cudaqx.py for full impl."""
-    n_dets = dem.num_detectors
-    n_obs = dem.num_observables
-    error_cols = []
-    for inst in dem.flattened():
-        if inst.type != "error": continue
-        p = inst.args_copy()[0]
-        dets, obs = [], []
-        for t in inst.targets_copy():
-            if t.is_relative_detector_id():    dets.append(t.val)
-            elif t.is_logical_observable_id(): obs.append(t.val)
-        error_cols.append({"p": p, "dets": dets, "obs": obs})
-    n_err = len(error_cols)
-    H   = np.zeros((n_dets, n_err), dtype=np.uint8, order="C")
-    obs = np.zeros((n_obs,  n_err), dtype=np.uint8, order="C")
-    p   = np.zeros(n_err, dtype=np.float64)
-    for e, col in enumerate(error_cols):
-        p[e] = col["p"]
-        for d in col["dets"]: H[d, e] = 1
-        for o in col["obs"]:  obs[o, e] = 1
-    return H, obs, p
+from ..dem_matrices import dem_to_matrices
+
+H, obs_matrix, priors = dem_to_matrices(
+    dem,
+    sparse=False,           # True -> scipy CSR, never materialises a dense array
+    merge_duplicates=True,  # default; fuses identical-footprint mechanisms
+)
 ```
+
+| | `sparse=False` (default) | `sparse=True` |
+|---|---|---|
+| `H`, `obs_matrix` | dense C-contiguous `uint8` | `scipy.sparse.csr_matrix` |
+| use for | CUDA / C extensions needing row-major | large multi-round LDPC, where dense is many GB and OOMs a worker |
+
+Two behaviours to know about:
+
+**Parity, not assignment.** stim treats a target listed an even number of
+times as cancelling, so `error(0.1) D0 D0 D1` flips only `D1`. The helper
+XORs (`np.add.at(...)` then `& 1`); writing `H[d, e] = 1` instead silently
+produces a wrong matrix. Regression test:
+`test_dem_to_matrices_repeated_targets_cancel`.
+
+**`merge_duplicates` changes the column count.** Mechanisms with identical
+(detector, observable) footprints fuse into one column, with priors combined
+by the XOR rule `p1(1-p2) + p2(1-p1)`. stim does not always do this itself —
+in `z_only` circuits X- and Y-type data errors keep separate columns despite
+identical symptoms, and those degenerate twins measurably degrade BP. So
+**`H.shape[1]` may be smaller than `dem.num_errors`** — derive the error-
+mechanism count from `H.shape[1]`, never from the DEM. Pass
+`merge_duplicates=False` if your decoder must stay column-aligned with the
+original DEM instructions.
 
 ### 2. Custom `CompiledDecoder`
 
@@ -253,6 +259,8 @@ class MyDecoder(ExternalDecoder):
     def setup(self, *, H, obs_matrix, priors, num_detectors, num_observables, dem):
         # Called ONCE per DEM. Stash whatever you need on self.
         # self.params holds the DecoderConfig(params=...) dict.
+        # H and obs_matrix are scipy CSR — call .toarray() if your library
+        # needs dense (only safe for small DEMs; see the note below).
         self._inner = my_lib.Decoder(H, priors, **self.params)
 
     # Implement EITHER decode_single OR decode_batch — LightStim bridges the other.
@@ -266,6 +274,19 @@ class MyDecoder(ExternalDecoder):
 
 register_decoder("my-decoder", MyDecoder, backend="cpu")
 ```
+
+### What `setup` receives
+
+The facade calls `dem_to_matrices(dem, sparse=True, merge_duplicates=True)`,
+so `H` and `obs_matrix` are **`scipy.sparse.csr_matrix`**, and `n_err`
+(= `H.shape[1]`) is the *merged* mechanism count, which **may be smaller than
+`dem.num_errors`** — see the `merge_duplicates` note in Pattern C. Size your
+`"correction"` output from `H.shape[1]`, not from the DEM.
+
+Sparse is deliberate: these are the decoders that run on large LDPC circuits
+where a dense `(n_detectors, n_error_mechanisms)` matrix can be many GB and
+OOM a worker. If your library needs dense input, `H.toarray()` works but
+reintroduces that cost.
 
 ### The three axes `ExternalDecoder` formalises
 
@@ -386,7 +407,8 @@ so CI doesn't fail when the library isn't installed.
 | `lightstim/simulation/decoder_backend/decoders/bposd.py` | **Pattern B reference** — param translation |
 | `lightstim/simulation/decoder_backend/decoders/cudaqx.py` | **Pattern C reference** — DEM matrix + custom CompiledDecoder + GPU |
 | `lightstim/simulation/decoder_backend/external.py` | **Pattern D** — `ExternalDecoder` facade + adapter |
-| `lightstim/simulation/decoder_backend/dem_matrices.py` | Shared `dem_to_matrices()` (H, obs_matrix, priors) |
+| `lightstim/simulation/decoder_backend/dem_matrices.py` | Shared `dem_to_matrices(dem, *, sparse=False, merge_duplicates=True)` → (H, obs_matrix, priors) |
+| `lightstim/simulation/decoder_backend/pcm.py` | Older `dem_to_check_matrices()` → CSC + priors. Merges duplicates by **summing** priors; prefer `dem_to_matrices` for new code |
 | `lightstim/simulation/decoder_backend/_accounting.py` | Shared `count_batch()` — denominator/error counting + failure-flag policy |
 | `lightstim/simulation/decoder_backend/pipeline.py` | Consumer of the registry; you shouldn't need to touch it |
 | `lightstim/simulation/decoder_backend/config.py` | `DecoderConfig` dataclass (incl. `on_decode_failure`) |
@@ -404,34 +426,41 @@ prediction will be wrong but the shape will be right — a silent
 correctness bug. (Pattern D handles this for you.)
 
 ### 2. C-contiguous matrices for GPU
-Pattern C constructs `H` and `obs_matrix` with `order="C"`. Most C++/CUDA
+`dem_to_matrices(sparse=False)` returns `order="C"` arrays. Most C++/CUDA
 extensions assume row-major; passing Fortran-ordered arrays silently
 transposes the decode and produces nonsense predictions.
 
-### 3. GPU decoders must use `num_workers=1`
+### 3. `H.shape[1]` is the mechanism count, not `dem.num_errors`
+`dem_to_matrices` merges identical-footprint mechanisms by default, so the two
+can differ (a `chen_p96` `z_only` DEM had ~36k duplicate columns). A
+`"correction"`-output decoder sized from `dem.num_errors` will then emit
+wrong-length predictions. Always use `H.shape[1]`, or pass
+`merge_duplicates=False` if you need DEM-column alignment.
+
+### 4. GPU decoders must use `num_workers=1`
 `cudaq_qec` decoders pre-allocate GPU memory in `compile_decoder_for_dem`.
 Running with `num_workers > 1` either OOMs or returns garbage. Document
 this in your decoder's docstring and in the smoke test.
 
-### 4. `sinter.collect` is bypassed for GPU
+### 5. `sinter.collect` is bypassed for GPU
 If your decoder needs GPU resources, `SimulationPipeline` already handles
 this — see the custom decode loop in `pipeline.py` and `worker.py`. You
 don't need to do anything special, but **do not** rely on
 `sinter.collect` semantics in your `compile_decoder_for_dem`.
 
-### 5. Soft-import discipline
+### 6. Soft-import discipline
 Inside your decoder file, the `try: import upstream_lib` block must
 catch `ImportError`. Use `pytest.importorskip` in tests. Otherwise a user
 without your library gets a hard import failure when they call
 `SimulationPipeline(...)`, not your decoder.
 
-### 6. Post-selection: usually free
+### 7. Post-selection: usually free
 If your decoder just consumes syndromes and emits predictions,
 post-selection (state injection, distillation) works automatically — the
 pipeline filters shots before they reach you. If you need to inspect the
 post-selection mask, see `lightstim/simulation/decoder_backend/post_select.py`.
 
-### 7. Failure flags need LightStim's pipeline (Pattern D)
+### 8. Failure flags need LightStim's pipeline (Pattern D)
 Per-shot failure flags ride a side channel (`compiled.last_flags`) that the
 LightStim pipeline reads in-process. They are **not** carried by the sinter
 bit-packed return, so a decoder that relies on `on_decode_failure` heralding

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -53,9 +53,10 @@ class _MyCompiled:                     # sinter.CompiledDecoder base optional
         ...
 ```
 
-Subclassing the sinter bases remains the repo convention (and is required if
-you also want the decoder usable with raw `sinter.collect`); matching this
-signature is why sinter-native decoders plug in unchanged.
+Subclassing the sinter bases is the repo convention and the documented API, but
+it is not a runtime requirement — raw `sinter.collect` accepts duck-typed
+classes too (verified on sinter 1.15/1.16). Matching this signature is why
+sinter-native decoders plug in unchanged.
 
 **Pattern C skips this contract entirely** — the `ExternalDecoder` facade
 implements it for you; you only write methods on plain unpacked arrays.
@@ -75,9 +76,18 @@ except ImportError:
     pass
 ```
 
-That's the entire built-in `mwpf.py`. `relay_bp.py` and `tesseract.py` are the
-same shape. User params flow straight through `DecoderConfig(params={…})` to
-the upstream class — don't add a translation layer for a single library.
+That's the entire built-in `mwpf.py`; `relay_bp.py` is the same shape. User
+params flow straight through `DecoderConfig(params={…})` to the upstream class
+— don't add a translation layer for a single library.
+
+**Lazy variant** (`tesseract.py`): when the upstream package is a native
+extension whose import can fail on a given host, don't import it at module
+load. Register a thin `sinter.Decoder` subclass that imports inside
+`__init__` and delegates `compile_decoder_for_dem` to the upstream object,
+guarded by `importlib.util.find_spec` so a broken wheel breaks only
+`DecoderConfig("tesseract")` and not the whole registry. This also covers the
+case — as with Tesseract — where the upstream class merely duck-types the
+sinter interface instead of subclassing it.
 
 **Need renamed params or defaults?** Give a thin wrapper class an
 `__init__(**params)` that merges defaults and renames keys before constructing
@@ -226,7 +236,8 @@ and document any new `params` in `lightstim/simulation/README.md`.
 |---|---|
 | `decoder_backend/registry.py` | `register_decoder()`, `get_decoder()`, `list_decoders()` |
 | `decoder_backend/decoders/__init__.py` | soft-import dispatcher — add your import here |
-| `decoder_backend/decoders/{mwpf,relay_bp,tesseract}.py` | Pattern A references |
+| `decoder_backend/decoders/{mwpf,relay_bp}.py` | Pattern A references — direct registration |
+| `decoder_backend/decoders/tesseract.py` | Pattern A lazy variant — deferred native import |
 | `decoder_backend/decoders/bposd.py` | Pattern A + param translation |
 | `decoder_backend/decoders/cudaqx.py` | Pattern B reference (DEM matrices + GPU) |
 | `decoder_backend/external.py` | Pattern C — the `ExternalDecoder` facade |

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -12,10 +12,11 @@ user-invocable: true
 
 # Add a New Decoder
 
-LightStim's decoder backend is a small registry of `sinter.Decoder`
-subclasses. Each decoder is registered under a name + backend (`cpu`,
-`gpu`, or `fpga`), then `DecoderConfig(name="…", backend="…", params={})`
-looks it up at runtime.
+LightStim's decoder backend is a small registry of decoder classes (by
+convention `sinter.Decoder` subclasses, though the pipeline only duck-types
+the interface — see the contract below). Each decoder is registered under a
+name + backend (`cpu`, `gpu`, or `fpga`), then
+`DecoderConfig(name="…", backend="…", params={})` looks it up at runtime.
 
 Adding a decoder is **always one new file** in
 `lightstim/simulation/decoder_backend/decoders/`, plus **one line** in
@@ -31,18 +32,15 @@ one that matches your situation.
 
 ## The contract
 
-Every decoder must subclass `sinter.Decoder` and implement
-`compile_decoder_for_dem`. That method takes a `stim.DetectorErrorModel`
-and returns a `sinter.CompiledDecoder`:
+The pipeline is **duck-typed** — it never checks `isinstance(..., sinter.Decoder)`.
+A decoder is any object with a `compile_decoder_for_dem` method that takes a
+`stim.DetectorErrorModel` and returns a compiled decoder:
 
 ```python
-import sinter
 import stim
 
-class MyDecoder(sinter.Decoder):
-    def compile_decoder_for_dem(
-        self, *, dem: stim.DetectorErrorModel
-    ) -> sinter.CompiledDecoder:
+class MyDecoder:                       # sinter.Decoder base is optional
+    def compile_decoder_for_dem(self, *, dem: stim.DetectorErrorModel):
         ...   # one-time prep per DEM
 ```
 
@@ -51,7 +49,7 @@ The compiled decoder must implement
 -> np.ndarray` — bit-packed in, bit-packed out:
 
 ```python
-class _MyCompiledDecoder(sinter.CompiledDecoder):
+class _MyCompiledDecoder:              # sinter.CompiledDecoder base is optional
     def decode_shots_bit_packed(
         self, *, bit_packed_detection_event_data: np.ndarray
     ) -> np.ndarray:
@@ -59,6 +57,12 @@ class _MyCompiledDecoder(sinter.CompiledDecoder):
         # output shape: (n_shots, ceil(n_observables / 8)), uint8, LSB-first
         ...
 ```
+
+Subclassing `sinter.Decoder` / `sinter.CompiledDecoder` is still the repo
+convention (the built-in decoders do, and it's required if you also want your
+decoder usable with a raw `sinter.collect` outside LightStim), but the method
+signatures above are the whole contract — `sinter` matching them is why
+sinter-native decoders plug in unchanged (Pattern A).
 
 If your underlying library already implements `sinter.Decoder` and
 `sinter.CompiledDecoder` correctly (e.g. `stimbposd.SinterDecoder_BPOSD`,

--- a/skills/extend-new-decoder/SKILL.md
+++ b/skills/extend-new-decoder/SKILL.md
@@ -32,6 +32,12 @@ one that matches your situation.
 
 ## The contract
 
+**Pattern D skips this section entirely.** If you subclass `ExternalDecoder`,
+the facade already implements this interface — you only write `setup` plus
+`decode_single`/`decode_batch` on plain unpacked numpy arrays, and never touch
+bit-packing or these method signatures. The contract below is what Patterns
+A–C implement (and what the facade implements *for* you).
+
 The pipeline is **duck-typed** — it never checks `isinstance(..., sinter.Decoder)`.
 A decoder is any object with a `compile_decoder_for_dem` method that takes a
 `stim.DetectorErrorModel` and returns a compiled decoder:

--- a/tests/test_simulation_backend_quality.py
+++ b/tests/test_simulation_backend_quality.py
@@ -92,7 +92,7 @@ def test_relay_bp_registered_and_runs():
 
 
 def test_ldpc_bp_registered_and_runs():
-    """Plain BP (ldpc.BpDecoder, Pattern D) registers and decodes when installed."""
+    """Plain BP (ldpc.BpDecoder, Pattern C facade) registers and decodes when installed."""
     importorskip_safe("ldpc")
 
     assert "ldpc-bp" in list_decoders()

--- a/tests/test_simulation_backend_quality.py
+++ b/tests/test_simulation_backend_quality.py
@@ -7,7 +7,10 @@ from lightstim.simulation.decoder_backend import DecoderConfig, SimulationPipeli
 from lightstim.simulation.decoder_backend._accounting import count_batch
 from lightstim.simulation.decoder_backend.dem_matrices import dem_to_matrices
 from lightstim.simulation.decoder_backend.external import ExternalDecoder
-from lightstim.simulation.decoder_backend.registry import register_decoder
+from lightstim.simulation.decoder_backend.registry import (
+    get_decoder,
+    register_decoder,
+)
 from lightstim.simulation.simulator import ExperimentTask, QECSimulator
 
 
@@ -19,6 +22,22 @@ def _simple_observable_circuit(error_probability: float = 0.0) -> stim.Circuit:
     circuit.append("DETECTOR", [stim.target_rec(-1)])
     circuit.append("OBSERVABLE_INCLUDE", [stim.target_rec(-1)], 0)
     return circuit
+
+
+def _max_detectors_per_error_component(dem: stim.DetectorErrorModel) -> int:
+    maximum = 0
+    for instruction in dem.flattened():
+        if instruction.type != "error":
+            continue
+        component_size = 0
+        for target in instruction.targets_copy():
+            if target.is_separator():
+                maximum = max(maximum, component_size)
+                component_size = 0
+            elif target.is_relative_detector_id():
+                component_size += 1
+        maximum = max(maximum, component_size)
+    return maximum
 
 
 @pytest.mark.smoke
@@ -51,6 +70,27 @@ def test_cpu_decoder_does_not_import_cudaq_qec():
         f"cudaq_qec was imported by the CPU path:\nstdout: {result.stdout}\n"
         f"stderr: {result.stderr}"
     )
+
+
+@pytest.mark.smoke
+def test_pymatching_requests_graphlike_dem_decomposition():
+    """PyMatching must not silently drop undecomposed circuit hyperedges."""
+    decoder = get_decoder("pymatching", backend="cpu")
+    assert decoder.decompose_errors is True
+
+    circuit = stim.Circuit.generated(
+        "surface_code:rotated_memory_z",
+        distance=3,
+        rounds=3,
+        after_clifford_depolarization=0.001,
+    )
+    raw_dem = circuit.detector_error_model()
+    decoder_dem = circuit.detector_error_model(
+        decompose_errors=decoder.decompose_errors
+    )
+
+    assert _max_detectors_per_error_component(raw_dem) > 2
+    assert _max_detectors_per_error_component(decoder_dem) <= 2
 
 
 def test_multiprocess_unknown_decoder_raises_in_parent():

--- a/tutorials/how-to-add-new-decoders.ipynb
+++ b/tutorials/how-to-add-new-decoders.ipynb
@@ -52,10 +52,10 @@
    "id": "25821ee5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:38:51.180906Z",
-     "iopub.status.busy": "2026-08-07T04:38:51.180770Z",
-     "iopub.status.idle": "2026-08-07T04:38:51.742699Z",
-     "shell.execute_reply": "2026-08-07T04:38:51.741580Z"
+     "iopub.execute_input": "2026-08-08T04:33:58.518475Z",
+     "iopub.status.busy": "2026-08-08T04:33:58.518198Z",
+     "iopub.status.idle": "2026-08-08T04:33:59.234339Z",
+     "shell.execute_reply": "2026-08-08T04:33:59.233518Z"
     }
    },
    "outputs": [
@@ -101,9 +101,9 @@
     "def demo_circuit(distance: int = 5, p: float = 1e-3) -> stim.Circuit:\n",
     "    \"\"\"A rotated surface-code Z-memory experiment with circuit-level noise.\n",
     "\n",
-    "    Used for Patterns A & B, whose decoders (PyMatching, BP+OSD, Relay-BP)\n",
-    "    build their graph / check matrix straight from the DEM and so handle the\n",
-    "    surface code's hyperedges. NOTE: at d=5, p=1e-3 the logical error rate is\n",
+    "    Used by every pattern below. Each of these decoders (PyMatching,\n",
+    "    Relay-BP, Tesseract, ldpc BP) builds its graph / check matrix straight\n",
+    "    from the DEM and so handles the surface code's hyperedges. NOTE: at d=5, p=1e-3 the logical error rate is\n",
     "    tiny (well below 1e-4), so a short run usually sees 0 errors - raise\n",
     "    max_shots for a real estimate.\n",
     "    \"\"\"\n",
@@ -166,10 +166,10 @@
    "id": "387ed34c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:38:51.744281Z",
-     "iopub.status.busy": "2026-08-07T04:38:51.744067Z",
-     "iopub.status.idle": "2026-08-07T04:38:52.294588Z",
-     "shell.execute_reply": "2026-08-07T04:38:52.293720Z"
+     "iopub.execute_input": "2026-08-08T04:33:59.236252Z",
+     "iopub.status.busy": "2026-08-08T04:33:59.236028Z",
+     "iopub.status.idle": "2026-08-08T04:33:59.841299Z",
+     "shell.execute_reply": "2026-08-08T04:33:59.840256Z"
     }
    },
    "outputs": [
@@ -177,13 +177,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  pymatching     LER=2.300e-04  (46/200000 shots)\n"
+      "  pymatching     LER=2.250e-04  (45/200000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=46, seconds=0.5423154851887375, decoder='pymatching', json_metadata={})"
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=45, seconds=0.5940127598587424, decoder='pymatching', json_metadata={})"
       ]
      },
      "execution_count": 2,
@@ -215,10 +215,10 @@
    "id": "115e808a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:38:52.296265Z",
-     "iopub.status.busy": "2026-08-07T04:38:52.296101Z",
-     "iopub.status.idle": "2026-08-07T04:39:00.830003Z",
-     "shell.execute_reply": "2026-08-07T04:39:00.829037Z"
+     "iopub.execute_input": "2026-08-08T04:33:59.843084Z",
+     "iopub.status.busy": "2026-08-08T04:33:59.842944Z",
+     "iopub.status.idle": "2026-08-08T04:34:07.883115Z",
+     "shell.execute_reply": "2026-08-08T04:34:07.881146Z"
     }
    },
    "outputs": [
@@ -233,13 +233,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  relay-bp       LER=1.450e-04  (29/200000 shots)\n"
+      "  relay-bp       LER=1.200e-04  (24/200000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=29, seconds=8.52741400199011, decoder='relay-bp', json_metadata={})"
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=24, seconds=8.02567717898637, decoder='relay-bp', json_metadata={})"
       ]
      },
      "execution_count": 3,
@@ -309,7 +309,7 @@
     "flipped_observables = decoder.decode(syndrome)   # bool[n_dets] -> bool[n_obs]\n",
     "```\n",
     "\n",
-    "> **Note — Tesseract is actually sinter-native**, and LightStim already ships it as the built-in `\"tesseract\"` (`decoders/tesseract.py`, a one-line Pattern A registration). We deliberately use its lower-level `compile_decoder()` / `decode()` API here *only to illustrate Pattern B*, registered under the demo name `\"tesseract-demo\"` so we don't shadow the built-in.\n",
+    "> **Note — Tesseract already ships as the built-in `\"tesseract\"`.** Upstream provides `TesseractSinterDecoder`, which duck-types the sinter interface, so `decoders/tesseract.py` registers a thin `sinter.Decoder` subclass that imports the native extension lazily in `__init__` (a broken wheel then breaks only this decoder, not the registry) — a Pattern A *lazy variant*, not a one-line direct registration. We deliberately use Tesseract's lower-level `compile_decoder()` / `decode()` API here *only to illustrate Pattern B*, registered as `\"tesseract-demo\"` so we don't shadow the built-in.\n",
     "\n",
     "The three parts: (1) build the decoder from the DEM, (2) a custom `CompiledDecoder` that unpacks the syndromes, loops `decode`, and packs the observable flips, (3) a top-level `sinter.Decoder`. Since Tesseract is hyperedge-aware, this runs on the surface-code DEM directly (no graphlike restriction).\n"
    ]
@@ -320,10 +320,10 @@
    "id": "52e8a8e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:39:00.831627Z",
-     "iopub.status.busy": "2026-08-07T04:39:00.831471Z",
-     "iopub.status.idle": "2026-08-07T04:39:00.836938Z",
-     "shell.execute_reply": "2026-08-07T04:39:00.836185Z"
+     "iopub.execute_input": "2026-08-08T04:34:07.885598Z",
+     "iopub.status.busy": "2026-08-08T04:34:07.885321Z",
+     "iopub.status.idle": "2026-08-08T04:34:07.891534Z",
+     "shell.execute_reply": "2026-08-08T04:34:07.890766Z"
     }
    },
    "outputs": [
@@ -410,10 +410,10 @@
    "id": "ff0af6d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:39:00.838291Z",
-     "iopub.status.busy": "2026-08-07T04:39:00.838163Z",
-     "iopub.status.idle": "2026-08-07T04:39:02.359910Z",
-     "shell.execute_reply": "2026-08-07T04:39:02.358946Z"
+     "iopub.execute_input": "2026-08-08T04:34:07.892987Z",
+     "iopub.status.busy": "2026-08-08T04:34:07.892837Z",
+     "iopub.status.idle": "2026-08-08T04:34:10.418028Z",
+     "shell.execute_reply": "2026-08-08T04:34:10.416901Z"
     }
    },
    "outputs": [
@@ -428,13 +428,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  bp-demo        LER=3.295e-02  (659/20000 shots)\n"
+      "  bp-demo        LER=3.340e-02  (668/20000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=20000, post_selected_shots=20000, errors=659, seconds=1.5132264429703355, decoder='bp-demo', json_metadata={})"
+       "SimulationStats(shots=20000, post_selected_shots=20000, errors=668, seconds=2.518130226060748, decoder='bp-demo', json_metadata={})"
       ]
      },
      "execution_count": 5,
@@ -490,10 +490,10 @@
    "id": "5fa34ccf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:39:02.372534Z",
-     "iopub.status.busy": "2026-08-07T04:39:02.372267Z",
-     "iopub.status.idle": "2026-08-07T04:39:02.377786Z",
-     "shell.execute_reply": "2026-08-07T04:39:02.376908Z"
+     "iopub.execute_input": "2026-08-08T04:34:10.430826Z",
+     "iopub.status.busy": "2026-08-08T04:34:10.430610Z",
+     "iopub.status.idle": "2026-08-08T04:34:10.436795Z",
+     "shell.execute_reply": "2026-08-08T04:34:10.435967Z"
     }
    },
    "outputs": [
@@ -526,7 +526,7 @@
     "except ImportError:\n",
     "    print(\"tesseract_decoder not installed - skipping\")\n",
     "\n",
-    "# Same predictions as the Pattern B 'tesseract' decoder - the facade owns the packing.\n",
+    "# Same predictions as the Pattern B 'tesseract-demo' decoder - the facade owns the packing.\n",
     "benchmark(\"tesseract-ext\", params={\"det_beam\": 50})\n"
    ]
   },
@@ -552,10 +552,10 @@
    "id": "508f29b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T04:39:02.379341Z",
-     "iopub.status.busy": "2026-08-07T04:39:02.379194Z",
-     "iopub.status.idle": "2026-08-07T04:39:13.618348Z",
-     "shell.execute_reply": "2026-08-07T04:39:13.616845Z"
+     "iopub.execute_input": "2026-08-08T04:34:10.438278Z",
+     "iopub.status.busy": "2026-08-08T04:34:10.438122Z",
+     "iopub.status.idle": "2026-08-08T04:34:21.900714Z",
+     "shell.execute_reply": "2026-08-08T04:34:21.899452Z"
     }
    },
    "outputs": [

--- a/tutorials/how-to-add-new-decoders.ipynb
+++ b/tutorials/how-to-add-new-decoders.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "| Pattern | When to use | Example here |\n",
     "|---|---|---|\n",
-    "| **A. Register a sinter decoder** | Upstream already implements `sinter.Decoder` | PyMatching (built-in) · **Relay-BP** |\n",
+    "| **A. Register a sinter decoder** | Upstream already implements `sinter.Decoder` | **Relay-BP** · MWPF |\n",
     "| **B. Custom decoder from a DEM** | Not sinter-compatible; you want full control | **Tesseract** (shown as custom) |\n",
     "| **C. `ExternalDecoder` facade** | Not sinter-compatible; you want the easy path | ldpc BP (correction) · Tesseract (observables) |\n",
     "\n",
@@ -52,10 +52,10 @@
    "id": "25821ee5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:33:58.518475Z",
-     "iopub.status.busy": "2026-08-08T04:33:58.518198Z",
-     "iopub.status.idle": "2026-08-08T04:33:59.234339Z",
-     "shell.execute_reply": "2026-08-08T04:33:59.233518Z"
+     "iopub.execute_input": "2026-08-08T20:57:38.844534Z",
+     "iopub.status.busy": "2026-08-08T20:57:38.844395Z",
+     "iopub.status.idle": "2026-08-08T20:57:39.332316Z",
+     "shell.execute_reply": "2026-08-08T20:57:39.331091Z"
     }
    },
    "outputs": [
@@ -63,7 +63,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "decoders registered at import: ['bposd', 'chain', 'ldpc-bp', 'mwpf', 'nv-qldpc-decoder', 'pymatching', 'relay-bp', 'tesseract']\n"
+      "decoders registered at import: ['bposd', 'chain', 'ldpc-bp', 'nv-qldpc-decoder', 'pymatching']\n"
      ]
     }
    ],
@@ -101,9 +101,10 @@
     "def demo_circuit(distance: int = 5, p: float = 1e-3) -> stim.Circuit:\n",
     "    \"\"\"A rotated surface-code Z-memory experiment with circuit-level noise.\n",
     "\n",
-    "    Used by every pattern below. Each of these decoders (PyMatching,\n",
-    "    Relay-BP, Tesseract, ldpc BP) builds its graph / check matrix straight\n",
-    "    from the DEM and so handles the surface code's hyperedges. NOTE: at d=5, p=1e-3 the logical error rate is\n",
+    "    Used by every pattern below. PyMatching asks Stim to decompose\n",
+    "    circuit-level hyperedges into graphlike components; Relay-BP,\n",
+    "    Tesseract, and ldpc BP consume the undecomposed DEM. NOTE: at d=5,\n",
+    "    p=1e-3 the logical error rate is\n",
     "    tiny (well below 1e-4), so a short run usually sees 0 errors - raise\n",
     "    max_shots for a real estimate.\n",
     "    \"\"\"\n",
@@ -151,13 +152,11 @@
    "id": "f015c20a",
    "metadata": {},
    "source": [
-    "## Pattern A — register a sinter-native decoder\n",
+    "## Baseline — PyMatching (built-in)\n",
     "\n",
-    "**When:** the upstream library already implements `sinter.Decoder`. There is nothing to write — you just put the class in the registry under a LightStim name.\n",
+    "PyMatching itself does not ship a `sinter.Decoder`; LightStim provides the wrapper in `decoders/pymatching.py`. The wrapper sets `decompose_errors=True`, so the pipeline asks Stim to turn decomposable circuit-level hyperedges into graphlike components before PyMatching builds its matching graph. Use the built-in by name:\n",
     "\n",
-    "### A1. PyMatching (built-in)\n",
-    "\n",
-    "PyMatching ships as a `sinter.Decoder` and LightStim registers it out of the box. Use it by name:\n"
+    "This is a built-in baseline, not Pattern A: LightStim owns the sinter adapter instead of directly registering an upstream decoder class.\n"
    ]
   },
   {
@@ -166,10 +165,10 @@
    "id": "387ed34c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:33:59.236252Z",
-     "iopub.status.busy": "2026-08-08T04:33:59.236028Z",
-     "iopub.status.idle": "2026-08-08T04:33:59.841299Z",
-     "shell.execute_reply": "2026-08-08T04:33:59.840256Z"
+     "iopub.execute_input": "2026-08-08T20:57:39.335214Z",
+     "iopub.status.busy": "2026-08-08T20:57:39.334933Z",
+     "iopub.status.idle": "2026-08-08T20:57:40.011167Z",
+     "shell.execute_reply": "2026-08-08T20:57:40.009982Z"
     }
    },
    "outputs": [
@@ -177,13 +176,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  pymatching     LER=2.250e-04  (45/200000 shots)\n"
+      "  pymatching     LER=1.300e-04  (26/200000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=45, seconds=0.5940127598587424, decoder='pymatching', json_metadata={})"
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=26, seconds=0.6647264150087722, decoder='pymatching', json_metadata={})"
       ]
      },
      "execution_count": 2,
@@ -200,7 +199,11 @@
    "id": "478ee53f",
    "metadata": {},
    "source": [
-    "### A2. Relay-BP — the highlighted example\n",
+    "## Pattern A — register a sinter-native decoder\n",
+    "\n",
+    "**When:** the upstream library already implements `sinter.Decoder`. There is nothing to write — you just put the class in the registry under a LightStim name.\n",
+    "\n",
+    "### Relay-BP — the highlighted example\n",
     "\n",
     "[Relay-BP](https://github.com/trmue/relay) ships sinter-compatible decoders via `relay_bp.stim`. `SinterDecoder_RelayBP` **is** a `sinter.Decoder` (it implements both `compile_decoder_for_dem` and `decode_via_files`), so we register the class **directly** — the purest Pattern A, exactly like the built-in `mwpf` decoder.\n",
     "\n",
@@ -215,10 +218,10 @@
    "id": "115e808a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:33:59.843084Z",
-     "iopub.status.busy": "2026-08-08T04:33:59.842944Z",
-     "iopub.status.idle": "2026-08-08T04:34:07.883115Z",
-     "shell.execute_reply": "2026-08-08T04:34:07.881146Z"
+     "iopub.execute_input": "2026-08-08T20:57:40.015536Z",
+     "iopub.status.busy": "2026-08-08T20:57:40.015250Z",
+     "iopub.status.idle": "2026-08-08T20:57:40.022059Z",
+     "shell.execute_reply": "2026-08-08T20:57:40.021098Z"
     }
    },
    "outputs": [
@@ -226,25 +229,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "registered 'relay-bp': True\n"
+      "relay_bp not installed - skipping registration\n",
+      "  relay-bp       not registered (optional library missing) - skipped\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  relay-bp       LER=1.200e-04  (24/200000 shots)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=24, seconds=8.02567717898637, decoder='relay-bp', json_metadata={})"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -320,10 +307,10 @@
    "id": "52e8a8e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:34:07.885598Z",
-     "iopub.status.busy": "2026-08-08T04:34:07.885321Z",
-     "iopub.status.idle": "2026-08-08T04:34:07.891534Z",
-     "shell.execute_reply": "2026-08-08T04:34:07.890766Z"
+     "iopub.execute_input": "2026-08-08T20:57:40.025864Z",
+     "iopub.status.busy": "2026-08-08T20:57:40.025599Z",
+     "iopub.status.idle": "2026-08-08T20:57:40.034645Z",
+     "shell.execute_reply": "2026-08-08T20:57:40.033625Z"
     }
    },
    "outputs": [
@@ -410,10 +397,10 @@
    "id": "ff0af6d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:34:07.892987Z",
-     "iopub.status.busy": "2026-08-08T04:34:07.892837Z",
-     "iopub.status.idle": "2026-08-08T04:34:10.418028Z",
-     "shell.execute_reply": "2026-08-08T04:34:10.416901Z"
+     "iopub.execute_input": "2026-08-08T20:57:40.038061Z",
+     "iopub.status.busy": "2026-08-08T20:57:40.037808Z",
+     "iopub.status.idle": "2026-08-08T20:57:41.579465Z",
+     "shell.execute_reply": "2026-08-08T20:57:41.578188Z"
     }
    },
    "outputs": [
@@ -428,13 +415,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  bp-demo        LER=3.340e-02  (668/20000 shots)\n"
+      "  bp-demo        LER=3.150e-02  (630/20000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=20000, post_selected_shots=20000, errors=668, seconds=2.518130226060748, decoder='bp-demo', json_metadata={})"
+       "SimulationStats(shots=20000, post_selected_shots=20000, errors=630, seconds=1.5281100799911655, decoder='bp-demo', json_metadata={})"
       ]
      },
      "execution_count": 5,
@@ -490,10 +477,10 @@
    "id": "5fa34ccf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:34:10.430826Z",
-     "iopub.status.busy": "2026-08-08T04:34:10.430610Z",
-     "iopub.status.idle": "2026-08-08T04:34:10.436795Z",
-     "shell.execute_reply": "2026-08-08T04:34:10.435967Z"
+     "iopub.execute_input": "2026-08-08T20:57:41.583008Z",
+     "iopub.status.busy": "2026-08-08T20:57:41.582694Z",
+     "iopub.status.idle": "2026-08-08T20:57:41.590630Z",
+     "shell.execute_reply": "2026-08-08T20:57:41.589663Z"
     }
    },
    "outputs": [
@@ -552,10 +539,10 @@
    "id": "508f29b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T04:34:10.438278Z",
-     "iopub.status.busy": "2026-08-08T04:34:10.438122Z",
-     "iopub.status.idle": "2026-08-08T04:34:21.900714Z",
-     "shell.execute_reply": "2026-08-08T04:34:21.899452Z"
+     "iopub.execute_input": "2026-08-08T20:57:41.593818Z",
+     "iopub.status.busy": "2026-08-08T20:57:41.593532Z",
+     "iopub.status.idle": "2026-08-08T20:57:53.742846Z",
+     "shell.execute_reply": "2026-08-08T20:57:53.740802Z"
     }
    },
    "outputs": [
@@ -563,21 +550,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  on_decode_failure=error    -> kept= 20000 errors=  667 LER=3.335e-02\n"
+      "  on_decode_failure=error    -> kept= 20000 errors=  642 LER=3.210e-02\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  on_decode_failure=discard  -> kept= 19333 errors=    0 LER=0.000e+00\n"
+      "  on_decode_failure=discard  -> kept= 19358 errors=    0 LER=0.000e+00\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  on_decode_failure=ignore   -> kept= 20000 errors=   57 LER=2.850e-03\n"
+      "  on_decode_failure=ignore   -> kept= 20000 errors=   50 LER=2.500e-03\n"
      ]
     }
    ],
@@ -618,7 +605,9 @@
     "|---|---|\n",
     "| `decoder_backend/registry.py` | `register_decoder()`, `get_decoder()`, `list_decoders()` |\n",
     "| `decoder_backend/decoders/__init__.py` | soft-import dispatcher |\n",
-    "| `decoder_backend/decoders/{pymatching,mwpf,relay_bp,tesseract}.py` | Pattern A references |\n",
+    "| `decoder_backend/decoders/pymatching.py` | built-in wrapper; requests Stim graphlike decomposition |\n",
+    "| `decoder_backend/decoders/{mwpf,relay_bp}.py` | Pattern A references — direct registration |\n",
+    "| `decoder_backend/decoders/tesseract.py` | Pattern A lazy variant — deferred native import |\n",
     "| `decoder_backend/decoders/bposd.py` | sinter wrapper that renames params (see Pattern A note) |\n",
     "| `decoder_backend/decoders/cudaqx.py` | Pattern B reference (DEM matrix + GPU) |\n",
     "| `decoder_backend/external.py` | Pattern C — `ExternalDecoder` facade |\n",
@@ -630,6 +619,7 @@
     "### Gotchas\n",
     "\n",
     "- **Bit order is little-endian** (`bitorder=\"little\"`) for both syndromes in and predictions out. Pattern C handles this for you.\n",
+    "- **PyMatching is graphlike, not hyperedge-native** — its wrapper requests `decompose_errors=True` so Stim decomposes supported circuit-level hyperedges first.\n",
     "- **`H.shape[1]` is the mechanism count, not `dem.num_errors`** — `dem_to_matrices` merges identical-footprint columns by default.\n",
     "- **Failure flags** ride an in-process side channel and require LightStim's `SimulationPipeline`, not a raw `sinter.collect`.\n",
     "\n",

--- a/tutorials/how-to-add-new-decoders.ipynb
+++ b/tutorials/how-to-add-new-decoders.ipynb
@@ -7,23 +7,25 @@
    "source": [
     "# How to add a new decoder to LightStim\n",
     "\n",
-    "LightStim's decoder backend is a small **registry** of [`sinter.Decoder`](https://github.com/quantumlib/Stim/tree/main/glue/sample) subclasses. Each decoder is registered under a *name* + *backend* (`cpu` / `gpu` / `fpga`), and at runtime\n",
+    "LightStim's decoder backend is a small **registry** of decoder classes. Each decoder is registered under a *name* + *backend* (`cpu` / `gpu` / `fpga`), and at runtime\n",
     "\n",
     "```python\n",
-    "DecoderConfig(name=\"\u2026\", backend=\"\u2026\", params={\u2026})\n",
+    "DecoderConfig(name=\"…\", backend=\"…\", params={…})\n",
     "```\n",
     "\n",
-    "looks it up. Every consumer \u2014 the simulation pipeline, the HTTP server, the notebooks, the benchmark scripts \u2014 goes through `DecoderConfig`, so once a decoder is registered it is usable *everywhere* by name.\n",
+    "looks it up. Every consumer — the simulation pipeline, the HTTP server, the notebooks, the benchmark scripts — goes through `DecoderConfig`, so once a decoder is registered it is usable *everywhere* by name.\n",
     "\n",
     "This tutorial walks through **three integration patterns**, with one runnable example each. Pick the one that matches your decoder:\n",
     "\n",
     "| Pattern | When to use | Example here |\n",
     "|---|---|---|\n",
-    "| **A. Register a sinter decoder** | Upstream already implements `sinter.Decoder` | PyMatching (built-in) \u00b7 **Relay-BP** |\n",
+    "| **A. Register a sinter decoder** | Upstream already implements `sinter.Decoder` | PyMatching (built-in) · **Relay-BP** |\n",
     "| **B. Custom decoder from a DEM** | Not sinter-compatible; you want full control | **Tesseract** (shown as custom) |\n",
-    "| **C. `ExternalDecoder` facade** | Not sinter-compatible; you want the easy path | ldpc BP (correction) \u00b7 Tesseract (observables) |\n",
+    "| **C. `ExternalDecoder` facade** | Not sinter-compatible; you want the easy path | ldpc BP (correction) · Tesseract (observables) |\n",
     "\n",
-    "> The code cells are **defensive**: if an optional decoder library isn't installed (or a decoder errors), the cell prints why and continues, so the notebook runs end-to-end in any environment. PyMatching is a hard dependency; **Relay-BP**, **ldpc**, and **Tesseract** are optional. (A prebuilt Tesseract wheel may not match every CPU; if `import tesseract_decoder` fails, build it from source.)\n"
+    "> The code cells are **defensive**: if an optional decoder library isn't installed (or a decoder errors), the cell prints why and continues, so the notebook runs end-to-end in any environment. PyMatching is a hard dependency; **Relay-BP**, **ldpc**, and **Tesseract** are optional. (A prebuilt Tesseract wheel may not match every CPU; if `import tesseract_decoder` fails, build it from source.)\n",
+    ">\n",
+    "> Relay-BP, ldpc BP, and Tesseract also ship as **built-ins** (`relay-bp`, `ldpc-bp`, `tesseract`) — LightStim registers them automatically when the library is installed. The demo registrations below therefore use separate names (`bp-demo`, `tesseract-demo`) so they don't shadow the built-ins.\n"
    ]
   },
   {
@@ -33,28 +35,35 @@
    "source": [
     "## The contract\n",
     "\n",
-    "Every decoder is a `sinter.Decoder` that implements `compile_decoder_for_dem(dem) -> sinter.CompiledDecoder`, and the compiled decoder implements `decode_shots_bit_packed(...)` \u2014 **bit-packed detector data in, bit-packed observable predictions out** (little-endian / LSB-first).\n",
+    "The pipeline is **duck-typed** — it never checks `isinstance(..., sinter.Decoder)`. A decoder is any object with `compile_decoder_for_dem(dem) -> compiled`, where the compiled decoder implements `decode_shots_bit_packed(...)` — **bit-packed detector data in, bit-packed observable predictions out** (little-endian / LSB-first). Subclassing `sinter.Decoder` is the repo convention, and matching that signature is why sinter-native decoders plug in unchanged (Pattern A). Pattern C skips the contract entirely — the facade implements it for you.\n",
     "\n",
     "LightStim adds three helpers around that:\n",
     "\n",
-    "- **`register_decoder(name, cls, aliases=[\u2026], backend=\"cpu\")`** \u2014 put a decoder class in the registry.\n",
-    "- **`list_decoders()`** \u2014 the registered (canonical) names.\n",
-    "- **`DecoderConfig` / `SimulationPipeline`** \u2014 the user-facing run API.\n",
+    "- **`register_decoder(name, cls, aliases=[…], backend=\"cpu\")`** — put a decoder class in the registry.\n",
+    "- **`list_decoders()`** — the registered (canonical) names.\n",
+    "- **`DecoderConfig` / `SimulationPipeline`** — the user-facing run API.\n",
     "\n",
     "Let's set up a demo experiment and a tiny benchmark helper we'll reuse for every pattern.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "25821ee5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:38:51.180906Z",
+     "iopub.status.busy": "2026-08-07T04:38:51.180770Z",
+     "iopub.status.idle": "2026-08-07T04:38:51.742699Z",
+     "shell.execute_reply": "2026-08-07T04:38:51.741580Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "decoders registered at import: ['bposd', 'mwpf', 'pymatching', 'relay-bp']\n"
+      "decoders registered at import: ['bposd', 'chain', 'ldpc-bp', 'mwpf', 'nv-qldpc-decoder', 'pymatching', 'relay-bp', 'tesseract']\n"
      ]
     }
    ],
@@ -142,9 +151,9 @@
    "id": "f015c20a",
    "metadata": {},
    "source": [
-    "## Pattern A \u2014 register a sinter-native decoder\n",
+    "## Pattern A — register a sinter-native decoder\n",
     "\n",
-    "**When:** the upstream library already implements `sinter.Decoder`. There is nothing to write \u2014 you just put the class in the registry under a LightStim name.\n",
+    "**When:** the upstream library already implements `sinter.Decoder`. There is nothing to write — you just put the class in the registry under a LightStim name.\n",
     "\n",
     "### A1. PyMatching (built-in)\n",
     "\n",
@@ -153,24 +162,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "387ed34c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:38:51.744281Z",
+     "iopub.status.busy": "2026-08-07T04:38:51.744067Z",
+     "iopub.status.idle": "2026-08-07T04:38:52.294588Z",
+     "shell.execute_reply": "2026-08-07T04:38:52.293720Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  pymatching     LER=2.500e-04  (50/200000 shots)\n"
+      "  pymatching     LER=2.300e-04  (46/200000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=50, seconds=0.5259534910146613, decoder='pymatching', json_metadata={})"
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=46, seconds=0.5423154851887375, decoder='pymatching', json_metadata={})"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,36 +200,49 @@
    "id": "478ee53f",
    "metadata": {},
    "source": [
-    "### A2. Relay-BP \u2014 the highlighted example\n",
+    "### A2. Relay-BP — the highlighted example\n",
     "\n",
-    "[Relay-BP](https://github.com/trmue/relay) ships sinter-compatible decoders via `relay_bp.stim`. `SinterDecoder_RelayBP` **is** a `sinter.Decoder` (it implements both `compile_decoder_for_dem` and `decode_via_files`), so we register the class **directly** \u2014 the purest Pattern A, exactly like the built-in `mwpf` decoder.\n",
+    "[Relay-BP](https://github.com/trmue/relay) ships sinter-compatible decoders via `relay_bp.stim`. `SinterDecoder_RelayBP` **is** a `sinter.Decoder` (it implements both `compile_decoder_for_dem` and `decode_via_files`), so we register the class **directly** — the purest Pattern A, exactly like the built-in `mwpf` decoder.\n",
     "\n",
     "`sinter_decoders(**kw)` returns `{\"relay-bp\": SinterDecoder_RelayBP(...), \"mem-bp\": ..., \"msl-bp\": ...}`; here we want the class itself so LightStim can construct it per-`DecoderConfig`.\n",
     "\n",
-    "> LightStim also ships this as a built-in module (`decoders/relay_bp.py`), so if `relay_bp` is installed it's *already* registered as `\"relay-bp\"`. The cell below shows the **user-side** path \u2014 registering it from your own code, no library edit needed.\n"
+    "> LightStim also ships this as a built-in module (`decoders/relay_bp.py`), so if `relay_bp` is installed it's *already* registered as `\"relay-bp\"`. The cell below shows the **user-side** path — registering it from your own code, no library edit needed.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "115e808a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:38:52.296265Z",
+     "iopub.status.busy": "2026-08-07T04:38:52.296101Z",
+     "iopub.status.idle": "2026-08-07T04:39:00.830003Z",
+     "shell.execute_reply": "2026-08-07T04:39:00.829037Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "registered 'relay-bp': True\n",
+      "registered 'relay-bp': True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  relay-bp       LER=1.450e-04  (29/200000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=29, seconds=9.036197791981976, decoder='relay-bp', json_metadata={})"
+       "SimulationStats(shots=200000, post_selected_shots=200000, errors=29, seconds=8.52741400199011, decoder='relay-bp', json_metadata={})"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,14 +282,14 @@
    "id": "ea47bd7a",
    "metadata": {},
    "source": [
-    "**Even simpler:** if the upstream library is *fully* sinter-native (class instantiable with no required args), registration is a one-liner with no example circuit needed \u2014 e.g. the built-in MWPF decoder is literally:\n",
+    "**Even simpler:** if the upstream library is *fully* sinter-native (class instantiable with no required args), registration is a one-liner with no example circuit needed — e.g. the built-in MWPF decoder is literally:\n",
     "\n",
     "```python\n",
     "from mwpf import SinterMWPFDecoder\n",
     "register_decoder(\"mwpf\", SinterMWPFDecoder)\n",
     "```\n",
     "\n",
-    "**Need different param names or defaults?** Give your wrapper a custom `__init__(**params)` that renames or defaults kwargs before constructing the inner decoder \u2014 registration is otherwise identical. That's all the built-in `bposd` wrapper does, to share one parameter vocabulary across its CPU and GPU BP+OSD backends. For a brand-new decoder you usually *don't* need this \u2014 just register it and let users pass its native params.\n"
+    "**Need different param names or defaults?** Give your wrapper a custom `__init__(**params)` that renames or defaults kwargs before constructing the inner decoder — registration is otherwise identical. That's all the built-in `bposd` wrapper does, to share one parameter vocabulary across its CPU and GPU BP+OSD backends. For a brand-new decoder you usually *don't* need this — just register it and let users pass its native params.\n"
    ]
   },
   {
@@ -268,9 +297,9 @@
    "id": "fd2e9ec5",
    "metadata": {},
    "source": [
-    "## Pattern B \u2014 custom decoder from a DEM (full control)\n",
+    "## Pattern B — custom decoder from a DEM (full control)\n",
     "\n",
-    "**When:** the upstream library is **not** sinter-compatible and you want to own the `sinter.CompiledDecoder` lifecycle yourself \u2014 build your decoder from the DEM (or its matrices) and write the unpack \u2192 decode \u2192 pack loop.\n",
+    "**When:** the upstream library is **not** sinter-compatible and you want to own the `sinter.CompiledDecoder` lifecycle yourself — build your decoder from the DEM (or its matrices, via `dem_to_matrices`) and write the unpack → decode → pack loop.\n",
     "\n",
     "We illustrate it with [**Tesseract**](https://github.com/quantumlib/tesseract-decoder), Google's beam-search most-likely-error decoder. It builds straight from a `stim.DetectorErrorModel` and returns **observable flips** directly (no correction-matrix multiply needed):\n",
     "\n",
@@ -280,34 +309,31 @@
     "flipped_observables = decoder.decode(syndrome)   # bool[n_dets] -> bool[n_obs]\n",
     "```\n",
     "\n",
-    "> **Note \u2014 Tesseract is actually sinter-native.** It ships `TesseractSinterDecoder` and `make_tesseract_sinter_decoders_dict`, so in real use you'd register it with **Pattern A** in one line (just like Relay-BP). We deliberately use its lower-level `compile_decoder()` / `decode()` API here *only to illustrate Pattern B* \u2014 wrapping a non-sinter decoder in your own `CompiledDecoder`.\n",
+    "> **Note — Tesseract is actually sinter-native**, and LightStim already ships it as the built-in `\"tesseract\"` (`decoders/tesseract.py`, a one-line Pattern A registration). We deliberately use its lower-level `compile_decoder()` / `decode()` API here *only to illustrate Pattern B*, registered under the demo name `\"tesseract-demo\"` so we don't shadow the built-in.\n",
     "\n",
     "The three parts: (1) build the decoder from the DEM, (2) a custom `CompiledDecoder` that unpacks the syndromes, loops `decode`, and packs the observable flips, (3) a top-level `sinter.Decoder`. Since Tesseract is hyperedge-aware, this runs on the surface-code DEM directly (no graphlike restriction).\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "52e8a8e5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:39:00.831627Z",
+     "iopub.status.busy": "2026-08-07T04:39:00.831471Z",
+     "iopub.status.idle": "2026-08-07T04:39:00.836938Z",
+     "shell.execute_reply": "2026-08-07T04:39:00.836185Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "registered 'tesseract': True\n",
-      "  tesseract      LER=6.000e-05  (12/200000 shots)\n"
+      "tesseract_decoder not installed - skipping\n",
+      "  tesseract-demo not registered (optional library missing) - skipped\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=12, seconds=45.589343569998164, decoder='tesseract', json_metadata={})"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -342,13 +368,13 @@
     "                config.compile_decoder(), dem.num_detectors, dem.num_observables\n",
     "            )\n",
     "\n",
-    "    register_decoder(\"tesseract\", TesseractDecoder)\n",
-    "    print(\"registered 'tesseract':\", \"tesseract\" in list_decoders())\n",
+    "    register_decoder(\"tesseract-demo\", TesseractDecoder)\n",
+    "    print(\"registered 'tesseract-demo':\", \"tesseract-demo\" in list_decoders())\n",
     "except ImportError:\n",
     "    print(\"tesseract_decoder not installed - skipping\")\n",
     "\n",
     "# Tesseract is a beam-search MLE decoder (slower per shot), so keep the shot count modest.\n",
-    "benchmark(\"tesseract\", params={\"det_beam\": 50})\n"
+    "benchmark(\"tesseract-demo\", params={\"det_beam\": 50})\n"
    ]
   },
   {
@@ -356,42 +382,59 @@
    "id": "7ceade56",
    "metadata": {},
    "source": [
-    "## Pattern C \u2014 the `ExternalDecoder` facade (recommended for non-sinter decoders)\n",
+    "## Pattern C — the `ExternalDecoder` facade (recommended for non-sinter decoders)\n",
     "\n",
     "**When:** same as Pattern B, but you'd rather *not* touch bit-packing, the sinter classes, or the worker plumbing.\n",
     "\n",
     "Subclass `ExternalDecoder`, declare `output_type`, build your decoder in `setup` (you receive the `dem` and its matrices `H`, `obs_matrix`, `priors`), and implement **one** of `decode_single` / `decode_batch` (LightStim bridges the other) on plain **unpacked** arrays.\n",
     "\n",
-    "`output_type` is the key knob \u2014 it declares *what your decode returns*:\n",
+    "Two things to know about what `setup` receives: `H` and `obs_matrix` are **scipy CSR** (the facade converts with `sparse=True` so large LDPC DEMs don't OOM), and error mechanisms with identical (detector, observable) footprints are already **merged** — so size any `\"correction\"` output from `H.shape[1]`, which can be smaller than `dem.num_errors`.\n",
     "\n",
-    "- **`\"correction\"`** \u2014 a correction over the *error mechanisms* (length `n_err`); LightStim multiplies it by the observable matrix to get the logical flips. Natural for BP / matching-style decoders.\n",
-    "- **`\"observables\"`** \u2014 the logical-observable flips directly (length `n_obs`); no matrix multiply. Natural for MLE / neural / lookup decoders.\n",
+    "`output_type` is the key knob — it declares *what your decode returns*:\n",
+    "\n",
+    "- **`\"correction\"`** — a correction over the *error mechanisms* (length `H.shape[1]`); LightStim multiplies it by the observable matrix to get the logical flips. Natural for BP / matching-style decoders.\n",
+    "- **`\"observables\"`** — the logical-observable flips directly (length `n_obs`); no matrix multiply. Natural for MLE / neural / lookup decoders.\n",
     "\n",
     "We show one of each.\n",
     "\n",
-    "### Example 1 \u2014 `output_type=\"correction\"`: plain BP from `ldpc`\n",
+    "### Example 1 — `output_type=\"correction\"`: plain BP from `ldpc`\n",
     "\n",
-    "[`ldpc`](https://github.com/quantumgizmos/ldpc)'s `BpDecoder` is a non-sinter belief-propagation decoder: build it from the check matrix `H` + priors, and `decode(syndrome)` returns a correction over error mechanisms. BP can **fail to converge** \u2014 we pass its `.converge` flag straight to LightStim (see *Failure flags* below). BP handles the surface code's hyperedges, so it runs on the demo DEM directly.\n"
+    "[`ldpc`](https://github.com/quantumgizmos/ldpc)'s `BpDecoder` is a non-sinter belief-propagation decoder: build it from the check matrix `H` + priors, and `decode(syndrome)` returns a correction over error mechanisms. BP can **fail to converge** — we pass its `.converge` flag straight to LightStim (see *Failure flags* below). BP handles the surface code's hyperedges, so it runs on the demo DEM directly.\n",
+    "\n",
+    "> LightStim ships a fuller version of exactly this class as the built-in `\"ldpc-bp\"` (`decoders/ldpc_bp.py`, with serial scheduling and dynamic min-sum defaults), so we register the demo under `\"bp-demo\"`.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "id": "ff0af6d1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:39:00.838291Z",
+     "iopub.status.busy": "2026-08-07T04:39:00.838163Z",
+     "iopub.status.idle": "2026-08-07T04:39:02.359910Z",
+     "shell.execute_reply": "2026-08-07T04:39:02.358946Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "registered 'ldpc-bp': True\n",
-      "  ldpc-bp        LER=3.155e-02  (631/20000 shots)\n"
+      "registered 'bp-demo': True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bp-demo        LER=3.295e-02  (659/20000 shots)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "SimulationStats(shots=20000, post_selected_shots=20000, errors=631, seconds=1.5319177219935227, decoder='ldpc-bp', json_metadata={})"
+       "SimulationStats(shots=20000, post_selected_shots=20000, errors=659, seconds=1.5132264429703355, decoder='bp-demo', json_metadata={})"
       ]
      },
      "execution_count": 5,
@@ -411,6 +454,7 @@
     "        output_type = \"correction\"\n",
     "\n",
     "        def setup(self, *, H, priors, **_):\n",
+    "            # H is scipy CSR; ldpc accepts it directly.\n",
     "            self._bp = BpDecoder(\n",
     "                H, error_channel=list(priors), max_iter=100, bp_method=\"min_sum\"\n",
     "            )\n",
@@ -420,14 +464,14 @@
     "            # BP may not converge - pass the convergence flag (False = failed).\n",
     "            return correction.astype(np.uint8), bool(self._bp.converge)\n",
     "\n",
-    "    register_decoder(\"ldpc-bp\", BpExternal)\n",
-    "    print(\"registered 'ldpc-bp':\", \"ldpc-bp\" in list_decoders())\n",
+    "    register_decoder(\"bp-demo\", BpExternal)\n",
+    "    print(\"registered 'bp-demo':\", \"bp-demo\" in list_decoders())\n",
     "except ImportError:\n",
     "    print(\"ldpc not installed - skipping\")\n",
     "\n",
     "# Plain BP (no OSD) is a weak surface-code decoder and often fails to converge;\n",
     "# with on_decode_failure=\"error\" (default) those shots count as logical errors.\n",
-    "benchmark(\"ldpc-bp\")\n"
+    "benchmark(\"bp-demo\")\n"
    ]
   },
   {
@@ -435,34 +479,31 @@
    "id": "d061cadf",
    "metadata": {},
    "source": [
-    "### Example 2 \u2014 `output_type=\"observables\"`: Tesseract\n",
+    "### Example 2 — `output_type=\"observables\"`: Tesseract\n",
     "\n",
-    "[Tesseract](https://github.com/quantumlib/tesseract-decoder) returns **observable flips** directly, so `output_type=\"observables\"` and there's no matrix multiply. It's the *same* decoder as Pattern B \u2014 but via the facade it's a few lines, no hand-written `CompiledDecoder`.\n"
+    "[Tesseract](https://github.com/quantumlib/tesseract-decoder) returns **observable flips** directly, so `output_type=\"observables\"` and there's no matrix multiply. It's the *same* decoder as Pattern B — but via the facade it's a few lines, no hand-written `CompiledDecoder`.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "5fa34ccf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:39:02.372534Z",
+     "iopub.status.busy": "2026-08-07T04:39:02.372267Z",
+     "iopub.status.idle": "2026-08-07T04:39:02.377786Z",
+     "shell.execute_reply": "2026-08-07T04:39:02.376908Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "registered 'tesseract-ext': True\n",
-      "  tesseract-ext  LER=6.000e-05  (12/200000 shots)\n"
+      "tesseract_decoder not installed - skipping\n",
+      "  tesseract-ext  not registered (optional library missing) - skipped\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "SimulationStats(shots=200000, post_selected_shots=200000, errors=12, seconds=45.58869765899726, decoder='tesseract-ext', json_metadata={})"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -496,38 +537,57 @@
    "source": [
     "### Failure flags (`on_decode_failure`)\n",
     "\n",
-    "The `ldpc-bp` decoder above returns a real per-shot `converge` flag (`False` = BP didn't converge). What LightStim does with a `False` is a `DecoderConfig` policy:\n",
+    "The `bp-demo` decoder above returns a real per-shot `converge` flag (`False` = BP didn't converge). What LightStim does with a `False` is a `DecoderConfig` policy:\n",
     "\n",
-    "- `\"error\"` *(default)* \u2014 count the shot as a logical error,\n",
-    "- `\"discard\"` \u2014 herald it: drop the shot from the denominator,\n",
-    "- `\"ignore\"` \u2014 trust the returned prediction anyway.\n",
+    "- `\"error\"` *(default)* — count the shot as a logical error,\n",
+    "- `\"discard\"` — herald it: drop the shot from the denominator,\n",
+    "- `\"ignore\"` — trust the returned prediction anyway.\n",
     "\n",
-    "(Return `None`/`True` to mean \"always succeeded\", as the Tesseract example does.) Here's the *same* `ldpc-bp` decoder under all three policies \u2014 note how `discard` reveals that BP, *when it converges*, is essentially error-free at this noise level:\n"
+    "(Return `None`/`True` to mean \"always succeeded\", as the Tesseract example does.) Here's the *same* `bp-demo` decoder under all three policies — note how `discard` reveals that BP, *when it converges*, is essentially error-free at this noise level:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "508f29b4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T04:39:02.379341Z",
+     "iopub.status.busy": "2026-08-07T04:39:02.379194Z",
+     "iopub.status.idle": "2026-08-07T04:39:13.618348Z",
+     "shell.execute_reply": "2026-08-07T04:39:13.616845Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  on_decode_failure=error    -> kept= 20000 errors=  667 LER=3.335e-02\n",
-      "  on_decode_failure=discard  -> kept= 19333 errors=    0 LER=0.000e+00\n",
+      "  on_decode_failure=error    -> kept= 20000 errors=  667 LER=3.335e-02\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  on_decode_failure=discard  -> kept= 19333 errors=    0 LER=0.000e+00\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  on_decode_failure=ignore   -> kept= 20000 errors=   57 LER=2.850e-03\n"
      ]
     }
    ],
    "source": [
-    "if \"ldpc-bp\" not in list_decoders():\n",
+    "if \"bp-demo\" not in list_decoders():\n",
     "    print(\"ldpc not installed - skipping failure-flag demo\")\n",
     "else:\n",
     "    for policy in (\"error\", \"discard\", \"ignore\"):\n",
     "        stats = SimulationPipeline(\n",
-    "            decoder_config=DecoderConfig(\"ldpc-bp\", on_decode_failure=policy),\n",
+    "            decoder_config=DecoderConfig(\"bp-demo\", on_decode_failure=policy),\n",
     "            max_shots=20_000, max_errors=10**9, batch_size=5_000,\n",
     "            num_workers=1, print_progress=False,\n",
     "        ).run(demo_circuit())\n",
@@ -544,13 +604,13 @@
    "source": [
     "## Making it permanent\n",
     "\n",
-    "The cells above register decoders *at runtime* from the notebook \u2014 perfect for experiments. To ship a decoder as a **built-in** (usable by name everywhere, including the server and benchmarks), add it to the library:\n",
+    "The cells above register decoders *at runtime* from the notebook — perfect for experiments. To ship a decoder as a **built-in** (usable by name everywhere, including the server and benchmarks), add it to the library:\n",
     "\n",
     "1. **One new file** in `lightstim/simulation/decoder_backend/decoders/`, ending with a `register_decoder(...)` call (wrap the upstream import in `try/except ImportError`).\n",
     "2. **One soft-import hook** in `decoders/__init__.py`, behind an `importlib.util.find_spec(\"your_lib\")` guard, so users without the library don't hit an `ImportError` at startup.\n",
     "3. **One smoke test** in `tests/test_simulation_backend_quality.py` (gate optional deps with `pytest.importorskip`).\n",
     "\n",
-    "The built-in Relay-BP integration (`decoders/relay_bp.py`) is exactly this \u2014 ~15 lines.\n",
+    "The built-in Relay-BP integration (`decoders/relay_bp.py`) is exactly this — ~15 lines.\n",
     "\n",
     "### Where things live\n",
     "\n",
@@ -558,16 +618,19 @@
     "|---|---|\n",
     "| `decoder_backend/registry.py` | `register_decoder()`, `get_decoder()`, `list_decoders()` |\n",
     "| `decoder_backend/decoders/__init__.py` | soft-import dispatcher |\n",
-    "| `decoder_backend/decoders/{pymatching,mwpf,relay_bp}.py` | Pattern A references |\n",
+    "| `decoder_backend/decoders/{pymatching,mwpf,relay_bp,tesseract}.py` | Pattern A references |\n",
     "| `decoder_backend/decoders/bposd.py` | sinter wrapper that renames params (see Pattern A note) |\n",
     "| `decoder_backend/decoders/cudaqx.py` | Pattern B reference (DEM matrix + GPU) |\n",
-    "| `decoder_backend/external.py` | Pattern C \u2014 `ExternalDecoder` facade |\n",
+    "| `decoder_backend/external.py` | Pattern C — `ExternalDecoder` facade |\n",
+    "| `decoder_backend/decoders/ldpc_bp.py` | Pattern C reference — the shipped version of `bp-demo` |\n",
+    "| `decoder_backend/decoders/chain.py` | multi-level chain over registered decoders (e.g. BP → relay-BP) |\n",
     "| `decoder_backend/dem_matrices.py` | shared `dem_to_matrices()` |\n",
     "| `decoder_backend/config.py` | `DecoderConfig` (incl. `on_decode_failure`) |\n",
     "\n",
     "### Gotchas\n",
     "\n",
     "- **Bit order is little-endian** (`bitorder=\"little\"`) for both syndromes in and predictions out. Pattern C handles this for you.\n",
+    "- **`H.shape[1]` is the mechanism count, not `dem.num_errors`** — `dem_to_matrices` merges identical-footprint columns by default.\n",
     "- **Failure flags** ride an in-process side channel and require LightStim's `SimulationPipeline`, not a raw `sinter.collect`.\n",
     "\n",
     "See `skills/extend-new-decoder/SKILL.md` for the full reference.\n"


### PR DESCRIPTION
## Summary

Rewrites the decoder-extension skill and tutorial around the current three integration patterns, and fixes the PyMatching circuit-level DEM path uncovered while validating the tutorial.

- **Rewrite `skills/extend-new-decoder/SKILL.md`** around:
  - Pattern A: direct or lazy registration of sinter-compatible decoders.
  - Pattern B: custom compiled decoders built from DEM matrices.
  - Pattern C: the `ExternalDecoder` facade for non-sinter libraries.
- **Update and re-execute `tutorials/how-to-add-new-decoders.ipynb`**:
  - Avoid shadowing built-in decoder registrations.
  - Document sparse/merged DEM-matrix behavior and failure flags.
  - Treat PyMatching as LightStim's built-in wrapper, not a direct Pattern A registration.
  - Explain that PyMatching uses Stim graphlike decomposition instead of consuming hyperedges natively.
- **Restore correct PyMatching DEM preparation**:
  - Set `PyMatchingDecoder.decompose_errors = True`.
  - The pipeline now asks Stim to decompose supported circuit-level hyperedges before building the matching graph.
  - Add a regression test using a surface-code DEM that contains 4-detector raw hyperedges and verifies the decoder path produces graphlike components.
- Align the remaining Pattern D docstrings with the unified Pattern C name.

## Test plan

- [x] GitHub CI passed on the final head.
- [x] `tests/test_simulation_backend_quality.py` - 31 passed, 2 skipped locally.
- [x] `tests/test_pipeline.py` - passed locally.
- [x] Tutorial notebook re-executed end-to-end with no cell errors.
- [x] `git diff --check` and Python compilation passed.
