### PR TITLE
Integrate hypergraph-product codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ print(f"LER: {stats.logical_error_rate:.3e} ± {stats.ler_error_bar():.3e}")
 | Unrotated surface | `UnrotatedSurfaceCode` | Lattice surgery coupler available |
 | Toric | `ToricCode` | Periodic boundary conditions |
 | Color (6-6-6) | `ColorCode` | Fold-transversal H/S gates |
+| Hypergraph product | `HGPCode` | Binary seed matrices; product-coloration SE |
 | Bivariate bicycle | `BBCode` | [[144,12,12]] gross code etc. |
 | PQRM | `PQRMPatch` | Transversal T gate; CrossLS protocol |
 | Repetition | `RepetitionCode` | Classical benchmark |

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -32,6 +32,9 @@ venv/bin/python benchmarks/memory/plot_memory.py \
 | BB [[108,8,10]] | `bb_108_8_10` | no (d=10 fixed) |
 | BB [[144,12,12]] | `bb_144_12_12` | no (d=12 fixed) |
 | BB [[288,12,18]] | `bb_288_12_18` | no (d=18 fixed) |
+| HGP / unrotated SC [[13,1,3]] | `hgp_13_1_3` | no (d=3 fixed) |
+| HGP / toric [[18,2,3]] | `hgp_18_2_3` | no (d=3 fixed) |
+| HGP [[225,9,4]] | `hgp_225_9_4` | no (d=4 fixed) |
 
 > **Not yet supported**: 4D geometric codes (`FourDGeoCode`) use an L-matrix parameter
 > interface incompatible with the `--distances` flag. See `notebooks/Memory/memory_4D_hadamard.ipynb`
@@ -44,7 +47,7 @@ venv/bin/python benchmarks/memory/plot_memory.py \
 | `pymatching` (default) | CPU | Surface / toric codes |
 | `mwpf` | CPU | General QLDPC |
 | `cpu_bposd` | CPU | QLDPC codes, no GPU |
-| `gpu_bposd` | GPU (CUDA) | BB codes at scale |
+| `gpu_bposd` | GPU (CUDA) | BB/HGP codes at scale |
 
 ## Color Code SE Circuits
 
@@ -104,6 +107,31 @@ venv/bin/python benchmarks/memory/run_memory.py \
     --p-values 1e-3 2e-3 5e-3 1e-2 \
     --decoder gpu_bposd
 ```
+
+### HGP product-coloration memory (GPU)
+
+```bash
+venv/bin/python benchmarks/memory/run_memory.py \
+    --codes hgp_13_1_3 hgp_18_2_3 hgp_225_9_4 \
+    --p-values 1e-3 2e-3 3e-3 \
+    --basis Z X \
+    --decoder gpu_bposd
+```
+
+With `--rounds` omitted, the three instances use their declared distances
+`3`, `3`, and `4`. The first two are structural reference anchors: their HGP
+patches are exactly the distance-3 unrotated surface code and, up to a
+coordinate transpose, the distance-3 toric code. The third is the qLDPC
+memory benchmark instance.
+
+The bundled `[[225,9,4]]` seed is a fixed, independently generated
+`(3,4)`-biregular instance with the same parameters as the smallest code in
+arXiv:2308.08648. It is not the authors' unpublished random matrix. Result
+rows identify its SE circuit explicitly as `product_coloration`.
+
+The benchmark CLI intentionally selects complete, reproducible instances by
+name instead of parsing parity-check matrices inline. For an arbitrary pair
+`H1, H2`, construct `HGPCode(H1, H2, d=...)` programmatically.
 
 ### Both Z and X basis
 ```bash

--- a/benchmarks/memory/run_memory.py
+++ b/benchmarks/memory/run_memory.py
@@ -10,13 +10,15 @@ Topological (require --distances):
     rotated_sc, unrotated_sc, toric, color, xzzx_sc
 BB codes (distance fixed by code, --distances ignored):
     bb_72_12_6, bb_108_8_10, bb_144_12_12, bb_288_12_18
+HGP codes (distance fixed by code, --distances ignored):
+    hgp_13_1_3, hgp_18_2_3, hgp_225_9_4
 
 Decoders
 --------
     pymatching   CPU MWPM        (default for surface codes)
     mwpf         CPU MWPF        (general purpose)
     cpu_bposd    CPU BP+OSD      (good for QLDPC codes, requires stimbposd)
-    gpu_bposd    GPU BP+OSD      (recommended for BB codes, requires CUDA)
+    gpu_bposd    GPU BP+OSD      (recommended for BB/HGP codes, requires CUDA)
 
 CSV output schema (keys / data)
 ---------------------------------
@@ -37,6 +39,13 @@ Usage
     venv/bin/python benchmarks/memory/run_memory.py \\
         --codes bb_72_12_6 bb_144_12_12 \\
         --p-values 1e-3 3e-3 1e-2 \\
+        --decoder gpu_bposd
+
+    # HGP product-coloration memory on GPU:
+    venv/bin/python benchmarks/memory/run_memory.py \\
+        --codes hgp_13_1_3 hgp_18_2_3 hgp_225_9_4 \\
+        --p-values 1e-3 2e-3 3e-3 \\
+        --basis Z X \\
         --decoder gpu_bposd
 
     # Color code with MWPF, save to custom path:
@@ -65,6 +74,12 @@ from lightstim.ir.qec_system import QECSystem
 from lightstim.noise.config import NoiseConfig
 from lightstim.protocols.memory import MemoryExperiment
 from lightstim.qec_code.BB_code import BBCode, BBCodeExtractionBlock
+from lightstim.qec_code.HGP import (
+    HGPProductColorationExtractionBlock,
+    hgp_13_1_3,
+    hgp_18_2_3,
+    hgp_225_9_4,
+)
 from lightstim.qec_code.color_code import (
     ColorCode,
     ColorCodeBellFlaggingBlock,
@@ -95,9 +110,28 @@ _BB_CONFIGS = {
     "bb_288_12_18": {"l": 12, "m": 12, "A": [[3,0],[0,2],[0,7]], "B": [[0,3],[1,0],[2,0]], "d": 18},  # needs logical_presets entry
 }
 
+_HGP_CONFIGS = {
+    "hgp_13_1_3": {
+        "factory": hgp_13_1_3,
+        "d": 3,
+        "se_circuit": "product_coloration",
+    },
+    "hgp_18_2_3": {
+        "factory": hgp_18_2_3,
+        "d": 3,
+        "se_circuit": "product_coloration",
+    },
+    "hgp_225_9_4": {
+        "factory": hgp_225_9_4,
+        "d": 4,
+        "se_circuit": "product_coloration",
+    },
+}
+
 _TOPO_CODES = {"rotated_sc", "unrotated_sc", "toric", "color", "xzzx_sc"}
 _BB_CODES   = set(_BB_CONFIGS)
-ALL_CODES   = sorted(_TOPO_CODES | _BB_CODES)
+_HGP_CODES  = set(_HGP_CONFIGS)
+ALL_CODES   = sorted(_TOPO_CODES | _BB_CODES | _HGP_CODES)
 
 DEFAULT_COLOR_SE_CIRCUIT = "space_multiplexing"
 
@@ -160,6 +194,17 @@ def _make_code(code_name: str, distance: int, se_circuit: str | None = None):
     if code_name in _BB_CONFIGS:
         cfg = _BB_CONFIGS[code_name]
         return BBCode(l=cfg["l"], m=cfg["m"], A=cfg["A"], B=cfg["B"]), BBCodeExtractionBlock
+    if code_name in _HGP_CONFIGS:
+        cfg = _HGP_CONFIGS[code_name]
+        selected_se_circuit = (
+            cfg["se_circuit"] if se_circuit in (None, "default") else se_circuit
+        )
+        if selected_se_circuit != cfg["se_circuit"]:
+            raise ValueError(
+                f"Unknown HGP SE circuit: {selected_se_circuit!r}. "
+                f"Available for {code_name}: {cfg['se_circuit']}"
+            )
+        return cfg["factory"](), HGPProductColorationExtractionBlock
     raise ValueError(f"Unknown code: {code_name!r}. Available: {ALL_CODES}")
 
 
@@ -331,6 +376,9 @@ def run(tasks: list[dict], decoder_cfg: DecoderConfig,
             color_spec = _color_se_spec(task["se_circuit"])
             layout = color_spec.layout
             block_class = color_spec.block_class.__name__
+        elif task["code"] in _HGP_CODES:
+            layout = "canonical_interleaved_product"
+            block_class = HGPProductColorationExtractionBlock.__name__
         else:
             layout = "code_default"
             block_class = "code_default"
@@ -368,7 +416,7 @@ def main():
                     help=f"QEC code(s) to benchmark. Built-in: {', '.join(ALL_CODES)}")
     ap.add_argument("--distances", nargs="+", type=int, default=None,
                     help="Distances to sweep (required for topological codes; "
-                         "BB codes use their built-in distance)")
+                         "BB/HGP codes use their built-in distance)")
     ap.add_argument("--p-values", nargs="+", type=float,
                     default=np.logspace(-3, -1.5, 6).tolist(),
                     help="Physical error rate values (default: 6 log-spaced points)")
@@ -443,11 +491,16 @@ def main():
     for code in args.codes:
         if code in _BB_CONFIGS:
             distances = [_BB_CONFIGS[code]["d"]]
+        elif code in _HGP_CONFIGS:
+            distances = [_HGP_CONFIGS[code]["d"]]
         else:
             distances = args.distances
-        se_circuits = (
-            args.color_se_circuits if code == "color" else ["default"]
-        )
+        if code == "color":
+            se_circuits = args.color_se_circuits
+        elif code in _HGP_CONFIGS:
+            se_circuits = [_HGP_CONFIGS[code]["se_circuit"]]
+        else:
+            se_circuits = ["default"]
         for d in distances:
             r = args.rounds if args.rounds is not None else d
             for se_circuit in se_circuits:

--- a/lightstim/qec_code/HGP/SE_block.py
+++ b/lightstim/qec_code/HGP/SE_block.py
@@ -1,0 +1,257 @@
+"""Product-coloration syndrome extraction for hypergraph-product codes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import stim
+
+from lightstim.qec_code.generic_css import color_bipartite_edges
+
+from .code_patch import HGPCode
+
+
+Basis = Literal["X", "Z"]
+Direction = Literal["horizontal", "vertical"]
+SeedEdge = tuple[int, int]
+QubitPair = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class HGPProductColorLayer:
+    """One product-color layer and its stable semantic label."""
+
+    basis: Basis
+    direction: Direction
+    color: int
+    seed: Literal["H1", "H2"]
+    seed_edges: tuple[SeedEdge, ...]
+    cnot_pairs: tuple[QubitPair, ...]
+
+    @property
+    def label(self) -> str:
+        return f"HGP:{self.basis}:{self.direction}:color={self.color}"
+
+
+class HGPProductColorationExtractionBlock:
+    """Algorithm-2 product coloration, expressed with CNOT gates.
+
+    The first seed ``H1`` is vertical and the second seed ``H2`` is
+    horizontal, matching :class:`HGPCode`.  Each seed Tanner graph is colored
+    once and its colors are lifted across every independent product row or
+    column.  Consequently, labels such as ``X/horizontal/color=2`` are stable
+    properties of the seed code instead of incidental colors of the flattened
+    quantum Tanner graph.
+
+    X and Z checks are separate measurement blocks.  This is the CNOT
+    equivalent of Algorithm 2 in arXiv:2308.08648: X ancillas are prepared and
+    measured in the X basis, while Z ancillas use the Z basis.
+    """
+
+    def __init__(self, system: Any, patch_name: str | None = None):
+        self.system = system
+        self.patch_name, self.patch = self._find_patch(patch_name)
+        self.local_to_global = self.system.local_to_global_map[self.patch_name]
+
+        self.vertical_seed_colors = self._color_seed(self.patch.h1)
+        self.horizontal_seed_colors = self._color_seed(self.patch.h2)
+
+        self.x_layers = tuple(
+            self._lift_layers("X", "horizontal")
+            + self._lift_layers("X", "vertical")
+        )
+        self.z_layers = tuple(
+            self._lift_layers("Z", "horizontal")
+            + self._lift_layers("Z", "vertical")
+        )
+        self.layers = self.x_layers + self.z_layers
+        self.depth_x = len(self.x_layers)
+        self.depth_z = len(self.z_layers)
+        self.cnot_depth = len(self.layers)
+
+        self._validate_active_stabilizers()
+        self.measurement_blocks = self._build_measurement_blocks()
+        self.circuit = stim.Circuit()
+        for block in self.measurement_blocks:
+            self.circuit += block
+
+    def _find_patch(self, requested_name: str | None) -> tuple[str, HGPCode]:
+        active_patch_names = {
+            stabilizer.get("patch_name")
+            for stabilizer in self.system.active_stabilizers
+        }
+        candidates = [
+            (name, patch)
+            for name, (patch, _) in self.system.patches.items()
+            if isinstance(patch, HGPCode) and name in active_patch_names
+        ]
+        if requested_name is not None:
+            candidates = [item for item in candidates if item[0] == requested_name]
+        if len(candidates) != 1:
+            names = [name for name, _ in candidates]
+            qualifier = f" named {requested_name!r}" if requested_name is not None else ""
+            raise ValueError(
+                "HGP product coloration requires exactly one active HGP patch"
+                f"{qualifier}; found {names}."
+            )
+        return candidates[0]
+
+    @staticmethod
+    def _color_seed(seed: Any) -> tuple[tuple[SeedEdge, ...], ...]:
+        edges = [
+            (check, bit)
+            for check, row in enumerate(seed.row_supports)
+            for bit in row
+        ]
+        return tuple(tuple(color) for color in color_bipartite_edges(edges))
+
+    def _g(self, local_index: int) -> int:
+        return self.local_to_global[local_index]
+
+    def _lift_layers(
+        self,
+        basis: Basis,
+        direction: Direction,
+    ) -> list[HGPProductColorLayer]:
+        active_syndromes = (
+            set(self.system.active_syndrome_indices_x)
+            if basis == "X"
+            else set(self.system.active_syndrome_indices_z)
+        )
+        seed = "H2" if direction == "horizontal" else "H1"
+        colors = (
+            self.horizontal_seed_colors
+            if direction == "horizontal"
+            else self.vertical_seed_colors
+        )
+        result = []
+
+        for color_index, seed_edges in enumerate(colors):
+            pairs: list[QubitPair] = []
+            if basis == "X" and direction == "horizontal":
+                # H2[check_2, bit_2]: X(bit_1, check_2) -> VV(bit_1, bit_2)
+                for check_2, bit_2 in seed_edges:
+                    for bit_1 in range(self.patch.h1.num_bits):
+                        syndrome = self._g(self.patch.x_check_qubits[(bit_1, check_2)])
+                        if syndrome in active_syndromes:
+                            data = self._g(self.patch.vv_qubits[(bit_1, bit_2)])
+                            pairs.append((syndrome, data))
+            elif basis == "X" and direction == "vertical":
+                # H1[check_1, bit_1]: X(bit_1, check_2) -> CC(check_1, check_2)
+                for check_1, bit_1 in seed_edges:
+                    for check_2 in range(self.patch.h2.num_checks):
+                        syndrome = self._g(self.patch.x_check_qubits[(bit_1, check_2)])
+                        if syndrome in active_syndromes:
+                            data = self._g(self.patch.cc_qubits[(check_1, check_2)])
+                            pairs.append((syndrome, data))
+            elif basis == "Z" and direction == "horizontal":
+                # H2[check_2, bit_2]: CC(check_1, check_2) -> Z(check_1, bit_2)
+                for check_2, bit_2 in seed_edges:
+                    for check_1 in range(self.patch.h1.num_checks):
+                        syndrome = self._g(self.patch.z_check_qubits[(check_1, bit_2)])
+                        if syndrome in active_syndromes:
+                            data = self._g(self.patch.cc_qubits[(check_1, check_2)])
+                            pairs.append((data, syndrome))
+            else:
+                # H1[check_1, bit_1]: VV(bit_1, bit_2) -> Z(check_1, bit_2)
+                for check_1, bit_1 in seed_edges:
+                    for bit_2 in range(self.patch.h2.num_bits):
+                        syndrome = self._g(self.patch.z_check_qubits[(check_1, bit_2)])
+                        if syndrome in active_syndromes:
+                            data = self._g(self.patch.vv_qubits[(bit_1, bit_2)])
+                            pairs.append((data, syndrome))
+
+            pairs.sort()
+            flat_qubits = [qubit for pair in pairs for qubit in pair]
+            if len(flat_qubits) != len(set(flat_qubits)):
+                raise RuntimeError(
+                    f"Product color {basis}/{direction}/{color_index} is not conflict-free."
+                )
+            result.append(
+                HGPProductColorLayer(
+                    basis=basis,
+                    direction=direction,
+                    color=color_index,
+                    seed=seed,
+                    seed_edges=tuple(seed_edges),
+                    cnot_pairs=tuple(pairs),
+                )
+            )
+        return result
+
+    def _validate_active_stabilizers(self) -> None:
+        patch_x = {self._g(index) for index in self.patch.x_check_qubits.values()}
+        patch_z = {self._g(index) for index in self.patch.z_check_qubits.values()}
+        active_all = set(self.system.active_syndrome_indices)
+        unexpected = active_all - patch_x - patch_z
+        if unexpected:
+            raise ValueError(
+                "HGP product coloration cannot schedule active syndrome qubits "
+                f"outside patch {self.patch_name!r}: {sorted(unexpected)}."
+            )
+
+        for basis, layers, stabilizers in (
+            ("X", self.x_layers, self.system.active_stabilizers_x),
+            ("Z", self.z_layers, self.system.active_stabilizers_z),
+        ):
+            expected: dict[int, set[int]] = {}
+            for layer in layers:
+                for control, target in layer.cnot_pairs:
+                    syndrome, data = (
+                        (control, target) if basis == "X" else (target, control)
+                    )
+                    expected.setdefault(syndrome, set()).add(data)
+
+            actual: dict[int, set[int]] = {}
+            for stabilizer in stabilizers:
+                syndrome = stabilizer.get("syn_idx")
+                if syndrome in actual:
+                    raise ValueError(
+                        f"Multiple active {basis} stabilizers use syndrome qubit {syndrome}."
+                    )
+                actual[syndrome] = set(stabilizer.get("data_indices", ()))
+
+            if expected != actual:
+                raise ValueError(
+                    f"Active {basis} stabilizers do not match the unmodified HGP "
+                    "product structure; use the generic CSS extraction block for "
+                    "a deformed or coupled patch."
+                )
+
+    @staticmethod
+    def _append_layer(circuit: stim.Circuit, layer: HGPProductColorLayer) -> None:
+        targets = [qubit for pair in layer.cnot_pairs for qubit in pair]
+        if targets:
+            circuit.append("CNOT", targets, tag=layer.label)
+        circuit.append("TICK", tag=layer.label)
+
+    def _build_measurement_blocks(self) -> tuple[stim.Circuit, stim.Circuit]:
+        x_syndromes = sorted(self.system.active_syndrome_indices_x)
+        z_syndromes = sorted(self.system.active_syndrome_indices_z)
+
+        x_block = stim.Circuit()
+        x_block.append("RX", x_syndromes)
+        x_block.append("TICK", tag="SE_start")
+        for layer in self.x_layers:
+            self._append_layer(x_block, layer)
+        x_block.append("MX", x_syndromes)
+
+        z_block = stim.Circuit()
+        z_block.append("R", z_syndromes)
+        z_block.append("TICK", tag="HGP:Z:start")
+        for layer in self.z_layers:
+            self._append_layer(z_block, layer)
+        z_block.append("M", z_syndromes)
+
+        return x_block, z_block
+
+
+HGPCodeExtractionBlock = HGPProductColorationExtractionBlock
+
+
+__all__ = [
+    "HGPCodeExtractionBlock",
+    "HGPProductColorLayer",
+    "HGPProductColorationExtractionBlock",
+]

--- a/lightstim/qec_code/HGP/__init__.py
+++ b/lightstim/qec_code/HGP/__init__.py
@@ -1,0 +1,34 @@
+"""Hypergraph-product quantum error-correcting codes."""
+
+from .algebra import CanonicalKernelBasis, canonical_kernel_basis
+from .binary_parity_check import BinaryParityCheck
+from .code_patch import HGPCode
+from .instances import (
+    hgp_13_1_3,
+    hgp_13_1_3_seed,
+    hgp_18_2_3,
+    hgp_18_2_3_seed,
+    hgp_225_9_4,
+    hgp_225_9_4_seed,
+)
+from .SE_block import (
+    HGPCodeExtractionBlock,
+    HGPProductColorLayer,
+    HGPProductColorationExtractionBlock,
+)
+
+__all__ = [
+    "BinaryParityCheck",
+    "CanonicalKernelBasis",
+    "HGPCode",
+    "HGPCodeExtractionBlock",
+    "HGPProductColorLayer",
+    "HGPProductColorationExtractionBlock",
+    "canonical_kernel_basis",
+    "hgp_13_1_3",
+    "hgp_13_1_3_seed",
+    "hgp_18_2_3",
+    "hgp_18_2_3_seed",
+    "hgp_225_9_4",
+    "hgp_225_9_4_seed",
+]

--- a/lightstim/qec_code/HGP/algebra.py
+++ b/lightstim/qec_code/HGP/algebra.py
@@ -1,0 +1,90 @@
+"""GF(2) algebra used by hypergraph-product code patches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .binary_parity_check import BinaryParityCheck, as_binary_parity_check
+
+
+@dataclass(frozen=True)
+class CanonicalKernelBasis:
+    """Kernel basis paired with deterministic pivot unit vectors.
+
+    ``basis`` and ``unit_complement`` store vectors as rows.  For every pair
+    of rows ``i, j``, their binary inner product is ``delta(i, j)``.
+    """
+
+    basis: np.ndarray
+    pivots: tuple[int, ...]
+    unit_complement: np.ndarray
+    rank: int
+
+    @property
+    def nullity(self) -> int:
+        return self.basis.shape[0]
+
+
+def canonical_kernel_basis(matrix: Any) -> CanonicalKernelBasis:
+    """Find a strongly lower-triangular kernel basis over GF(2).
+
+    This is the column-elimination construction from Algorithm 1 of
+    Quintavalle, Webster, and Vasmer, Quantum 7, 1153 (2023).  The input is
+    copied: canonical analysis never changes the parity checks used to build
+    the physical HGP patch.
+    """
+    parity_check = as_binary_parity_check(matrix)
+    work = parity_check.to_dense(dtype=np.uint8)
+    num_bits = parity_check.num_bits
+
+    # Column operations are accumulated on the right:
+    #     original_matrix @ transform == work.
+    transform = np.eye(num_bits, dtype=np.uint8)
+    kernel_candidates = set(range(num_bits))
+
+    for column in range(num_bits):
+        nonzero_rows = np.flatnonzero(work[:, column])
+        if nonzero_rows.size == 0:
+            continue
+
+        pivot_row = int(nonzero_rows[0])
+        kernel_candidates.remove(column)
+        for later_column in range(column + 1, num_bits):
+            if work[pivot_row, later_column]:
+                work[:, later_column] ^= work[:, column]
+                transform[:, later_column] ^= transform[:, column]
+
+    pivots = tuple(sorted(kernel_candidates))
+    if pivots:
+        basis = transform[:, list(pivots)].T.copy()
+        unit_complement = np.eye(num_bits, dtype=np.uint8)[list(pivots)]
+    else:
+        basis = np.zeros((0, num_bits), dtype=np.uint8)
+        unit_complement = np.zeros((0, num_bits), dtype=np.uint8)
+
+    if np.any((parity_check.to_dense() @ basis.T) % 2):
+        raise RuntimeError("Internal error: canonical basis is not in the kernel.")
+    if not np.array_equal((unit_complement @ basis.T) % 2, np.eye(len(pivots), dtype=np.uint8)):
+        raise RuntimeError("Internal error: kernel basis and pivot vectors are not paired.")
+
+    return CanonicalKernelBasis(
+        basis=basis,
+        pivots=pivots,
+        unit_complement=unit_complement,
+        rank=num_bits - len(pivots),
+    )
+
+
+def transpose_parity_check(matrix: BinaryParityCheck) -> BinaryParityCheck:
+    """Transpose a normalized parity-check matrix without densifying it."""
+    return BinaryParityCheck.from_row_supports(
+        (matrix.num_bits, matrix.num_checks),
+        matrix.column_supports,
+        source_metadata={
+            "construction": "transpose",
+            "source": dict(matrix.source_metadata),
+        },
+    )

--- a/lightstim/qec_code/HGP/binary_parity_check.py
+++ b/lightstim/qec_code/HGP/binary_parity_check.py
@@ -1,0 +1,240 @@
+"""Normalized binary parity-check matrices for HGP seed codes.
+
+The canonical representation stores the support of each row.  Constructors
+adapt dense arrays, sparse matrices, and structured polynomial descriptions to
+that representation without making SciPy a required LightStim dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+
+def _toggle_support(indices: Iterable[int]) -> tuple[int, ...]:
+    """Return sorted GF(2) support, cancelling repeated indices."""
+    support: set[int] = set()
+    for raw_index in indices:
+        index = int(raw_index)
+        if index in support:
+            support.remove(index)
+        else:
+            support.add(index)
+    return tuple(sorted(support))
+
+
+@dataclass(frozen=True)
+class BinaryParityCheck:
+    """A binary parity-check matrix represented by its nonzero row supports."""
+
+    num_checks: int
+    num_bits: int
+    row_supports: tuple[tuple[int, ...], ...]
+    source_metadata: Mapping[str, Any] = field(default_factory=dict, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.num_checks < 0:
+            raise ValueError("num_checks must be non-negative.")
+        if self.num_bits < 0:
+            raise ValueError("num_bits must be non-negative.")
+        if len(self.row_supports) != self.num_checks:
+            raise ValueError(
+                f"Expected {self.num_checks} row supports, got {len(self.row_supports)}."
+            )
+
+        normalized_rows = []
+        for row_index, row in enumerate(self.row_supports):
+            normalized = tuple(int(index) for index in row)
+            if normalized != tuple(sorted(set(normalized))):
+                raise ValueError(
+                    f"Row {row_index} must contain unique, sorted bit indices."
+                )
+            if any(index < 0 or index >= self.num_bits for index in normalized):
+                raise ValueError(
+                    f"Row {row_index} contains an index outside [0, {self.num_bits})."
+                )
+            normalized_rows.append(normalized)
+
+        object.__setattr__(self, "row_supports", tuple(normalized_rows))
+        object.__setattr__(self, "source_metadata", dict(self.source_metadata))
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.num_checks, self.num_bits
+
+    @property
+    def column_supports(self) -> tuple[tuple[int, ...], ...]:
+        columns: list[list[int]] = [[] for _ in range(self.num_bits)]
+        for check_index, row in enumerate(self.row_supports):
+            for bit_index in row:
+                columns[bit_index].append(check_index)
+        return tuple(tuple(column) for column in columns)
+
+    @classmethod
+    def from_dense(
+        cls,
+        matrix: Any,
+        *,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> "BinaryParityCheck":
+        """Normalize a dense two-dimensional binary array."""
+        array = np.asarray(matrix)
+        if array.ndim != 2:
+            raise ValueError(f"Parity-check matrix must be two-dimensional, got {array.ndim}D.")
+        if not np.all((array == 0) | (array == 1)):
+            raise ValueError("Parity-check matrix entries must be binary (0 or 1).")
+
+        rows = tuple(tuple(np.flatnonzero(row).tolist()) for row in array)
+        metadata = {"construction": "dense"}
+        if source_metadata:
+            metadata.update(source_metadata)
+        return cls(array.shape[0], array.shape[1], rows, metadata)
+
+    @classmethod
+    def from_row_supports(
+        cls,
+        shape: tuple[int, int],
+        rows: Sequence[Iterable[int]],
+        *,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> "BinaryParityCheck":
+        """Build from the bit indices touched by each parity check."""
+        if len(shape) != 2:
+            raise ValueError("shape must be a (num_checks, num_bits) pair.")
+        num_checks, num_bits = (int(value) for value in shape)
+        normalized = tuple(_toggle_support(row) for row in rows)
+        metadata = {"construction": "row_supports"}
+        if source_metadata:
+            metadata.update(source_metadata)
+        return cls(num_checks, num_bits, normalized, metadata)
+
+    @classmethod
+    def from_scipy_sparse(
+        cls,
+        matrix: Any,
+        *,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> "BinaryParityCheck":
+        """Normalize a SciPy-like sparse matrix without importing SciPy.
+
+        The object must expose ``shape`` and ``tocoo``.  Integer entries are
+        interpreted over GF(2), so duplicate or even-valued contributions
+        cancel.
+        """
+        if not hasattr(matrix, "shape") or not hasattr(matrix, "tocoo"):
+            raise TypeError("Expected a SciPy-like sparse matrix with shape and tocoo().")
+        if len(matrix.shape) != 2:
+            raise ValueError("Parity-check matrix must be two-dimensional.")
+
+        coo = matrix.tocoo(copy=True)
+        row_entries: list[list[int]] = [[] for _ in range(int(matrix.shape[0]))]
+        for row, column, value in zip(coo.row, coo.col, coo.data):
+            if not np.isfinite(value) or int(value) != value:
+                raise ValueError("Sparse parity-check entries must be finite integers.")
+            if int(value) % 2:
+                row_entries[int(row)].append(int(column))
+
+        metadata = {"construction": "scipy_sparse"}
+        if source_metadata:
+            metadata.update(source_metadata)
+        return cls.from_row_supports(
+            (int(matrix.shape[0]), int(matrix.shape[1])),
+            row_entries,
+            source_metadata=metadata,
+        )
+
+    @classmethod
+    def from_cyclic_polynomial(
+        cls,
+        exponents: Iterable[int],
+        size: int,
+        *,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> "BinaryParityCheck":
+        """Build a circulant matrix from a polynomial modulo ``x**size - 1``.
+
+        Row ``i`` has ones at columns ``(i + exponent) % size``.  Repeated
+        monomials cancel over GF(2).
+        """
+        size = int(size)
+        if size <= 0:
+            raise ValueError("Cyclic polynomial size must be positive.")
+        normalized_exponents = _toggle_support(int(exp) % size for exp in exponents)
+        rows = [
+            _toggle_support((row + exponent) % size for exponent in normalized_exponents)
+            for row in range(size)
+        ]
+        metadata = {
+            "construction": "cyclic_polynomial",
+            "exponents": normalized_exponents,
+            "size": size,
+        }
+        if source_metadata:
+            metadata.update(source_metadata)
+        return cls.from_row_supports((size, size), rows, source_metadata=metadata)
+
+    @classmethod
+    def from_bivariate_polynomial(
+        cls,
+        monomials: Iterable[tuple[int, int]],
+        shape: tuple[int, int],
+        *,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> "BinaryParityCheck":
+        """Build a 2D circulant matrix over ``Z_l x Z_m``.
+
+        Coordinates are flattened as ``(i, j) -> i*m + j``.  A monomial
+        ``(a, b)`` maps row ``(i, j)`` to column ``(i+a, j+b)`` modulo
+        ``(l, m)``.
+        """
+        if len(shape) != 2:
+            raise ValueError("shape must be the cyclic dimensions (l, m).")
+        l, m = (int(value) for value in shape)
+        if l <= 0 or m <= 0:
+            raise ValueError("Bivariate cyclic dimensions must be positive.")
+
+        normalized_monomials: set[tuple[int, int]] = set()
+        for a, b in monomials:
+            monomial = (int(a) % l, int(b) % m)
+            if monomial in normalized_monomials:
+                normalized_monomials.remove(monomial)
+            else:
+                normalized_monomials.add(monomial)
+        ordered_monomials = tuple(sorted(normalized_monomials))
+
+        rows = []
+        for i in range(l):
+            for j in range(m):
+                rows.append(
+                    _toggle_support(
+                        ((i + a) % l) * m + (j + b) % m
+                        for a, b in ordered_monomials
+                    )
+                )
+
+        metadata = {
+            "construction": "bivariate_polynomial",
+            "monomials": ordered_monomials,
+            "cyclic_shape": (l, m),
+        }
+        if source_metadata:
+            metadata.update(source_metadata)
+        size = l * m
+        return cls.from_row_supports((size, size), rows, source_metadata=metadata)
+
+    def to_dense(self, *, dtype: Any = np.uint8) -> np.ndarray:
+        matrix = np.zeros(self.shape, dtype=dtype)
+        for row_index, support in enumerate(self.row_supports):
+            matrix[row_index, list(support)] = 1
+        return matrix
+
+
+def as_binary_parity_check(matrix: Any) -> BinaryParityCheck:
+    """Normalize supported public input forms to ``BinaryParityCheck``."""
+    if isinstance(matrix, BinaryParityCheck):
+        return matrix
+    if hasattr(matrix, "tocoo") and hasattr(matrix, "shape"):
+        return BinaryParityCheck.from_scipy_sparse(matrix)
+    return BinaryParityCheck.from_dense(matrix)

--- a/lightstim/qec_code/HGP/code_patch.py
+++ b/lightstim/qec_code/HGP/code_patch.py
@@ -1,0 +1,290 @@
+"""Hypergraph-product CSS code patch."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+from lightstim.ir.qec_patch import QECPatch
+
+from .algebra import CanonicalKernelBasis, canonical_kernel_basis, transpose_parity_check
+from .binary_parity_check import BinaryParityCheck, as_binary_parity_check
+
+
+ProductIndex = tuple[int, int]
+
+
+class HGPCode(QECPatch):
+    """Hypergraph-product code constructed from two binary parity checks.
+
+    The original seed matrices define the physical Tanner graph.  Separate
+    canonical kernel analyses define deterministic, paired logical operators;
+    row reduction is never applied to the physical stabilizer supports.
+
+    Qubit and check ordering
+    ------------------------
+    Data columns are ordered as ``V1 x V2`` followed by ``C1 x C2``.
+
+    Z checks are indexed by ``C1 x V2`` and have parity-check matrix
+    ``[H1 kron I_n2 | I_m1 kron H2.T]``.
+
+    X checks are indexed by ``V1 x C2`` and have parity-check matrix
+    ``[I_n1 kron H2 | H1.T kron I_m2]``.
+
+    The first seed is drawn on the vertical axis and the second on the
+    horizontal axis.  Bits occupy even coordinates and checks odd coordinates.
+    """
+
+    def __init__(self, H1: Any, H2: Any | None = None, **kwargs: Any):
+        super().__init__(H1=H1, H2=H2, **kwargs)
+
+    def _process_params(self) -> None:
+        self.h1 = as_binary_parity_check(self.params["H1"])
+        raw_h2 = self.params.get("H2")
+        self.h2 = self.h1 if raw_h2 is None else as_binary_parity_check(raw_h2)
+        self.shift = self.params.get("shift", (0, 0))
+        self.code_distance = self.params.get("d")
+
+        if not isinstance(self.shift, tuple) or len(self.shift) != 2:
+            raise ValueError("shift must be a two-number tuple.")
+        if self.h1.num_bits == 0 or self.h2.num_bits == 0:
+            raise ValueError("Each HGP seed must contain at least one bit column.")
+
+        # Semantic product indices remain stable even if display coordinates
+        # are shifted or transformed later.
+        self.vv_qubits: Dict[ProductIndex, int] = {}
+        self.cc_qubits: Dict[ProductIndex, int] = {}
+        self.x_check_qubits: Dict[ProductIndex, int] = {}
+        self.z_check_qubits: Dict[ProductIndex, int] = {}
+        self.logical_pairs: List[Dict[str, Any]] = []
+
+    @property
+    def num_data_qubits(self) -> int:
+        return self.h1.num_bits * self.h2.num_bits + self.h1.num_checks * self.h2.num_checks
+
+    @property
+    def data_index_order(self) -> tuple[int, ...]:
+        vv = [self.vv_qubits[key] for key in sorted(self.vv_qubits)]
+        cc = [self.cc_qubits[key] for key in sorted(self.cc_qubits)]
+        return tuple(vv + cc)
+
+    @property
+    def syndrome_coords_x(self) -> List[Tuple[float, float]]:
+        return [self.qubit_coords[index] for index in sorted(self.syndrome_indices_x)]
+
+    @property
+    def syndrome_coords_z(self) -> List[Tuple[float, float]]:
+        return [self.qubit_coords[index] for index in sorted(self.syndrome_indices_z)]
+
+    def build(self) -> None:
+        self.kernel_h1 = canonical_kernel_basis(self.h1)
+        self.kernel_h2 = canonical_kernel_basis(self.h2)
+        self.kernel_h1_transpose = canonical_kernel_basis(transpose_parity_check(self.h1))
+        self.kernel_h2_transpose = canonical_kernel_basis(transpose_parity_check(self.h2))
+
+        self._register_qubits()
+        self._build_stabilizers()
+        self._build_logical_operators()
+
+        if self.shift != (0, 0):
+            self.shift_coords(*self.shift)
+
+    def _register_qubits(self) -> None:
+        # Data sector V1 x V2: first seed is vertical, second horizontal.
+        for bit_1 in range(self.h1.num_bits):
+            for bit_2 in range(self.h2.num_bits):
+                coord = (2 * bit_2, 2 * bit_1)
+                self.vv_qubits[(bit_1, bit_2)] = self.add_qubit(*coord, role="data")
+
+        # Data sector C1 x C2.
+        for check_1 in range(self.h1.num_checks):
+            for check_2 in range(self.h2.num_checks):
+                coord = (2 * check_2 + 1, 2 * check_1 + 1)
+                self.cc_qubits[(check_1, check_2)] = self.add_qubit(*coord, role="data")
+
+        # X checks V1 x C2.
+        for bit_1 in range(self.h1.num_bits):
+            for check_2 in range(self.h2.num_checks):
+                coord = (2 * check_2 + 1, 2 * bit_1)
+                self.x_check_qubits[(bit_1, check_2)] = self.add_qubit(
+                    *coord, role="syndrome_x"
+                )
+
+        # Z checks C1 x V2.
+        for check_1 in range(self.h1.num_checks):
+            for bit_2 in range(self.h2.num_bits):
+                coord = (2 * bit_2, 2 * check_1 + 1)
+                self.z_check_qubits[(check_1, bit_2)] = self.add_qubit(
+                    *coord, role="syndrome_z"
+                )
+
+    def _build_stabilizers(self) -> None:
+        h1_columns = self.h1.column_supports
+        h2_columns = self.h2.column_supports
+
+        # Hx = [I_n1 kron H2 | H1.T kron I_m2].
+        for bit_1 in range(self.h1.num_bits):
+            for check_2, h2_row in enumerate(self.h2.row_supports):
+                targets = {
+                    self.qubit_coords[self.vv_qubits[(bit_1, bit_2)]]: "X"
+                    for bit_2 in h2_row
+                }
+                targets.update(
+                    {
+                        self.qubit_coords[self.cc_qubits[(check_1, check_2)]]: "X"
+                        for check_1 in h1_columns[bit_1]
+                    }
+                )
+                syndrome = self.qubit_coords[self.x_check_qubits[(bit_1, check_2)]]
+                self.create_stim_stabilizer(targets, syndrome, "X")
+
+        # Hz = [H1 kron I_n2 | I_m1 kron H2.T].
+        for check_1, h1_row in enumerate(self.h1.row_supports):
+            for bit_2 in range(self.h2.num_bits):
+                targets = {
+                    self.qubit_coords[self.vv_qubits[(bit_1, bit_2)]]: "Z"
+                    for bit_1 in h1_row
+                }
+                targets.update(
+                    {
+                        self.qubit_coords[self.cc_qubits[(check_1, check_2)]]: "Z"
+                        for check_2 in h2_columns[bit_2]
+                    }
+                )
+                syndrome = self.qubit_coords[self.z_check_qubits[(check_1, bit_2)]]
+                self.create_stim_stabilizer(targets, syndrome, "Z")
+
+    def _register_logical_pair(
+        self,
+        *,
+        x_indices: set[int],
+        z_indices: set[int],
+        sector: str,
+        seed_indices: tuple[int, int],
+    ) -> None:
+        logical_id = len(self.logical_pairs)
+        overlap = x_indices & z_indices
+        if len(overlap) != 1:
+            raise RuntimeError(
+                f"Canonical logical pair {logical_id} must have one pivot, got {sorted(overlap)}."
+            )
+
+        x_targets = {self.qubit_coords[index]: "X" for index in sorted(x_indices)}
+        self.create_stim_logical(x_targets, "X")
+        x_record = self.logical_ops[-1]
+        x_record.update(
+            logical_id=logical_id,
+            sector=sector,
+            seed_indices=seed_indices,
+        )
+
+        z_targets = {self.qubit_coords[index]: "Z" for index in sorted(z_indices)}
+        self.create_stim_logical(z_targets, "Z")
+        z_record = self.logical_ops[-1]
+        z_record.update(
+            logical_id=logical_id,
+            sector=sector,
+            seed_indices=seed_indices,
+        )
+
+        self.logical_pairs.append(
+            {
+                "logical_id": logical_id,
+                "sector": sector,
+                "seed_indices": seed_indices,
+                "pivot_index": next(iter(overlap)),
+                "x": x_record,
+                "z": z_record,
+            }
+        )
+
+    @staticmethod
+    def _support(vector: np.ndarray) -> tuple[int, ...]:
+        return tuple(int(index) for index in np.flatnonzero(vector))
+
+    def _build_logical_operators(self) -> None:
+        k1 = self.kernel_h1
+        k2 = self.kernel_h2
+        k1t = self.kernel_h1_transpose
+        k2t = self.kernel_h2_transpose
+
+        # Logical pairs on V1 x V2:
+        #   X = kernel(H1) x pivot(H2)
+        #   Z = pivot(H1) x kernel(H2).
+        for logical_1, vector_1 in enumerate(k1.basis):
+            pivot_1 = k1.pivots[logical_1]
+            for logical_2, vector_2 in enumerate(k2.basis):
+                pivot_2 = k2.pivots[logical_2]
+                x_indices = {
+                    self.vv_qubits[(bit_1, pivot_2)]
+                    for bit_1 in self._support(vector_1)
+                }
+                z_indices = {
+                    self.vv_qubits[(pivot_1, bit_2)]
+                    for bit_2 in self._support(vector_2)
+                }
+                self._register_logical_pair(
+                    x_indices=x_indices,
+                    z_indices=z_indices,
+                    sector="bit_bit",
+                    seed_indices=(logical_1, logical_2),
+                )
+
+        # Logical pairs on C1 x C2:
+        #   X = pivot(H1.T) x kernel(H2.T)
+        #   Z = kernel(H1.T) x pivot(H2.T).
+        for logical_1, vector_1 in enumerate(k1t.basis):
+            pivot_1 = k1t.pivots[logical_1]
+            for logical_2, vector_2 in enumerate(k2t.basis):
+                pivot_2 = k2t.pivots[logical_2]
+                x_indices = {
+                    self.cc_qubits[(pivot_1, check_2)]
+                    for check_2 in self._support(vector_2)
+                }
+                z_indices = {
+                    self.cc_qubits[(check_1, pivot_2)]
+                    for check_1 in self._support(vector_1)
+                }
+                self._register_logical_pair(
+                    x_indices=x_indices,
+                    z_indices=z_indices,
+                    sector="check_check",
+                    seed_indices=(logical_1, logical_2),
+                )
+
+        self.num_logicals = len(self.logical_pairs)
+
+    def get_data_parity_check_matrices(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return dense ``(Hx, Hz)`` restricted to data-qubit columns."""
+        data_order = self.data_index_order
+        data_to_column = {index: column for column, index in enumerate(data_order)}
+        x_stabilizers = [stab for stab in self.stabilizers if stab["type"] == "X"]
+        z_stabilizers = [stab for stab in self.stabilizers if stab["type"] == "Z"]
+
+        def matrix_for(stabilizers: List[Dict[str, Any]]) -> np.ndarray:
+            matrix = np.zeros((len(stabilizers), len(data_order)), dtype=np.uint8)
+            for row, stabilizer in enumerate(stabilizers):
+                for data_index in stabilizer["data_indices"]:
+                    matrix[row, data_to_column[data_index]] = 1
+            return matrix
+
+        return matrix_for(x_stabilizers), matrix_for(z_stabilizers)
+
+    def get_info(self) -> Dict[str, Any]:
+        info = super().get_info()
+        info.update(
+            {
+                "h1_shape": self.h1.shape,
+                "h2_shape": self.h2.shape,
+                "rank_h1": self.kernel_h1.rank,
+                "rank_h2": self.kernel_h2.rank,
+                "num_data_qubits": self.num_data_qubits,
+                "num_x_syndromes": len(self.syndrome_indices_x),
+                "num_z_syndromes": len(self.syndrome_indices_z),
+                "num_logicals": self.num_logicals,
+                "code_distance": self.code_distance,
+                "logical_pairs": self.logical_pairs,
+            }
+        )
+        return info

--- a/lightstim/qec_code/HGP/instances.py
+++ b/lightstim/qec_code/HGP/instances.py
@@ -1,0 +1,96 @@
+"""Fixed, reproducible HGP instances used in examples and tests."""
+
+from __future__ import annotations
+
+from .binary_parity_check import BinaryParityCheck
+from .code_patch import HGPCode
+
+
+_HGP_13_1_3_ROWS = (
+    (0, 1),
+    (1, 2),
+)
+
+_HGP_225_9_4_ROWS = (
+    (1, 4, 5, 10),
+    (0, 5, 8, 9),
+    (3, 4, 7, 11),
+    (0, 4, 6, 11),
+    (3, 7, 8, 10),
+    (0, 1, 2, 3),
+    (1, 8, 9, 11),
+    (2, 6, 9, 10),
+    (2, 5, 6, 7),
+)
+
+
+def hgp_13_1_3_seed() -> BinaryParityCheck:
+    """Return the open-boundary length-3 repetition-code parity check."""
+    return BinaryParityCheck.from_row_supports(
+        (2, 3),
+        _HGP_13_1_3_ROWS,
+        source_metadata={
+            "code_family": "open_repetition",
+            "classical_parameters": (3, 1, 3),
+        },
+    )
+
+
+def hgp_13_1_3() -> HGPCode:
+    """Build the ``[[13, 1, 3]]`` unrotated-surface-code HGP patch."""
+    return HGPCode(hgp_13_1_3_seed(), d=3)
+
+
+def hgp_18_2_3_seed() -> BinaryParityCheck:
+    """Return the cyclic length-3 repetition-code parity check."""
+    return BinaryParityCheck.from_cyclic_polynomial(
+        (0, 1),
+        size=3,
+        source_metadata={
+            "code_family": "cyclic_repetition",
+            "classical_parameters": (3, 1, 3),
+        },
+    )
+
+
+def hgp_18_2_3() -> HGPCode:
+    """Build the ``[[18, 2, 3]]`` toric-code HGP patch."""
+    return HGPCode(hgp_18_2_3_seed(), d=3)
+
+
+def hgp_225_9_4_seed() -> BinaryParityCheck:
+    """Return a fixed ``[12, 3, 4]`` (3,4)-biregular classical seed.
+
+    Xu et al. construct their HGP family by rejection-sampling (3,4)-biregular
+    Tanner graphs but do not publish a canonical parity-check matrix for each
+    random instance.  This independently generated, fixed matrix matches the
+    degree profile and the smallest reported code parameters, making the
+    resulting self-product a reproducible ``[[225, 9, 4]]`` representative.
+    """
+    return BinaryParityCheck.from_row_supports(
+        (9, 12),
+        _HGP_225_9_4_ROWS,
+        source_metadata={
+            "construction": "fixed_biregular_instance",
+            "bit_degree": 3,
+            "check_degree": 4,
+            "classical_parameters": (12, 3, 4),
+            "reference": "https://arxiv.org/abs/2308.08648",
+            "relationship_to_reference": "independent_parameter_matching_instance",
+        },
+    )
+
+
+def hgp_225_9_4() -> HGPCode:
+    """Build the reproducible ``[[225, 9, 4]]`` self-product HGP patch."""
+    return HGPCode(hgp_225_9_4_seed(), d=4)
+
+
+__all__ = [
+    "hgp_13_1_3",
+    "hgp_13_1_3_seed",
+    "hgp_18_2_3",
+    "hgp_18_2_3_seed",
+    "hgp_225_9_4",
+    "hgp_225_9_4_seed",
+]

--- a/lightstim/qec_code/generic_css/SE_block.py
+++ b/lightstim/qec_code/generic_css/SE_block.py
@@ -5,10 +5,11 @@ stabilizer supports but do not yet have a code-specific syndrome-extraction
 schedule. X and Z checks are measured with independent bipartite edge colorings.
 """
 
-from collections import defaultdict, deque
-from typing import Any, DefaultDict, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import stim
+
+from .bipartite_edge_coloring import color_bipartite_edges
 
 
 EdgePayload = Tuple[int, int]
@@ -78,130 +79,4 @@ class GenericCSSColorationExtractionBlock:
             for data_idx in stab.get("data_indices", []):
                 edges.append((syn_idx, data_idx))
 
-        return _edge_color_bipartite(edges)
-
-
-def _edge_color_bipartite(edges: Sequence[EdgePayload]) -> List[List[EdgePayload]]:
-    """Optimal edge coloring for a bipartite graph using repeated matchings."""
-    if not edges:
-        return []
-
-    left_values = sorted({syn_idx for syn_idx, _ in edges})
-    right_values = sorted({data_idx for _, data_idx in edges})
-    left_index = {value: idx for idx, value in enumerate(left_values)}
-    right_index = {value: idx for idx, value in enumerate(right_values)}
-
-    n_left_real = len(left_values)
-    n_right_real = len(right_values)
-    degree_left = [0] * n_left_real
-    degree_right = [0] * n_right_real
-
-    buckets: DefaultDict[Tuple[int, int], List[Optional[EdgePayload]]] = defaultdict(list)
-    for edge in edges:
-        left = left_index[edge[0]]
-        right = right_index[edge[1]]
-        degree_left[left] += 1
-        degree_right[right] += 1
-        buckets[(left, right)].append(edge)
-
-    delta = max(max(degree_left, default=0), max(degree_right, default=0))
-    if delta == 0:
-        return []
-
-    n_vertices = max(n_left_real, n_right_real)
-    degree_left.extend([0] * (n_vertices - n_left_real))
-    degree_right.extend([0] * (n_vertices - n_right_real))
-
-    left_deficits: List[int] = []
-    right_deficits: List[int] = []
-    for left, degree in enumerate(degree_left):
-        left_deficits.extend([left] * (delta - degree))
-    for right, degree in enumerate(degree_right):
-        right_deficits.extend([right] * (delta - degree))
-
-    if len(left_deficits) != len(right_deficits):
-        raise RuntimeError("Internal edge-coloring error: unbalanced regularization deficits.")
-
-    for left, right in zip(left_deficits, right_deficits):
-        buckets[(left, right)].append(None)
-
-    layers: List[List[EdgePayload]] = []
-    for _ in range(delta):
-        adjacency = [[] for _ in range(n_vertices)]
-        for (left, right), payloads in buckets.items():
-            if payloads:
-                adjacency[left].append(right)
-        for neighbors in adjacency:
-            neighbors.sort()
-
-        matching = _hopcroft_karp_perfect(adjacency, n_vertices, n_vertices)
-        layer: List[EdgePayload] = []
-
-        for left, right in enumerate(matching):
-            payloads = buckets[(left, right)]
-            payload = payloads.pop()
-            if not payloads:
-                del buckets[(left, right)]
-            if payload is not None:
-                layer.append(payload)
-
-        layer.sort()
-        layers.append(layer)
-
-    if buckets:
-        raise RuntimeError("Internal edge-coloring error: uncolored edges remain.")
-
-    return layers
-
-
-def _hopcroft_karp_perfect(
-    adjacency: Sequence[Sequence[int]],
-    n_left: int,
-    n_right: int,
-) -> List[int]:
-    pair_left = [-1] * n_left
-    pair_right = [-1] * n_right
-    dist = [0] * n_left
-
-    def bfs() -> bool:
-        queue: deque[int] = deque()
-        found_free = False
-        for left in range(n_left):
-            if pair_left[left] == -1:
-                dist[left] = 0
-                queue.append(left)
-            else:
-                dist[left] = -1
-
-        while queue:
-            left = queue.popleft()
-            for right in adjacency[left]:
-                matched_left = pair_right[right]
-                if matched_left == -1:
-                    found_free = True
-                elif dist[matched_left] == -1:
-                    dist[matched_left] = dist[left] + 1
-                    queue.append(matched_left)
-        return found_free
-
-    def dfs(left: int) -> bool:
-        for right in adjacency[left]:
-            matched_left = pair_right[right]
-            if matched_left == -1 or (
-                dist[matched_left] == dist[left] + 1 and dfs(matched_left)
-            ):
-                pair_left[left] = right
-                pair_right[right] = left
-                return True
-        dist[left] = -1
-        return False
-
-    matching_size = 0
-    while bfs():
-        for left in range(n_left):
-            if pair_left[left] == -1 and dfs(left):
-                matching_size += 1
-
-    if matching_size != n_left:
-        raise RuntimeError("Internal edge-coloring error: regularized graph has no perfect matching.")
-    return pair_left
+        return color_bipartite_edges(edges)

--- a/lightstim/qec_code/generic_css/__init__.py
+++ b/lightstim/qec_code/generic_css/__init__.py
@@ -1,3 +1,7 @@
 from .SE_block import GenericCSSColorationExtractionBlock
+from .bipartite_edge_coloring import color_bipartite_edges
 
-__all__ = ["GenericCSSColorationExtractionBlock"]
+__all__ = [
+    "GenericCSSColorationExtractionBlock",
+    "color_bipartite_edges",
+]

--- a/lightstim/qec_code/generic_css/bipartite_edge_coloring.py
+++ b/lightstim/qec_code/generic_css/bipartite_edge_coloring.py
@@ -1,0 +1,155 @@
+"""Deterministic optimal edge coloring for bipartite Tanner graphs."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import DefaultDict, Hashable, Optional, Sequence, TypeVar
+
+
+LeftNode = TypeVar("LeftNode", bound=Hashable)
+RightNode = TypeVar("RightNode", bound=Hashable)
+Edge = tuple[LeftNode, RightNode]
+
+
+def color_bipartite_edges(edges: Sequence[Edge]) -> list[list[Edge]]:
+    """Partition bipartite edges into a minimum number of matchings.
+
+    The two entries of an edge live in separate vertex namespaces.  Returned
+    colors are deterministic for a fixed input order and their count equals the
+    maximum Tanner degree, by Konig's line-coloring theorem.
+
+    Args:
+        edges: ``(left_node, right_node)`` pairs. Parallel edges are allowed.
+
+    Returns:
+        A list of colors, each represented by a conflict-free list of edges.
+    """
+    if not edges:
+        return []
+
+    left_values = list(dict.fromkeys(left for left, _ in edges))
+    right_values = list(dict.fromkeys(right for _, right in edges))
+    left_index = {value: index for index, value in enumerate(left_values)}
+    right_index = {value: index for index, value in enumerate(right_values)}
+
+    n_left_real = len(left_values)
+    n_right_real = len(right_values)
+    degree_left = [0] * n_left_real
+    degree_right = [0] * n_right_real
+
+    buckets: DefaultDict[tuple[int, int], list[Optional[Edge]]] = defaultdict(list)
+    for edge in edges:
+        left = left_index[edge[0]]
+        right = right_index[edge[1]]
+        degree_left[left] += 1
+        degree_right[right] += 1
+        buckets[(left, right)].append(edge)
+
+    delta = max(max(degree_left, default=0), max(degree_right, default=0))
+    if delta == 0:
+        return []
+
+    # Regularize to a balanced Delta-regular bipartite multigraph. Repeated
+    # perfect matchings then give an optimal Delta-edge-coloring.
+    n_vertices = max(n_left_real, n_right_real)
+    degree_left.extend([0] * (n_vertices - n_left_real))
+    degree_right.extend([0] * (n_vertices - n_right_real))
+
+    left_deficits: list[int] = []
+    right_deficits: list[int] = []
+    for left, degree in enumerate(degree_left):
+        left_deficits.extend([left] * (delta - degree))
+    for right, degree in enumerate(degree_right):
+        right_deficits.extend([right] * (delta - degree))
+
+    if len(left_deficits) != len(right_deficits):
+        raise RuntimeError(
+            "Internal edge-coloring error: unbalanced regularization deficits."
+        )
+
+    for left, right in zip(left_deficits, right_deficits):
+        buckets[(left, right)].append(None)
+
+    colors: list[list[Edge]] = []
+    for _ in range(delta):
+        adjacency = [[] for _ in range(n_vertices)]
+        for (left, right), payloads in buckets.items():
+            if payloads:
+                adjacency[left].append(right)
+        for neighbors in adjacency:
+            neighbors.sort()
+
+        matching = _hopcroft_karp_perfect(adjacency, n_vertices, n_vertices)
+        color: list[Edge] = []
+        for left, right in enumerate(matching):
+            payloads = buckets[(left, right)]
+            payload = payloads.pop()
+            if not payloads:
+                del buckets[(left, right)]
+            if payload is not None:
+                color.append(payload)
+
+        color.sort(key=lambda edge: (left_index[edge[0]], right_index[edge[1]]))
+        colors.append(color)
+
+    if buckets:
+        raise RuntimeError("Internal edge-coloring error: uncolored edges remain.")
+    return colors
+
+
+def _hopcroft_karp_perfect(
+    adjacency: Sequence[Sequence[int]],
+    n_left: int,
+    n_right: int,
+) -> list[int]:
+    pair_left = [-1] * n_left
+    pair_right = [-1] * n_right
+    dist = [0] * n_left
+
+    def bfs() -> bool:
+        queue: deque[int] = deque()
+        found_free = False
+        for left in range(n_left):
+            if pair_left[left] == -1:
+                dist[left] = 0
+                queue.append(left)
+            else:
+                dist[left] = -1
+
+        while queue:
+            left = queue.popleft()
+            for right in adjacency[left]:
+                matched_left = pair_right[right]
+                if matched_left == -1:
+                    found_free = True
+                elif dist[matched_left] == -1:
+                    dist[matched_left] = dist[left] + 1
+                    queue.append(matched_left)
+        return found_free
+
+    def dfs(left: int) -> bool:
+        for right in adjacency[left]:
+            matched_left = pair_right[right]
+            if matched_left == -1 or (
+                dist[matched_left] == dist[left] + 1 and dfs(matched_left)
+            ):
+                pair_left[left] = right
+                pair_right[right] = left
+                return True
+        dist[left] = -1
+        return False
+
+    matching_size = 0
+    while bfs():
+        for left in range(n_left):
+            if pair_left[left] == -1 and dfs(left):
+                matching_size += 1
+
+    if matching_size != n_left:
+        raise RuntimeError(
+            "Internal edge-coloring error: regularized graph has no perfect matching."
+        )
+    return pair_left
+
+
+__all__ = ["color_bipartite_edges"]

--- a/notebooks/Memory/memory_HGP.ipynb
+++ b/notebooks/Memory/memory_HGP.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# Memory Experiment - Hypergraph Product Code\n",
+    "\n",
+    "Build and inspect three HGP instances through LightStim's public `MemoryExperiment` interface: `[[13,1,3]]` (unrotated surface), `[[18,2,3]]` (toric), and `[[225,9,4]]`. Batch sweeps use [`benchmarks/memory/run_memory.py`](../../benchmarks/memory/run_memory.py)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = next(\n",
+    "    path\n",
+    "    for path in (Path.cwd(), *Path.cwd().parents)\n",
+    "    if (path / \"lightstim\").is_dir() and (path / \"pyproject.toml\").exists()\n",
+    ")\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "\n",
+    "from lightstim.protocols import MemoryExperiment\n",
+    "from lightstim.qec_code.HGP import (\n",
+    "    HGPCodeExtractionBlock,\n",
+    "    hgp_13_1_3,\n",
+    "    hgp_18_2_3,\n",
+    "    hgp_225_9_4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "build-memory",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASIS = \"Z\"  # \"Z\" or \"X\"\n",
+    "SHOTS = 16\n",
+    "\n",
+    "\n",
+    "def build_memory(name, patch):\n",
+    "    experiment = MemoryExperiment(\n",
+    "        qec_patch=patch,\n",
+    "        patch_name=name,\n",
+    "        extraction_block_class=HGPCodeExtractionBlock,\n",
+    "        rounds=patch.code_distance,\n",
+    "        basis=BASIS,\n",
+    "        if_detector=True,\n",
+    "    )\n",
+    "    circuit = experiment.build().without_noise()\n",
+    "    sample = circuit.compile_detector_sampler().sample(\n",
+    "        SHOTS,\n",
+    "        append_observables=True,\n",
+    "    )\n",
+    "    assert not sample.any()\n",
+    "    print(\n",
+    "        f\"{name}: [[{patch.num_data_qubits}, {patch.num_logicals}, \"\n",
+    "        f\"{patch.code_distance}]], total_qubits={circuit.num_qubits}, \"\n",
+    "        f\"detectors={circuit.num_detectors}, observables={circuit.num_observables}\"\n",
+    "    )\n",
+    "    return circuit\n",
+    "\n",
+    "\n",
+    "patches = {\n",
+    "    \"hgp_13_1_3\": hgp_13_1_3(),\n",
+    "    \"hgp_18_2_3\": hgp_18_2_3(),\n",
+    "    \"hgp_225_9_4\": hgp_225_9_4(),\n",
+    "}\n",
+    "circuits = {\n",
+    "    name: build_memory(name, patch)\n",
+    "    for name, patch in patches.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "surface-heading",
+   "metadata": {},
+   "source": [
+    "## `[[13,1,3]]` - unrotated surface code\n",
+    "\n",
+    "One complete bulk syndrome-extraction round (ticks 11-21), shown with `detslice-with-ops-svg`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "surface-diagram",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuits[\"hgp_13_1_3\"].without_noise().diagram(\n",
+    "    \"detslice-with-ops-svg\", tick=range(11, 22)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "toric-heading",
+   "metadata": {},
+   "source": [
+    "## `[[18,2,3]]` - toric code\n",
+    "\n",
+    "One complete bulk syndrome-extraction round (ticks 11-21), shown with `detslice-with-ops-svg`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "toric-diagram",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuits[\"hgp_18_2_3\"].without_noise().diagram(\n",
+    "    \"detslice-with-ops-svg\", tick=range(11, 22)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qldpc-heading",
+   "metadata": {},
+   "source": [
+    "## `[[225,9,4]]` - qLDPC instance\n",
+    "\n",
+    "One complete bulk syndrome-extraction round (ticks 19-37), shown with `detslice-with-ops-svg`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qldpc-diagram",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuits[\"hgp_225_9_4\"].without_noise().diagram(\n",
+    "    \"detslice-with-ops-svg\", tick=range(19, 38)\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.10.12.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -57,6 +57,7 @@ They compare LER vs PER and show distance scaling for each code family.
 |---|---|
 | `memory_surface_family.ipynb` | Rotated SC, unrotated SC, toric code |
 | `memory_xzzx.ipynb` | Rotated XZZX surface code |
+| `memory_HGP.ipynb` | HGP codes ([[13,1,3]], [[18,2,3]], [[225,9,4]]) |
 | `memory_BB.ipynb` | Bivariate Bicycle codes ([[72,12,6]] … [[288,12,18]]) |
 | `memory_color.ipynb` | Triangular color code (6-6-6) |
 | `memory_PQRM.ipynb` | PQRM codes (1,2,4), (1,3,5), (1,4,6) |

--- a/tests/test_hgp_code.py
+++ b/tests/test_hgp_code.py
@@ -1,0 +1,398 @@
+"""Phase-1 tests for hypergraph-product code patches."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Callable
+
+import numpy as np
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.HGP import (
+    BinaryParityCheck,
+    HGPCode,
+    HGPProductColorationExtractionBlock,
+    canonical_kernel_basis,
+    hgp_13_1_3,
+    hgp_13_1_3_seed,
+    hgp_18_2_3,
+    hgp_18_2_3_seed,
+    hgp_225_9_4,
+    hgp_225_9_4_seed,
+)
+from lightstim.qec_code.generic_css import (
+    GenericCSSColorationExtractionBlock,
+    color_bipartite_edges,
+)
+from lightstim.qec_code.surface_code.toric import ToricCode
+from lightstim.qec_code.surface_code.unrotated import UnrotatedSurfaceCode
+from lightstim.utils.linear_algebra import row_echelon
+
+
+def _gf2_rank(matrix: np.ndarray) -> int:
+    return int(row_echelon(matrix.astype(np.uint8))[1])
+
+
+def _classical_distance(matrix: np.ndarray) -> int:
+    for weight in range(1, matrix.shape[1] + 1):
+        for support in combinations(range(matrix.shape[1]), weight):
+            if not np.any(np.bitwise_xor.reduce(matrix[:, support], axis=1)):
+                return weight
+    raise ValueError("The classical code has no nonzero codewords.")
+
+
+def _stabilizer_signatures(
+    patch,
+    transform: Callable[[tuple[float, float]], tuple[float, float]] = lambda coord: coord,
+) -> set[tuple[str, tuple[float, float], frozenset[tuple[float, float]]]]:
+    return {
+        (
+            stabilizer["type"],
+            transform(stabilizer["syn_coord"]),
+            frozenset(
+                transform(patch.qubit_coords[index])
+                for index in stabilizer["data_indices"]
+            ),
+        )
+        for stabilizer in patch.stabilizers
+    }
+
+
+def _logical_vectors(code: HGPCode) -> tuple[np.ndarray, np.ndarray]:
+    data_order = code.data_index_order
+    data_to_column = {index: column for column, index in enumerate(data_order)}
+    logical_x = np.zeros((code.num_logicals, len(data_order)), dtype=np.uint8)
+    logical_z = np.zeros_like(logical_x)
+
+    for pair in code.logical_pairs:
+        logical_id = pair["logical_id"]
+        for index in pair["x"]["data_indices"]:
+            logical_x[logical_id, data_to_column[index]] = 1
+        for index in pair["z"]["data_indices"]:
+            logical_z[logical_id, data_to_column[index]] = 1
+    return logical_x, logical_z
+
+
+def _assert_css_and_logical_invariants(code: HGPCode) -> None:
+    hx, hz = code.get_data_parity_check_matrices()
+    logical_x, logical_z = _logical_vectors(code)
+
+    assert not np.any((hx @ hz.T) % 2)
+    assert not np.any((hz @ logical_x.T) % 2)
+    assert not np.any((hx @ logical_z.T) % 2)
+    assert np.array_equal(
+        (logical_x @ logical_z.T) % 2,
+        np.eye(code.num_logicals, dtype=np.uint8),
+    )
+    assert code.num_logicals == code.num_data_qubits - _gf2_rank(hx) - _gf2_rank(hz)
+
+
+def test_binary_parity_check_constructors_share_one_representation():
+    open_repetition = hgp_13_1_3_seed().to_dense()
+    dense = BinaryParityCheck.from_dense(open_repetition)
+    supports = BinaryParityCheck.from_row_supports(
+        (2, 3),
+        [(0, 1), (1, 2)],
+    )
+    cycle = BinaryParityCheck.from_cyclic_polynomial([0, 1], size=3)
+
+    assert dense.shape == (2, 3)
+    assert dense.row_supports == supports.row_supports
+    assert np.array_equal(dense.to_dense(), open_repetition)
+    assert np.array_equal(
+        cycle.to_dense(),
+        np.array(
+            [
+                [1, 1, 0],
+                [0, 1, 1],
+                [1, 0, 1],
+            ],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_sparse_and_bivariate_parity_check_constructors():
+    class SparseLike:
+        shape = (2, 3)
+        row = np.array([0, 0, 1, 1])
+        col = np.array([0, 2, 1, 1])
+        data = np.array([1, 3, 1, 1])
+
+        def tocoo(self, *, copy):
+            assert copy
+            return self
+
+    sparse = BinaryParityCheck.from_scipy_sparse(SparseLike())
+    bivariate = BinaryParityCheck.from_bivariate_polynomial(
+        [(0, 0), (1, 0)],
+        shape=(2, 3),
+    )
+
+    assert sparse.row_supports == ((0, 2), ())
+    assert bivariate.shape == (6, 6)
+    assert bivariate.row_supports == (
+        (0, 3),
+        (1, 4),
+        (2, 5),
+        (0, 3),
+        (1, 4),
+        (2, 5),
+    )
+
+
+def test_canonical_kernel_basis_returns_paired_pivot_vectors():
+    canonical = canonical_kernel_basis(hgp_13_1_3_seed())
+
+    assert canonical.rank == 2
+    assert canonical.nullity == 1
+    assert canonical.pivots == (2,)
+    assert np.array_equal(canonical.basis, np.array([[1, 1, 1]], dtype=np.uint8))
+    assert np.array_equal(
+        (canonical.unit_complement @ canonical.basis.T) % 2,
+        np.eye(1, dtype=np.uint8),
+    )
+
+
+def test_repetition_product_is_the_13_1_3_unrotated_surface_patch():
+    seed = hgp_13_1_3_seed()
+    hgp = hgp_13_1_3()
+    surface = UnrotatedSurfaceCode(distance=3)
+
+    assert seed.shape == (2, 3)
+    assert seed.row_supports == ((0, 1), (1, 2))
+    assert seed.source_metadata["code_family"] == "open_repetition"
+    assert hgp.code_distance == 3
+    assert hgp.num_data_qubits == 13
+    assert hgp.num_qubits == 25
+    assert len(hgp.syndrome_indices_x) == 6
+    assert len(hgp.syndrome_indices_z) == 6
+    assert hgp.num_logicals == 1
+    assert [pair["sector"] for pair in hgp.logical_pairs] == ["bit_bit"]
+
+    assert set(hgp.data_coords) == set(surface.data_coords)
+    assert set(hgp.syndrome_coords_x) == set(surface.syndrome_coords_x)
+    assert set(hgp.syndrome_coords_z) == set(surface.syndrome_coords_z)
+    assert _stabilizer_signatures(hgp) == _stabilizer_signatures(surface)
+    assert {len(op["data_indices"]) for op in hgp.logical_ops} == {3}
+    _assert_css_and_logical_invariants(hgp)
+
+
+def test_cycle_product_is_the_18_2_3_toric_patch():
+    seed = hgp_18_2_3_seed()
+    hgp = hgp_18_2_3()
+    toric = ToricCode(distance=3)
+    transpose_coords = lambda coord: (coord[1], coord[0])
+
+    assert seed.shape == (3, 3)
+    assert seed.row_supports == ((0, 1), (1, 2), (0, 2))
+    assert seed.source_metadata["code_family"] == "cyclic_repetition"
+    assert hgp.code_distance == 3
+    assert hgp.num_data_qubits == 18
+    assert hgp.num_qubits == 36
+    assert len(hgp.syndrome_indices_x) == 9
+    assert len(hgp.syndrome_indices_z) == 9
+    assert hgp.num_logicals == 2
+    assert [pair["sector"] for pair in hgp.logical_pairs] == [
+        "bit_bit",
+        "check_check",
+    ]
+
+    # ToricCode uses the transposed checkerboard orientation compared with the
+    # unrotated patch.  After that coordinate relabeling, the Tanner graphs are
+    # exactly identical, including X/Z check types.
+    assert set(hgp.data_coords) == {transpose_coords(coord) for coord in toric.data_coords}
+    assert set(hgp.syndrome_coords_x) == {
+        transpose_coords(coord) for coord in toric.syndrome_coords_x
+    }
+    assert set(hgp.syndrome_coords_z) == {
+        transpose_coords(coord) for coord in toric.syndrome_coords_z
+    }
+    assert _stabilizer_signatures(hgp) == _stabilizer_signatures(toric, transpose_coords)
+    assert {len(op["data_indices"]) for op in hgp.logical_ops} == {3}
+    _assert_css_and_logical_invariants(hgp)
+
+
+def test_distinct_rectangular_rank_deficient_seeds_are_preserved():
+    h1 = np.array(
+        [
+            [1, 1, 0, 1],
+            [0, 1, 1, 0],
+            [1, 0, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+    h2 = np.array(
+        [
+            [1, 1, 1],
+            [1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+    original_h1 = h1.copy()
+    original_h2 = h2.copy()
+
+    code = HGPCode(h1, h2)
+
+    # Canonical kernel analysis is separate from the physical Tanner graph:
+    # neither caller-owned matrix nor the stored seed support is row-reduced.
+    assert np.array_equal(h1, original_h1)
+    assert np.array_equal(h2, original_h2)
+    assert np.array_equal(code.h1.to_dense(), original_h1)
+    assert np.array_equal(code.h2.to_dense(), original_h2)
+
+    assert code.h1.shape == (3, 4)
+    assert code.h2.shape == (2, 3)
+    assert code.kernel_h1.rank == 2
+    assert code.kernel_h2.rank == 1
+    assert code.num_data_qubits == 18
+    assert code.num_logicals == 5
+    assert [pair["sector"] for pair in code.logical_pairs].count("bit_bit") == 4
+    assert [pair["sector"] for pair in code.logical_pairs].count("check_check") == 1
+    _assert_css_and_logical_invariants(code)
+
+    system = QECSystem()
+    system.add_patch(code, name="asymmetric_hgp")
+    block = HGPProductColorationExtractionBlock(system)
+    assert block.depth_x == 6
+    assert block.depth_z == 6
+
+
+def test_fixed_3_4_biregular_seed_builds_225_9_4_hgp_instance():
+    seed = hgp_225_9_4_seed()
+    matrix = seed.to_dense()
+    code = hgp_225_9_4()
+
+    assert seed.shape == (9, 12)
+    assert set(matrix.sum(axis=0)) == {3}
+    assert set(matrix.sum(axis=1)) == {4}
+    assert _gf2_rank(matrix) == 9
+    assert _classical_distance(matrix) == 4
+
+    assert code.num_data_qubits == 225
+    assert code.num_qubits == 441
+    assert code.num_logicals == 9
+    assert len(code.syndrome_indices_x) == 108
+    assert len(code.syndrome_indices_z) == 108
+    _assert_css_and_logical_invariants(code)
+
+
+def test_public_bipartite_coloring_is_optimal_on_biregular_seed():
+    seed = hgp_225_9_4_seed()
+    edges = [
+        (check, bit)
+        for check, row in enumerate(seed.row_supports)
+        for bit in row
+    ]
+    colors = color_bipartite_edges(edges)
+
+    assert len(colors) == 4
+    assert sorted(edge for color in colors for edge in color) == sorted(edges)
+    for color in colors:
+        assert len({check for check, _ in color}) == len(color)
+        assert len({bit for _, bit in color}) == len(color)
+
+
+def test_public_bipartite_coloring_accepts_non_orderable_hashable_labels():
+    left_a = object()
+    left_b = object()
+    right_a = object()
+    right_b = object()
+    edges = [(left_a, right_b), (left_b, right_a), (left_a, right_a)]
+
+    colors = color_bipartite_edges(edges)
+
+    assert len(colors) == 2
+    assert {edge for color in colors for edge in color} == set(edges)
+
+
+def test_hgp_product_coloration_has_stable_four_phase_16_layer_schedule():
+    system = QECSystem()
+    system.add_patch(hgp_225_9_4(), name="hgp225")
+    block = HGPProductColorationExtractionBlock(system)
+
+    assert block.depth_x == 8
+    assert block.depth_z == 8
+    assert block.cnot_depth == 16
+    assert len(block.measurement_blocks) == 2
+    assert [(layer.basis, layer.direction, layer.color) for layer in block.layers] == [
+        *(('X', 'horizontal', color) for color in range(4)),
+        *(('X', 'vertical', color) for color in range(4)),
+        *(('Z', 'horizontal', color) for color in range(4)),
+        *(('Z', 'vertical', color) for color in range(4)),
+    ]
+
+    for layer in block.layers:
+        qubits = [qubit for pair in layer.cnot_pairs for qubit in pair]
+        assert len(qubits) == len(set(qubits))
+
+    assert sum(len(layer.cnot_pairs) for layer in block.x_layers) == 108 * 7
+    assert sum(len(layer.cnot_pairs) for layer in block.z_layers) == 108 * 7
+    assert block.measurement_blocks[0].num_measurements == 108
+    assert block.measurement_blocks[1].num_measurements == 108
+
+
+def test_product_coloration_ignores_registered_inactive_hgp_patches():
+    system = QECSystem()
+    system.add_patch(hgp_13_1_3(), name="active")
+    system.add_patch(
+        hgp_13_1_3(),
+        offset=(20, 0),
+        name="inactive",
+        is_active=False,
+    )
+
+    block = HGPProductColorationExtractionBlock(system)
+
+    assert block.patch_name == "active"
+    assert block.cnot_depth == 8
+
+
+def test_generic_css_coloration_remains_an_optional_hgp_fallback():
+    system = QECSystem()
+    system.add_patch(hgp_13_1_3(), name="surface_hgp")
+
+    generic = GenericCSSColorationExtractionBlock(system)
+    product = HGPProductColorationExtractionBlock(system)
+
+    assert generic.cnot_depth == 8
+    assert product.cnot_depth == 8
+    generic_edges = {
+        ("X", edge)
+        for layer in generic.x_layers
+        for edge in layer
+    } | {
+        ("Z", (data, syndrome))
+        for layer in generic.z_layers
+        for syndrome, data in layer
+    }
+    product_edges = {
+        (layer.basis, pair)
+        for layer in product.layers
+        for pair in layer.cnot_pairs
+    }
+    assert generic_edges == product_edges
+
+
+def test_hgp_225_product_coloration_memory_is_noiseless_in_both_bases():
+    for basis in ("X", "Z"):
+        code = hgp_225_9_4()
+        circuit = MemoryExperiment(
+            qec_patch=code,
+            patch_name="hgp225",
+            extraction_block_class=HGPProductColorationExtractionBlock,
+            rounds=code.code_distance,
+            noise_params=None,
+            basis=basis,
+        ).build()
+        detectors, observables = circuit.compile_detector_sampler(seed=42).sample(
+            shots=20,
+            separate_observables=True,
+        )
+
+        assert circuit.num_qubits == 441
+        assert circuit.num_detectors > 0
+        assert circuit.num_observables == 9
+        assert not np.any(detectors)
+        assert not np.any(observables)

--- a/tests/test_run_memory.py
+++ b/tests/test_run_memory.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(REPO / "benchmarks" / "memory"))
 from run_memory import (
     COLOR_SE_CIRCUITS,
     _BB_CONFIGS,
+    _HGP_CONFIGS,
     _TOPO_CODES,
     _decoder_config,
     _task_key,
@@ -91,6 +92,51 @@ def test_build_circuit_bb(code):
     circuit, n_data, n_total, k = build_circuit(code, d, p=1e-2)
     assert circuit.num_qubits > 0
     assert k > 1  # BB codes are high-rate
+
+
+@pytest.mark.parametrize(
+    "code_name,expected_n_data,expected_n_total,expected_k",
+    [
+        ("hgp_13_1_3", 13, 25, 1),
+        ("hgp_18_2_3", 18, 36, 2),
+        ("hgp_225_9_4", 225, 441, 9),
+    ],
+)
+@pytest.mark.parametrize("basis", ["Z", "X"])
+def test_build_circuit_hgp(
+    code_name,
+    expected_n_data,
+    expected_n_total,
+    expected_k,
+    basis,
+):
+    cfg = _HGP_CONFIGS[code_name]
+    circuit, n_data, n_total, k = build_circuit(
+        code_name,
+        cfg["d"],
+        p=1e-2,
+        basis=basis,
+        se_circuit=cfg["se_circuit"],
+    )
+
+    assert n_data == expected_n_data
+    assert n_total == expected_n_total
+    assert k == expected_k
+    assert circuit.num_detectors > 0
+    assert circuit.num_observables == k
+    dem = circuit.detector_error_model()
+    assert dem.num_detectors == circuit.num_detectors
+    assert dem.num_observables == k
+
+
+def test_hgp_rejects_unknown_se_circuit():
+    with pytest.raises(ValueError, match="Unknown HGP SE circuit"):
+        build_circuit(
+            "hgp_225_9_4",
+            4,
+            p=1e-2,
+            se_circuit="not_a_schedule",
+        )
 
 
 def test_build_circuit_xzzx_gets_checkerboard_basis():


### PR DESCRIPTION
## Summary

- add a general hypergraph-product code patch built from two binary parity-check matrices
- keep the physical Tanner graph unchanged while deriving deterministic canonical logical operators from separate GF(2) kernel analysis
- add product-coloration syndrome extraction with separate X/Z measurement blocks
- expose the reusable bipartite edge-coloring primitive from generic CSS
- add reproducible `[[13,1,3]]`, `[[18,2,3]]`, and `[[225,9,4]]` instances
- integrate the three instances with the memory benchmark CLI
- add a minimal cleared-output Memory notebook using full-round `detslice-with-ops-svg` views

## Why

HGP syndrome extraction measures X and Z checks in separate sub-rounds. This integration exercises the measurement-block and Pauli-tracker semantics introduced with the color-code memory work, and establishes HGP as the binary-product baseline for future lifted-product and subsystem-code integrations.

The bundled `[[225,9,4]]` seed is a fixed, independently generated `(3,4)`-biregular instance matching the parameters reported in arXiv:2308.08648; it is not presented as the authors' unpublished random matrix.

## Validation

- HGP, tracker, scheduling, and non-CLI memory benchmark focused tests pass
- full non-slow test suite passes when excluding the API harness and CLI subprocess tests that require a worktree-local `venv/bin/python`
- all three HGP benchmark circuits build in X and Z basis and produce detector error models
- noiseless `[[225,9,4]]` memory passes in both bases with rounds equal to distance
- exact Tanner-graph regressions match the unrotated surface and toric reference patches
- notebook JSON is valid, outputs are cleared, and all three diagrams use one complete bulk-round `detslice-with-ops-svg`
- `git diff --check` passes
