### PR TITLE
Use product-block layout for HGP codes

### DIFF
--- a/lightstim/qec_code/HGP/SE_block.py
+++ b/lightstim/qec_code/HGP/SE_block.py
@@ -37,8 +37,8 @@ class HGPProductColorLayer:
 class HGPProductColorationExtractionBlock:
     """Algorithm-2 product coloration, expressed with CNOT gates.
 
-    The first seed ``H1`` is vertical and the second seed ``H2`` is
-    horizontal, matching :class:`HGPCode`.  Each seed Tanner graph is colored
+    The first seed ``H1`` is horizontal and the second seed ``H2`` is
+    vertical, matching :class:`HGPCode`.  Each seed Tanner graph is colored
     once and its colors are lifted across every independent product row or
     column.  Consequently, labels such as ``X/horizontal/color=2`` are stable
     properties of the seed code instead of incidental colors of the flattened
@@ -54,16 +54,18 @@ class HGPProductColorationExtractionBlock:
         self.patch_name, self.patch = self._find_patch(patch_name)
         self.local_to_global = self.system.local_to_global_map[self.patch_name]
 
-        self.vertical_seed_colors = self._color_seed(self.patch.h1)
-        self.horizontal_seed_colors = self._color_seed(self.patch.h2)
+        self.horizontal_seed_colors = self._color_seed(self.patch.h1)
+        self.vertical_seed_colors = self._color_seed(self.patch.h2)
 
+        # Preserve the established H2-then-H1 gate order while giving each
+        # layer the direction label of the product-block display.
         self.x_layers = tuple(
-            self._lift_layers("X", "horizontal")
-            + self._lift_layers("X", "vertical")
+            self._lift_layers("X", "vertical")
+            + self._lift_layers("X", "horizontal")
         )
         self.z_layers = tuple(
-            self._lift_layers("Z", "horizontal")
-            + self._lift_layers("Z", "vertical")
+            self._lift_layers("Z", "vertical")
+            + self._lift_layers("Z", "horizontal")
         )
         self.layers = self.x_layers + self.z_layers
         self.depth_x = len(self.x_layers)
@@ -119,7 +121,7 @@ class HGPProductColorationExtractionBlock:
             if basis == "X"
             else set(self.system.active_syndrome_indices_z)
         )
-        seed = "H2" if direction == "horizontal" else "H1"
+        seed = "H1" if direction == "horizontal" else "H2"
         colors = (
             self.horizontal_seed_colors
             if direction == "horizontal"
@@ -129,7 +131,7 @@ class HGPProductColorationExtractionBlock:
 
         for color_index, seed_edges in enumerate(colors):
             pairs: list[QubitPair] = []
-            if basis == "X" and direction == "horizontal":
+            if basis == "X" and direction == "vertical":
                 # H2[check_2, bit_2]: X(bit_1, check_2) -> VV(bit_1, bit_2)
                 for check_2, bit_2 in seed_edges:
                     for bit_1 in range(self.patch.h1.num_bits):
@@ -137,7 +139,7 @@ class HGPProductColorationExtractionBlock:
                         if syndrome in active_syndromes:
                             data = self._g(self.patch.vv_qubits[(bit_1, bit_2)])
                             pairs.append((syndrome, data))
-            elif basis == "X" and direction == "vertical":
+            elif basis == "X" and direction == "horizontal":
                 # H1[check_1, bit_1]: X(bit_1, check_2) -> CC(check_1, check_2)
                 for check_1, bit_1 in seed_edges:
                     for check_2 in range(self.patch.h2.num_checks):
@@ -145,7 +147,7 @@ class HGPProductColorationExtractionBlock:
                         if syndrome in active_syndromes:
                             data = self._g(self.patch.cc_qubits[(check_1, check_2)])
                             pairs.append((syndrome, data))
-            elif basis == "Z" and direction == "horizontal":
+            elif basis == "Z" and direction == "vertical":
                 # H2[check_2, bit_2]: CC(check_1, check_2) -> Z(check_1, bit_2)
                 for check_2, bit_2 in seed_edges:
                     for check_1 in range(self.patch.h1.num_checks):

--- a/lightstim/qec_code/HGP/code_patch.py
+++ b/lightstim/qec_code/HGP/code_patch.py
@@ -32,8 +32,11 @@ class HGPCode(QECPatch):
     X checks are indexed by ``V1 x C2`` and have parity-check matrix
     ``[I_n1 kron H2 | H1.T kron I_m2]``.
 
-    The first seed is drawn on the vertical axis and the second on the
-    horizontal axis.  Bits occupy even coordinates and checks odd coordinates.
+    The first seed is drawn on the horizontal axis and the second on the
+    vertical axis.  The four product sectors are displayed separately, with
+    ``V1 x V2`` data at upper left, Z checks at upper right, X checks at lower
+    left, and ``C1 x C2`` data at lower right.  One empty coordinate row and
+    column separate the sectors.
     """
 
     def __init__(self, H1: Any, H2: Any | None = None, **kwargs: Any):
@@ -91,30 +94,41 @@ class HGPCode(QECPatch):
             self.shift_coords(*self.shift)
 
     def _register_qubits(self) -> None:
-        # Data sector V1 x V2: first seed is vertical, second horizontal.
+        # H1 is the horizontal axis and H2 is the vertical axis.  Keep product
+        # sectors visually separate so the algebraic construction is explicit:
+        #
+        #       V1 x V2 data  |  C1 x V2 Z checks
+        #       --------------+------------------
+        #       V1 x C2 X     |  C1 x C2 data
+        #
+        # The +1 offsets leave one empty coordinate row and column as a gutter.
+        right_start = self.h1.num_bits + 1
+        lower_start = self.h2.num_bits + 1
+
+        # Data sector V1 x V2 (upper left).
         for bit_1 in range(self.h1.num_bits):
             for bit_2 in range(self.h2.num_bits):
-                coord = (2 * bit_2, 2 * bit_1)
+                coord = (bit_1, bit_2)
                 self.vv_qubits[(bit_1, bit_2)] = self.add_qubit(*coord, role="data")
 
-        # Data sector C1 x C2.
+        # Data sector C1 x C2 (lower right).
         for check_1 in range(self.h1.num_checks):
             for check_2 in range(self.h2.num_checks):
-                coord = (2 * check_2 + 1, 2 * check_1 + 1)
+                coord = (right_start + check_1, lower_start + check_2)
                 self.cc_qubits[(check_1, check_2)] = self.add_qubit(*coord, role="data")
 
-        # X checks V1 x C2.
+        # X checks V1 x C2 (lower left).
         for bit_1 in range(self.h1.num_bits):
             for check_2 in range(self.h2.num_checks):
-                coord = (2 * check_2 + 1, 2 * bit_1)
+                coord = (bit_1, lower_start + check_2)
                 self.x_check_qubits[(bit_1, check_2)] = self.add_qubit(
                     *coord, role="syndrome_x"
                 )
 
-        # Z checks C1 x V2.
+        # Z checks C1 x V2 (upper right).
         for check_1 in range(self.h1.num_checks):
             for bit_2 in range(self.h2.num_bits):
-                coord = (2 * bit_2, 2 * check_1 + 1)
+                coord = (right_start + check_1, bit_2)
                 self.z_check_qubits[(check_1, bit_2)] = self.add_qubit(
                     *coord, role="syndrome_z"
                 )

--- a/notebooks/Memory/memory_HGP.ipynb
+++ b/notebooks/Memory/memory_HGP.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Memory Experiment - Hypergraph Product Code\n",
     "\n",
-    "Build and inspect three HGP instances through LightStim's public `MemoryExperiment` interface: `[[13,1,3]]` (unrotated surface), `[[18,2,3]]` (toric), and `[[225,9,4]]`. Batch sweeps use [`benchmarks/memory/run_memory.py`](../../benchmarks/memory/run_memory.py)."
+    "Build and inspect three HGP instances through LightStim's public `MemoryExperiment` interface: `[[13,1,3]]` (unrotated surface), `[[18,2,3]]` (toric), and `[[225,9,4]]`. The default product-block coordinates place $V_1\\times V_2$ data at upper left, Z ancillas at upper right, X ancillas at lower left, and $C_1\\times C_2$ data at lower right. Batch sweeps use [`benchmarks/memory/run_memory.py`](../../benchmarks/memory/run_memory.py)."
    ]
   },
   {

--- a/tests/test_hgp_code.py
+++ b/tests/test_hgp_code.py
@@ -44,19 +44,171 @@ def _classical_distance(matrix: np.ndarray) -> int:
 
 def _stabilizer_signatures(
     patch,
+    coords_by_index: dict[int, tuple[float, float]] | None = None,
     transform: Callable[[tuple[float, float]], tuple[float, float]] = lambda coord: coord,
 ) -> set[tuple[str, tuple[float, float], frozenset[tuple[float, float]]]]:
+    coords = patch.qubit_coords if coords_by_index is None else coords_by_index
     return {
         (
             stabilizer["type"],
-            transform(stabilizer["syn_coord"]),
+            transform(coords[stabilizer["syn_idx"]]),
             frozenset(
-                transform(patch.qubit_coords[index])
+                transform(coords[index])
                 for index in stabilizer["data_indices"]
             ),
         )
         for stabilizer in patch.stabilizers
     }
+
+
+def _checkerboard_tanner_embedding(code: HGPCode) -> dict[int, tuple[float, float]]:
+    """Embed semantic product indices in the conventional surface-code grid."""
+    coords: dict[int, tuple[float, float]] = {}
+    coords.update(
+        {
+            index: (2 * bit_2, 2 * bit_1)
+            for (bit_1, bit_2), index in code.vv_qubits.items()
+        }
+    )
+    coords.update(
+        {
+            index: (2 * check_2 + 1, 2 * check_1 + 1)
+            for (check_1, check_2), index in code.cc_qubits.items()
+        }
+    )
+    coords.update(
+        {
+            index: (2 * check_2 + 1, 2 * bit_1)
+            for (bit_1, check_2), index in code.x_check_qubits.items()
+        }
+    )
+    coords.update(
+        {
+            index: (2 * bit_2, 2 * check_1 + 1)
+            for (check_1, bit_2), index in code.z_check_qubits.items()
+        }
+    )
+    return coords
+
+
+def _assert_hgp_parity_check_formula(code: HGPCode) -> None:
+    h1 = code.h1.to_dense()
+    h2 = code.h2.to_dense()
+    n1, n2 = code.h1.num_bits, code.h2.num_bits
+    m1, m2 = code.h1.num_checks, code.h2.num_checks
+    expected_hx = np.concatenate(
+        [np.kron(np.eye(n1, dtype=np.uint8), h2), np.kron(h1.T, np.eye(m2, dtype=np.uint8))],
+        axis=1,
+    )
+    expected_hz = np.concatenate(
+        [np.kron(h1, np.eye(n2, dtype=np.uint8)), np.kron(np.eye(m1, dtype=np.uint8), h2.T)],
+        axis=1,
+    )
+    hx, hz = code.get_data_parity_check_matrices()
+    assert np.array_equal(hx, expected_hx)
+    assert np.array_equal(hz, expected_hz)
+
+
+def _assert_product_block_layout(code: HGPCode) -> None:
+    """Check all four sectors, including the single-coordinate gutter."""
+    right_start = code.h1.num_bits + 1
+    lower_start = code.h2.num_bits + 1
+
+    assert {
+        key: code.qubit_coords[index] for key, index in code.vv_qubits.items()
+    } == {
+        (bit_1, bit_2): (bit_1, bit_2)
+        for bit_1 in range(code.h1.num_bits)
+        for bit_2 in range(code.h2.num_bits)
+    }
+    assert {
+        key: code.qubit_coords[index] for key, index in code.z_check_qubits.items()
+    } == {
+        (check_1, bit_2): (right_start + check_1, bit_2)
+        for check_1 in range(code.h1.num_checks)
+        for bit_2 in range(code.h2.num_bits)
+    }
+    assert {
+        key: code.qubit_coords[index] for key, index in code.x_check_qubits.items()
+    } == {
+        (bit_1, check_2): (bit_1, lower_start + check_2)
+        for bit_1 in range(code.h1.num_bits)
+        for check_2 in range(code.h2.num_checks)
+    }
+    assert {
+        key: code.qubit_coords[index] for key, index in code.cc_qubits.items()
+    } == {
+        (check_1, check_2): (right_start + check_1, lower_start + check_2)
+        for check_1 in range(code.h1.num_checks)
+        for check_2 in range(code.h2.num_checks)
+    }
+
+    all_coords = list(code.qubit_coords.values())
+    assert len(all_coords) == len(set(all_coords)) == code.num_qubits
+
+    # Coordinates changed, but stable semantic registration order did not.
+    offset = 0
+    for mapping in (
+        code.vv_qubits,
+        code.cc_qubits,
+        code.x_check_qubits,
+        code.z_check_qubits,
+    ):
+        indices = [mapping[key] for key in sorted(mapping)]
+        assert indices == list(range(offset, offset + len(mapping)))
+        offset += len(mapping)
+
+
+def _assert_product_layer_semantics(
+    block: HGPProductColorationExtractionBlock,
+) -> None:
+    """Verify that direction relabeling does not alter any scheduled target."""
+    code = block.patch
+    global_index = block.local_to_global
+
+    for layer in block.layers:
+        expected_seed = "H1" if layer.direction == "horizontal" else "H2"
+        assert layer.seed == expected_seed
+        expected_pairs: list[tuple[int, int]] = []
+
+        if layer.basis == "X" and layer.direction == "vertical":
+            for check_2, bit_2 in layer.seed_edges:
+                for bit_1 in range(code.h1.num_bits):
+                    expected_pairs.append(
+                        (
+                            global_index[code.x_check_qubits[(bit_1, check_2)]],
+                            global_index[code.vv_qubits[(bit_1, bit_2)]],
+                        )
+                    )
+        elif layer.basis == "X" and layer.direction == "horizontal":
+            for check_1, bit_1 in layer.seed_edges:
+                for check_2 in range(code.h2.num_checks):
+                    expected_pairs.append(
+                        (
+                            global_index[code.x_check_qubits[(bit_1, check_2)]],
+                            global_index[code.cc_qubits[(check_1, check_2)]],
+                        )
+                    )
+        elif layer.basis == "Z" and layer.direction == "vertical":
+            for check_2, bit_2 in layer.seed_edges:
+                for check_1 in range(code.h1.num_checks):
+                    expected_pairs.append(
+                        (
+                            global_index[code.cc_qubits[(check_1, check_2)]],
+                            global_index[code.z_check_qubits[(check_1, bit_2)]],
+                        )
+                    )
+        else:
+            for check_1, bit_1 in layer.seed_edges:
+                for bit_2 in range(code.h2.num_bits):
+                    expected_pairs.append(
+                        (
+                            global_index[code.vv_qubits[(bit_1, bit_2)]],
+                            global_index[code.z_check_qubits[(check_1, bit_2)]],
+                        )
+                    )
+
+        assert layer.cnot_pairs == tuple(sorted(expected_pairs))
 
 
 def _logical_vectors(code: HGPCode) -> tuple[np.ndarray, np.ndarray]:
@@ -171,10 +323,15 @@ def test_repetition_product_is_the_13_1_3_unrotated_surface_patch():
     assert hgp.num_logicals == 1
     assert [pair["sector"] for pair in hgp.logical_pairs] == ["bit_bit"]
 
-    assert set(hgp.data_coords) == set(surface.data_coords)
-    assert set(hgp.syndrome_coords_x) == set(surface.syndrome_coords_x)
-    assert set(hgp.syndrome_coords_z) == set(surface.syndrome_coords_z)
-    assert _stabilizer_signatures(hgp) == _stabilizer_signatures(surface)
+    # The default HGP display separates the four product sectors.  Its Tanner
+    # graph is nevertheless exactly the standard unrotated surface-code graph
+    # under this independent semantic-index embedding.
+    assert _stabilizer_signatures(
+        hgp,
+        _checkerboard_tanner_embedding(hgp),
+    ) == _stabilizer_signatures(surface)
+    _assert_hgp_parity_check_formula(hgp)
+    _assert_product_block_layout(hgp)
     assert {len(op["data_indices"]) for op in hgp.logical_ops} == {3}
     _assert_css_and_logical_invariants(hgp)
 
@@ -199,17 +356,14 @@ def test_cycle_product_is_the_18_2_3_toric_patch():
         "check_check",
     ]
 
-    # ToricCode uses the transposed checkerboard orientation compared with the
-    # unrotated patch.  After that coordinate relabeling, the Tanner graphs are
-    # exactly identical, including X/Z check types.
-    assert set(hgp.data_coords) == {transpose_coords(coord) for coord in toric.data_coords}
-    assert set(hgp.syndrome_coords_x) == {
-        transpose_coords(coord) for coord in toric.syndrome_coords_x
-    }
-    assert set(hgp.syndrome_coords_z) == {
-        transpose_coords(coord) for coord in toric.syndrome_coords_z
-    }
-    assert _stabilizer_signatures(hgp) == _stabilizer_signatures(toric, transpose_coords)
+    # ToricCode uses the transposed checkerboard orientation.  Compare Tanner
+    # graphs through semantic indices instead of constraining the HGP display.
+    assert _stabilizer_signatures(
+        hgp,
+        _checkerboard_tanner_embedding(hgp),
+    ) == _stabilizer_signatures(toric, transform=transpose_coords)
+    _assert_hgp_parity_check_formula(hgp)
+    _assert_product_block_layout(hgp)
     assert {len(op["data_indices"]) for op in hgp.logical_ops} == {3}
     _assert_css_and_logical_invariants(hgp)
 
@@ -250,6 +404,8 @@ def test_distinct_rectangular_rank_deficient_seeds_are_preserved():
     assert code.num_logicals == 5
     assert [pair["sector"] for pair in code.logical_pairs].count("bit_bit") == 4
     assert [pair["sector"] for pair in code.logical_pairs].count("check_check") == 1
+    _assert_hgp_parity_check_formula(code)
+    _assert_product_block_layout(code)
     _assert_css_and_logical_invariants(code)
 
     system = QECSystem()
@@ -317,16 +473,23 @@ def test_hgp_product_coloration_has_stable_four_phase_16_layer_schedule():
     assert block.cnot_depth == 16
     assert len(block.measurement_blocks) == 2
     assert [(layer.basis, layer.direction, layer.color) for layer in block.layers] == [
-        *(('X', 'horizontal', color) for color in range(4)),
         *(('X', 'vertical', color) for color in range(4)),
-        *(('Z', 'horizontal', color) for color in range(4)),
+        *(('X', 'horizontal', color) for color in range(4)),
         *(('Z', 'vertical', color) for color in range(4)),
+        *(('Z', 'horizontal', color) for color in range(4)),
+    ]
+    assert [layer.seed for layer in block.layers] == [
+        *("H2" for _ in range(4)),
+        *("H1" for _ in range(4)),
+        *("H2" for _ in range(4)),
+        *("H1" for _ in range(4)),
     ]
 
     for layer in block.layers:
         qubits = [qubit for pair in layer.cnot_pairs for qubit in pair]
         assert len(qubits) == len(set(qubits))
 
+    _assert_product_layer_semantics(block)
     assert sum(len(layer.cnot_pairs) for layer in block.x_layers) == 108 * 7
     assert sum(len(layer.cnot_pairs) for layer in block.z_layers) == 108 * 7
     assert block.measurement_blocks[0].num_measurements == 108


### PR DESCRIPTION
## What changed

- replace the interleaved checkerboard coordinates of HGP patches with a separated four-sector product layout
- place `V1 x V2` data at upper left, Z ancillas at upper right, X ancillas at lower left, and `C1 x C2` data at lower right
- keep the existing H2-then-H1 syndrome-extraction gate order while relabeling product layers to match the displayed axes
- update the HGP memory notebook description and strengthen coordinate, Tanner-graph, registration-order, and per-layer regression tests

## Why

The separated product view makes the HGP construction directly visible and gives HGP and lifted-product codes a common semantic presentation. The coordinates are presentation metadata: qubit IDs, stabilizers, logical operators, CNOT targets, and measurement order remain unchanged.

## Validation

- `pytest -q tests/test_hgp_code.py tests/test_run_memory.py -k 'hgp or HGP'` (20 passed)
- `git diff --check origin/main...HEAD`
- generated all three notebook diagrams as complete bulk-round `detslice-with-ops-svg` views
