### PR TITLE
General PPM layer: pure lowering kernel, algebraic certificates, protocol outputs, sequential experiments (stacked on #75)

### DIFF
--- a/docs/specs/ppm-lowering.md
+++ b/docs/specs/ppm-lowering.md
@@ -84,6 +84,29 @@ pair is a per-shot coin while every certified correlation stays silent).
 | engine composition | measurement-block engine round over post-PPM tracker state (shared census) | `test_kernel_api_composes_with_measurement_block_engine` |
 | deformed / non-rectangular patches | not supported: the corridor path reconstructs standard rectangles from specs; adjacent classification would reject a mismatched live view | — |
 
+## Known interface gaps against the review's spec
+
+Honestly listed, each a deliberate scope cut of this iteration:
+
+- **wall certificates**: wall (stretched-stabilizer) plans carry
+  `certificate=None`; their validation lives in the rule-table laws and
+  the end-to-end distance tests.
+- **paused/restored checks**: handled by coupler activation
+  (`QECSystem.activate_coupler` pauses, `deactivate` restores), not
+  exposed as a `LoweringPlan` field.
+- **no `post_state` field**: sequential composition reads the LIVE
+  system's state after apply/split; the plan does not carry a
+  self-contained state transition.
+- **logical representatives**: an explicit live-probe input on the
+  cell-adjacent path (`patch_view`); the corridor path derives standard
+  representatives from the registered logical operators — which is also
+  why deformed/non-rectangular patches are unsupported.
+- **evaluation specification is implicit**: the initial/final state
+  letters choose which correlations are deterministic; there is no
+  first-class evaluation-spec object.  The protocol-output vs evaluation
+  distinction is carried by `PPMOutcome` plus the emitted
+  observables/closure detectors.
+
 ## Known reproducibility note
 
 Circuit builds are process-nondeterministic without a pinned

--- a/docs/specs/ppm-lowering.md
+++ b/docs/specs/ppm-lowering.md
@@ -79,7 +79,7 @@ pair is a per-shot coin while every certified correlation stays silent).
 | Y | **rejected explicitly** (`UnsupportedPauliError`): needs a twist/Y-wall construction this stack does not implement | `test_y_letter_rejected_explicitly` |
 | target weight | 2 (adjacent + routed), 3 (T corridor) | row tests, `test_three_target_one_step_t_corridor` |
 | weight ≥ 4 | **rejected explicitly** (`BentLayoutError`): needs the snake / kf-wall attach machinery not carried by this variant | `test_weight4_straight_chain_is_an_explicit_gap` |
-| route shapes | zero-cell (adjacent), straight, branched/T; bends force the diagonal schedule (machinery present, no dedicated matrix test yet) | corridor tests |
+| route shapes | zero-cell (adjacent), straight (incl. 3-cell longer route), bent/L (forces the diagonal schedule), branched/T | corridor tests, `test_longer_straight_route_full_distance`, `test_bent_route_forces_diagonal_and_full_distance` |
 | sequential composition | commuting and anti-commuting consecutive PPMs; corridor reuse between steps | `test_ppm_outcomes`, driver tests |
 | engine composition | measurement-block engine round over post-PPM tracker state (shared census) | `test_kernel_api_composes_with_measurement_block_engine` |
 | deformed / non-rectangular patches | not supported: the corridor path reconstructs standard rectangles from specs; adjacent classification would reject a mismatched live view | — |

--- a/docs/specs/ppm-lowering.md
+++ b/docs/specs/ppm-lowering.md
@@ -1,0 +1,92 @@
+# PPM lowering: design note and capability table
+
+Status: PR-B working document (general-ppm branch).
+
+## Layering
+
+```
+PPMRequest ──lower_ppm()──► LoweringPlan ──apply_plan()──► QECSystem registration
+   (pure, no mutation)          │                                │
+                                │ certificate                    │ activate / merged
+                                ▼                                ▼ rounds / split
+                         LoweringCertificate          PPMOutcome (protocol output)
+```
+
+- `lower_ppm(specs, request, system=..., ...)` is PURE: it classifies the
+  seam (live probe for cell-adjacent pairs), routes the explicit corridor,
+  chooses the construction (plain/recoloured merge, stretched wall) and the
+  merged-round schedule, and returns a declarative `LoweringPlan`.  It never
+  touches the system, builder, or tracker.
+- `apply_plan(system, plan, name)` is the single mutation: coupler
+  registration.  Activation, merged rounds, split, and corridor readout
+  remain with the caller (`SequentialPPMExperiment` is one such caller; a
+  logical-level compiler is the intended other — see
+  `test_kernel_api_composes_with_measurement_block_engine` for the
+  driver-free consumption path).
+- Routing and lowering are separate responsibilities.  The route is an
+  explicit input everywhere; **there is no auto-router** and no API name
+  suggests one.
+
+## The algebraic certificate
+
+Every accepted corridor layout carries `MultiPatchLayout.verify()`'s named
+oracle items on `SubsetRoute.certificate` / `LoweringPlan.certificate`:
+
+| item | meaning |
+|---|---|
+| `commute` | merged check set is mutually commuting |
+| `joint` | the requested product IS in the measured span |
+| `no_single` | no single target logical is exposed |
+| `no_subjoint` | no proper subset product is exposed |
+| `logical_count` | rank change is exactly one measured DOF |
+| `no_twist` | no Y check appears in the construction |
+| `no_weight1_logical` | no weight-1 undetected logical |
+| `no_mpp`, `no_tick_collision`, `dem_valid` | circuit-level items (layouts without stretched checks) |
+
+`certificate.measures_exactly_the_product` (= `joint & no_single &
+no_subjoint`) is the **true weight-w instrument guarantee**: measuring
+`M(P1*...*Pw)` reveals ONE bit; measuring `w-1` pairwise parities reveals
+more logical information and is a different quantum instrument.  Wall
+(stretched-stabilizer) plans currently carry `certificate=None`: their
+validation lives in the rule-table laws and end-to-end distance tests — a
+known gap.
+
+## Protocol output vs evaluation observable
+
+Each applied PPM banks a `PPMOutcome`: the joint's measurement-record
+parity before the merge and after the split (`record_parity()` over the
+record-carrying tracker rows; UNMEASURED-sentinel rows are excluded from
+the reconstruction basis).  `None` before the merge of an anti-commuting
+request is a **legitimately random protocol output**, not an error.
+
+Whether a protocol output enters a deterministic, decodable quantity — an
+`OBSERVABLE_INCLUDE`, a closure detector, a feed-forward dependency — is
+the caller's EVALUATION choice, made from input states, the record
+parities, and the final measurement bases.  The driver's final readout
+emits the standing logical observables; the closure detectors it emits are
+the certified correlations.  Tests: `tests/test_ppm_outcomes.py`
+(commuting repeat reproducible shot-by-shot; anti-commuting corner-layout
+pair is a per-shot coin while every certified correlation stays silent).
+
+## Capability table
+
+| axis | supported today | verified by |
+|---|---|---|
+| patch family | standard rotated rectangular patches (`PatchSpec` adapter; colour-swap knob) | whole suite |
+| live geometry | cell-adjacent classification probes the LIVE system (`patch_view`); routed corridors consume orientation-stamped specs | `test_ppm_lowering` |
+| distance | d=3 across the matrix; d=5 representative | `test_zz_pair_full_distance_d5` |
+| Pauli letters | X, Z (homogeneous and mixed) | rule-row tests |
+| Y | **rejected explicitly** (`UnsupportedPauliError`): needs a twist/Y-wall construction this stack does not implement | `test_y_letter_rejected_explicitly` |
+| target weight | 2 (adjacent + routed), 3 (T corridor) | row tests, `test_three_target_one_step_t_corridor` |
+| weight ≥ 4 | **rejected explicitly** (`BentLayoutError`): needs the snake / kf-wall attach machinery not carried by this variant | `test_weight4_straight_chain_is_an_explicit_gap` |
+| route shapes | zero-cell (adjacent), straight, branched/T; bends force the diagonal schedule (machinery present, no dedicated matrix test yet) | corridor tests |
+| sequential composition | commuting and anti-commuting consecutive PPMs; corridor reuse between steps | `test_ppm_outcomes`, driver tests |
+| engine composition | measurement-block engine round over post-PPM tracker state (shared census) | `test_kernel_api_composes_with_measurement_block_engine` |
+| deformed / non-rectangular patches | not supported: the corridor path reconstructs standard rectangles from specs; adjacent classification would reject a mismatched live view | — |
+
+## Known reproducibility note
+
+Circuit builds are process-nondeterministic without a pinned
+`PYTHONHASHSEED` (set ordering reaches detector-coordinate assignment;
+physics is unaffected).  Byte-level reproduction of a build requires
+recording the hash seed alongside the commit.

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -729,7 +729,7 @@ class CircuitBuilder:
             or tracker.expected_num_logicals != 1
             or tracker.stabilizer_with_logical_components
             or tracker._gauge_logical_vectors
-            or tracker._absorbed_logical_dofs
+            or tracker.absorbed_ops.count
             or tracker.post_select_row_indices
             or self.circuit.num_observables > 0
         ):

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -1,6 +1,6 @@
-import copy
 import logging
 import stim
+import copy
 import numpy as np
 from typing import List, Dict, Any, Optional, Union, Literal, Set, Tuple
 from dataclasses import dataclass
@@ -171,6 +171,318 @@ class CircuitBuilder:
     # --------------------------------------------------------------------------
     # B. Syndrome Extraction
     # --------------------------------------------------------------------------
+    def apply_syndrome_extraction(self,
+                                  circuit_chunk: stim.Circuit,
+                                  rounds: int = 1,
+                                  noiseless: bool = False,
+                                  z_only: bool = False,
+                                  measurement_blocks: Optional[Tuple[stim.Circuit, ...]] = None):
+        """
+        Applies syndrome extraction with automated Tracker integration.
+
+        Args:
+            circuit_chunk: A Stim circuit representing ONE round of stabilizer measurement.
+                           Only includes circuit operations. The last instruction has to be syndrome qubit measurement.
+            rounds: Number of times to repeat.
+            noiseless: If True, tag all gate instructions in circuit_chunk as 'noiseless'
+                so the noise injector skips them. Useful for injection-stabilization rounds.
+            z_only: If True, only Z-ancilla measurements emit DETECTOR instructions.
+                X-ancilla are still measured (so the tableau update is correct) but
+                suppressed from the DEM. State is stored for apply_data_readout(z_only=True).
+        """
+        if measurement_blocks is not None:
+            # multi-block round: route to the upstream measurement-block engine
+            # (explicit tracker boundaries within the round, e.g. middle-out
+            # color-code circuits).  The legacy single-block path below stays
+            # byte-identical for every existing protocol.
+            return self._apply_syndrome_extraction_blocks(
+                circuit_chunk, rounds=rounds, noiseless=noiseless,
+                z_only=z_only, measurement_blocks=measurement_blocks)
+        if rounds < 1: return
+        if noiseless:
+            circuit_chunk = _make_noiseless(circuit_chunk)
+
+        # ======================================================================
+        # Phase 1: First Round (Tracker-Driven)
+        # ======================================================================
+        _log.debug("Applying first round of syndrome extraction...")
+        # Analyze Ideal Basis for the Tracker
+        back_propagated_paulis, syn_qubit_indices = self._get_back_propagated_pauli(circuit_chunk, self.tracker.num_qubits)
+        syn_coords = [self.system.qubit_coords[i] for i in syn_qubit_indices] # extract from circuit_chunk, more robust
+
+        # Build Z-only mask: True for X-ancilla (suppress their DETECTORs)
+        no_detector_mask = None
+        if z_only:
+            x_anc_set = set(self.system.active_syndrome_indices_x)
+            no_detector_mask = np.array([q in x_anc_set for q in syn_qubit_indices], dtype=bool)
+            self._z_only_syn_qubit_indices = syn_qubit_indices
+            self._z_only_no_detector_mask  = no_detector_mask
+            self._z_only_n_meas_per_round  = len(syn_qubit_indices)
+
+        # Append chunk to actual circuit (optionally tagging all instructions as noiseless)
+        if noiseless:
+            for inst in circuit_chunk:
+                if isinstance(inst, stim.CircuitInstruction):
+                    self.circuit.append(inst.name, inst.targets_copy(), inst.gate_args_copy(), tag="noiseless")
+                else:
+                    self.circuit.append(inst)
+        else:
+            self.circuit += circuit_chunk
+
+        total_measurements = self.tracker.total_measurements
+        meas_rec_to_idx_map_update = {total_measurements + i: syn_idx for i, syn_idx in enumerate(syn_qubit_indices)}
+        self.tracker.meas_rec_to_idx_map.update(meas_rec_to_idx_map_update)
+        # Ask Tracker to process it (Update Tableau + Generate Detectors)
+        if self.if_detector:
+            # Time shift before first-round detectors so that each call to
+            # apply_syndrome_extraction occupies its own time slice.  Without
+            # this, consecutive calls (e.g. surface-only SE then combined SE)
+            # place their detectors at the same t coordinate, confusing the
+            # decoder's matching graph.
+            self.circuit.append("SHIFT_COORDS", [], [0, 0, 1])
+
+            self.tracker.process_mid_measurement(
+                circuit=self.circuit,
+                back_propagated_paulis=back_propagated_paulis,
+                syn_coords=syn_coords,
+                no_detector_mask=no_detector_mask,
+            )
+
+        # ======================================================================
+        # Phase 2: Repeat Rounds (Stim Loop)
+        # ======================================================================
+        if rounds > 1:
+            _log.debug("Applying rest rounds of syndrome extraction...")
+
+            loop_body = stim.Circuit()
+            num_syn = len(syn_coords)
+
+            # Circuit operations for the repeated block
+            loop_body.append("TICK")
+            if noiseless:
+                for inst in circuit_chunk:
+                    if isinstance(inst, stim.CircuitInstruction):
+                        loop_body.append(inst.name, inst.targets_copy(), inst.gate_args_copy(), tag="noiseless")
+                    else:
+                        loop_body.append(inst)
+            else:
+                loop_body += circuit_chunk
+            
+            if self.if_detector:
+                # Time Shift for visualization
+                loop_body.append("SHIFT_COORDS", [], [0, 0, 1])
+
+                # Construct Repeated Detectors: rec[-k] ^ rec[-k-num_syn]
+                for i in range(num_syn):
+                    if no_detector_mask is not None and no_detector_mask[i]:
+                        continue  # z_only: skip X-ancilla detectors
+                    # Stim record indices are relative to the current moment in the loop
+                    rec_current = -num_syn + i
+                    rec_prev = -num_syn + i - num_syn
+
+                    coord = list(syn_coords[i]) + [0]
+                    _append_detector(
+                        loop_body,
+                        [stim.target_rec(rec_current), stim.target_rec(rec_prev)],
+                        coord,
+                        post_select=tuple(coord) in self.tracker.post_select_detector_coords,
+                    ) 
+            
+            self.circuit.append(stim.CircuitRepeatBlock(rounds - 1, loop_body))
+
+            # Update the meas_rec_to_idx_map for the repeated rounds
+            total_measurements = self.tracker.total_measurements
+            for r in range(rounds - 1):
+                self.tracker.meas_rec_to_idx_map.update({total_measurements + num_syn * r + i: syn_idx for i, syn_idx in enumerate(syn_qubit_indices)})
+            
+            # Update Tracker Counter, but the tableau does not need to be updated again
+            meas_record_offset = num_syn * (rounds - 1)
+            self.tracker.total_measurements += meas_record_offset
+            for i in range(len(syn_coords)):
+                records = self.tracker.stabilizers.records[i]
+                shift_records = [rec + meas_record_offset for rec in records]
+                self.tracker.stabilizers.records[i] = shift_records
+
+    def _apply_syndrome_extraction_blocks(self,
+                                  circuit_chunk: stim.Circuit,
+                                  rounds: int = 1,
+                                  noiseless: bool = False,
+                                  z_only: bool = False,
+                                  measurement_blocks: Optional[Tuple[stim.Circuit, ...]] = None):
+        """
+        Applies syndrome extraction with automated Tracker integration.
+
+        Args:
+            circuit_chunk: The complete physical circuit for one SE round.
+            measurement_blocks: Explicit tracker boundaries within the round.
+                Each block starts from its input preparation and ends in one
+                contiguous readout layer. When omitted, ``circuit_chunk`` is
+                treated as one measurement block.
+            rounds: Number of times to repeat.
+            noiseless: If True, tag all gate instructions in circuit_chunk as 'noiseless'
+                so the noise injector skips them. Useful for injection-stabilization rounds.
+            z_only: If True, only Z-ancilla measurements emit DETECTOR instructions.
+                X-ancilla are still measured (so the tableau update is correct) but
+                suppressed from the DEM. State is stored for apply_data_readout(z_only=True).
+        """
+        if rounds < 1:
+            return
+
+        blocks = tuple(measurement_blocks or (circuit_chunk,))
+        if not blocks:
+            raise ValueError("measurement_blocks must not be empty.")
+        if noiseless:
+            blocks = tuple(_make_noiseless(block) for block in blocks)
+        circuit_chunk = self._join_measurement_blocks(blocks)
+
+        if not self.if_detector:
+            self.circuit += circuit_chunk
+            if rounds > 1:
+                steady_round_body = stim.Circuit()
+                steady_round_body.append("TICK")
+                steady_round_body += circuit_chunk
+                self.circuit += steady_round_body
+                if rounds > 2:
+                    self.circuit.append(stim.CircuitRepeatBlock(
+                        rounds - 2,
+                        steady_round_body,
+                    ))
+            return
+
+        analyses = tuple(
+            self._analyze_measurement_block(block, z_only=z_only)
+            for block in blocks
+        )
+        if z_only:
+            if len(analyses) != 1:
+                raise ValueError(
+                    "z_only readout currently supports one measurement block per SE round."
+                )
+            analysis = analyses[0]
+            self._z_only_syn_qubit_indices = (
+                analysis.measurement_qubit_indices
+            )
+            self._z_only_no_detector_mask = analysis.no_detector_mask
+            self._z_only_n_meas_per_round = len(
+                analysis.measurement_qubit_indices
+            )
+
+        _log.debug("Applying first round of syndrome extraction...")
+        self._process_measurement_blocks(
+            output_circuit=self.circuit,
+            analyses=analyses,
+            shift_round=True,
+        )
+
+        if rounds <= 1:
+            return
+
+        _log.debug("Applying second syndrome-extraction round...")
+        first_round_logical_components = set(
+            self.tracker.stabilizer_with_logical_components
+        )
+        steady_round_body = stim.Circuit()
+        steady_round_body.append("TICK")
+        self._process_measurement_blocks(
+            output_circuit=steady_round_body,
+            analyses=analyses,
+            shift_round=True,
+        )
+        self.tracker.stabilizer_with_logical_components.update(
+            first_round_logical_components
+        )
+        self.circuit += steady_round_body
+
+        if rounds <= 2:
+            return
+
+        repeated_round_body = self._try_compress_steady_rounds(
+            repetitions=rounds - 2,
+            analyses=analyses,
+        )
+        if repeated_round_body is not None:
+            self.circuit.append(stim.CircuitRepeatBlock(
+                rounds - 2,
+                repeated_round_body,
+            ))
+            return
+
+        if not self._uses_disposable_syndrome_readout(analyses):
+            persistent_logical_components = set(
+                self.tracker.stabilizer_with_logical_components
+            )
+            for _ in range(rounds - 2):
+                explicit_round_body = stim.Circuit()
+                explicit_round_body.append("TICK")
+                self._process_measurement_blocks(
+                    output_circuit=explicit_round_body,
+                    analyses=analyses,
+                    shift_round=True,
+                )
+                self.circuit += explicit_round_body
+                self.tracker.stabilizer_with_logical_components.update(
+                    persistent_logical_components
+                )
+                persistent_logical_components.update(
+                    self.tracker.stabilizer_with_logical_components
+                )
+            return
+
+        self.circuit.append(stim.CircuitRepeatBlock(
+            rounds - 2,
+            steady_round_body,
+        ))
+
+        persistent_logical_components = set(
+            self.tracker.stabilizer_with_logical_components
+        )
+        for _ in range(rounds - 2):
+            promotable_stabilizer_rows = []
+            for analysis in analyses:
+                repeated_base_idx = self.tracker.total_measurements
+                self.tracker.meas_rec_to_idx_map.update({
+                    repeated_base_idx + i: qubit
+                    for i, qubit in enumerate(
+                        analysis.measurement_qubit_indices
+                    )
+                })
+                promotable_stabilizer_rows.append(
+                    self.tracker.process_measurement_block(
+                        circuit=stim.Circuit(),
+                        forward_symplectic_matrix=(
+                            analysis.forward_symplectic_matrix
+                        ),
+                        back_propagated_paulis=(
+                            analysis.back_propagated_paulis
+                        ),
+                        reset_paulis=analysis.reset_paulis,
+                        measurement_qubit_indices=(
+                            analysis.measurement_qubit_indices
+                        ),
+                        measurement_bases=analysis.measurement_bases,
+                        measurement_coords=analysis.measurement_coords,
+                        discarded_measurement_qubit_indices=(
+                            analysis.discarded_measurement_qubit_indices
+                        ),
+                        no_detector_mask=np.ones(
+                            len(analysis.measurement_qubit_indices),
+                            dtype=bool,
+                        ),
+                    )
+                )
+            self._finish_measurement_block_group(
+                analyses,
+                promotable_stabilizer_rows=tuple(
+                    promotable_stabilizer_rows
+                ),
+            )
+            self.tracker.stabilizer_with_logical_components.update(
+                persistent_logical_components
+            )
+            persistent_logical_components.update(
+                self.tracker.stabilizer_with_logical_components
+            )
+
     @staticmethod
     def _join_measurement_blocks(
         measurement_blocks: Tuple[stim.Circuit, ...],
@@ -189,27 +501,6 @@ class CircuitBuilder:
             == set(analysis.measurement_qubit_indices)
             for analysis in analyses
         )
-
-    def _finish_measurement_block_group(
-        self,
-        analyses: Tuple[_MeasurementBlockAnalysis, ...],
-        *,
-        promotable_stabilizer_rows: Tuple[Set[int], ...],
-        tracker: Optional[SyndromeTracker] = None,
-    ) -> None:
-        """Apply Builder-owned state classification at an SE-round boundary."""
-        tracker = self.tracker if tracker is None else tracker
-        if self._uses_disposable_syndrome_readout(analyses):
-            if len(analyses) == 1:
-                tracker.promote_stabilizer_rows_to_logicals(
-                    promotable_stabilizer_rows[0]
-                )
-            else:
-                tracker.rebase_stabilizers_onto_code_basis(self.system)
-        else:
-            tracker.validate_logical_count(
-                context="syndrome-extraction round"
-            )
 
     def _analyze_measurement_block(
         self,
@@ -369,7 +660,7 @@ class CircuitBuilder:
                 )
 
             promotable_stabilizer_rows.append(
-                tracker.process_mid_measurement(
+                tracker.process_measurement_block(
                     circuit=output_circuit,
                     forward_symplectic_matrix=(
                         analysis.forward_symplectic_matrix
@@ -397,184 +688,25 @@ class CircuitBuilder:
             tracker=tracker,
         )
 
-    def apply_syndrome_extraction(self,
-                                  circuit_chunk: stim.Circuit,
-                                  rounds: int = 1,
-                                  noiseless: bool = False,
-                                  z_only: bool = False,
-                                  measurement_blocks: Optional[Tuple[stim.Circuit, ...]] = None):
-        """
-        Applies syndrome extraction with automated Tracker integration.
-
-        Args:
-            circuit_chunk: The complete physical circuit for one SE round.
-            measurement_blocks: Explicit tracker boundaries within the round.
-                Each block starts from its input preparation and ends in one
-                contiguous readout layer. When omitted, ``circuit_chunk`` is
-                treated as one measurement block.
-            rounds: Number of times to repeat.
-            noiseless: If True, tag all gate instructions in circuit_chunk as 'noiseless'
-                so the noise injector skips them. Useful for injection-stabilization rounds.
-            z_only: If True, only Z-ancilla measurements emit DETECTOR instructions.
-                X-ancilla are still measured (so the tableau update is correct) but
-                suppressed from the DEM. State is stored for apply_data_readout(z_only=True).
-        """
-        if rounds < 1:
-            return
-
-        blocks = tuple(measurement_blocks or (circuit_chunk,))
-        if not blocks:
-            raise ValueError("measurement_blocks must not be empty.")
-        if noiseless:
-            blocks = tuple(_make_noiseless(block) for block in blocks)
-        circuit_chunk = self._join_measurement_blocks(blocks)
-
-        if not self.if_detector:
-            self.circuit += circuit_chunk
-            if rounds > 1:
-                steady_round_body = stim.Circuit()
-                steady_round_body.append("TICK")
-                steady_round_body += circuit_chunk
-                self.circuit += steady_round_body
-                if rounds > 2:
-                    self.circuit.append(stim.CircuitRepeatBlock(
-                        rounds - 2,
-                        steady_round_body,
-                    ))
-            return
-
-        analyses = tuple(
-            self._analyze_measurement_block(block, z_only=z_only)
-            for block in blocks
-        )
-        if z_only:
-            if len(analyses) != 1:
-                raise ValueError(
-                    "z_only readout currently supports one measurement block per SE round."
+    def _finish_measurement_block_group(
+        self,
+        analyses: Tuple[_MeasurementBlockAnalysis, ...],
+        *,
+        promotable_stabilizer_rows: Tuple[Set[int], ...],
+        tracker: Optional[SyndromeTracker] = None,
+    ) -> None:
+        """Apply Builder-owned state classification at an SE-round boundary."""
+        tracker = self.tracker if tracker is None else tracker
+        if self._uses_disposable_syndrome_readout(analyses):
+            if len(analyses) == 1:
+                tracker.promote_stabilizer_rows_to_logicals(
+                    promotable_stabilizer_rows[0]
                 )
-            analysis = analyses[0]
-            self._z_only_syn_qubit_indices = (
-                analysis.measurement_qubit_indices
-            )
-            self._z_only_no_detector_mask = analysis.no_detector_mask
-            self._z_only_n_meas_per_round = len(
-                analysis.measurement_qubit_indices
-            )
-
-        _log.debug("Applying first round of syndrome extraction...")
-        self._process_measurement_blocks(
-            output_circuit=self.circuit,
-            analyses=analyses,
-            shift_round=True,
-        )
-
-        if rounds <= 1:
-            return
-
-        _log.debug("Applying second syndrome-extraction round...")
-        first_round_logical_components = set(
-            self.tracker.stabilizer_with_logical_components
-        )
-        steady_round_body = stim.Circuit()
-        steady_round_body.append("TICK")
-        self._process_measurement_blocks(
-            output_circuit=steady_round_body,
-            analyses=analyses,
-            shift_round=True,
-        )
-        self.tracker.stabilizer_with_logical_components.update(
-            first_round_logical_components
-        )
-        self.circuit += steady_round_body
-
-        if rounds <= 2:
-            return
-
-        repeated_round_body = self._try_compress_steady_rounds(
-            repetitions=rounds - 2,
-            analyses=analyses,
-        )
-        if repeated_round_body is not None:
-            self.circuit.append(stim.CircuitRepeatBlock(
-                rounds - 2,
-                repeated_round_body,
-            ))
-            return
-
-        if not self._uses_disposable_syndrome_readout(analyses):
-            persistent_logical_components = set(
-                self.tracker.stabilizer_with_logical_components
-            )
-            for _ in range(rounds - 2):
-                explicit_round_body = stim.Circuit()
-                explicit_round_body.append("TICK")
-                self._process_measurement_blocks(
-                    output_circuit=explicit_round_body,
-                    analyses=analyses,
-                    shift_round=True,
-                )
-                self.circuit += explicit_round_body
-                self.tracker.stabilizer_with_logical_components.update(
-                    persistent_logical_components
-                )
-                persistent_logical_components.update(
-                    self.tracker.stabilizer_with_logical_components
-                )
-            return
-
-        self.circuit.append(stim.CircuitRepeatBlock(
-            rounds - 2,
-            steady_round_body,
-        ))
-
-        persistent_logical_components = set(
-            self.tracker.stabilizer_with_logical_components
-        )
-        for _ in range(rounds - 2):
-            promotable_stabilizer_rows = []
-            for analysis in analyses:
-                repeated_base_idx = self.tracker.total_measurements
-                self.tracker.meas_rec_to_idx_map.update({
-                    repeated_base_idx + i: qubit
-                    for i, qubit in enumerate(
-                        analysis.measurement_qubit_indices
-                    )
-                })
-                promotable_stabilizer_rows.append(
-                    self.tracker.process_mid_measurement(
-                        circuit=stim.Circuit(),
-                        forward_symplectic_matrix=(
-                            analysis.forward_symplectic_matrix
-                        ),
-                        back_propagated_paulis=(
-                            analysis.back_propagated_paulis
-                        ),
-                        reset_paulis=analysis.reset_paulis,
-                        measurement_qubit_indices=(
-                            analysis.measurement_qubit_indices
-                        ),
-                        measurement_bases=analysis.measurement_bases,
-                        measurement_coords=analysis.measurement_coords,
-                        discarded_measurement_qubit_indices=(
-                            analysis.discarded_measurement_qubit_indices
-                        ),
-                        no_detector_mask=np.ones(
-                            len(analysis.measurement_qubit_indices),
-                            dtype=bool,
-                        ),
-                    )
-                )
-            self._finish_measurement_block_group(
-                analyses,
-                promotable_stabilizer_rows=tuple(
-                    promotable_stabilizer_rows
-                ),
-            )
-            self.tracker.stabilizer_with_logical_components.update(
-                persistent_logical_components
-            )
-            persistent_logical_components.update(
-                self.tracker.stabilizer_with_logical_components
+            else:
+                tracker.rebase_stabilizers_onto_code_basis(self.system)
+        else:
+            tracker.validate_logical_count(
+                context="syndrome-extraction round"
             )
 
     def _try_compress_steady_rounds(
@@ -808,246 +940,6 @@ class CircuitBuilder:
     # --------------------------------------------------------------------------
     # C. Unitary Block (Logical Gates, Unitary Encoding, etc.)
     # --------------------------------------------------------------------------
-    def apply_unitary_block(self, unitary_block: stim.Circuit, noiseless: bool = False):
-        """
-        Applies a unitary circuit block and updates the tracker's tableau.
-
-        This method is used for logical operations (e.g., transversal CNOT) that
-        need to update the stabilizer tableau to reflect the unitary transformation.
-
-        Args:
-            unitary_block: A Stim circuit containing only unitary operations (no measurements/resets).
-            noiseless: If True, tag all gate instructions with 'noiseless' so that
-                       noise injection rules skip them.
-        """
-        # Append the unitary block to the circuit
-        if self.circuit[-1].name != "TICK":
-            self.circuit.append("TICK")
-
-        if noiseless:
-            # Re-emit each instruction with the noiseless tag
-            for inst in unitary_block:
-                if isinstance(inst, stim.CircuitInstruction):
-                    self.circuit.append(
-                        inst.name, inst.targets_copy(), inst.gate_args_copy(),
-                        tag="noiseless",
-                    )
-        else:
-            self.circuit += unitary_block
-
-        # Update the tracker's tableau to reflect the unitary transformation
-        self.tracker.process_unitary_block(unitary_block)
-
-    # --------------------------------------------------------------------------
-    # D. Logical Coupler Activity, Stabilizer Masking/Unmasking
-    # --------------------------------------------------------------------------
-    def activate_coupler(self, name: str):
-        """
-        Turn on the logical coupler. A wrapper for QECSystem.activate_coupler.
-        This changes the active stabilizer set for the NEXT round of extraction.
-        """
-        # Call the system's state manager
-        self.system.activate_coupler(name)
-
-    def deactivate_coupler(self, name: str):
-        """
-        Turn off the logical coupler and restore original patch boundaries.
-        A wrapper for QECSystem.deactivate_coupler.
-        """
-        self.system.deactivate_coupler(name)
-
-    def mask_stabilizers(self, ids: Set[int]):
-        """
-        Mask (Deactivate) the stabilizers with the given ids.
-        To be implemented.
-        """
-        pass
-
-    def unmask_stabilizers(self, ids: Set[int]):
-        """
-        Unmask (Activate) the stabilizers with the given ids.
-        To be implemented.
-        """
-        pass
-
-
-    # --------------------------------------------------------------------------
-    # E. Data Qubit Measurement
-    # --------------------------------------------------------------------------
-    def apply_data_readout(self, final_measurements: Dict[int, str] = None, noiseless: bool = False,
-                           z_only: bool = False):
-        """
-        Applies destructive measurement on data qubits and calls Tracker to
-        resolve remaining stabilizers into Detectors/Observables.
-
-        Args:
-            final_measurements: Dict mapping qubit index to measurement basis ('X', 'Y', 'Z').
-            noiseless: If True, tag measurement instructions with 'noiseless' so that
-                       noise injection rules skip them.
-            z_only: If True, bypass tracker.process_data_measurement and construct
-                DETECTOR / OBSERVABLE_INCLUDE manually from Z-stabilizers and Z-logicals.
-                Requires apply_syndrome_extraction to have been called with z_only=True.
-        """
-        if final_measurements is None:
-            final_measurements = {q: 'Z' for q in self.system.data_indices}
-
-        # Final destructive data readout must start in a fresh moment. Some
-        # extraction blocks, such as middle-out color-code circuits, end with
-        # data-qubit gauge measurements instead of a trailing TICK.
-        if len(self.circuit) > 0 and self.circuit[-1].name != "TICK":
-            self.circuit.append("TICK")
-
-        xs = [q for q, b in final_measurements.items() if b == 'X']
-        ys = [q for q, b in final_measurements.items() if b == 'Y']
-        zs = [q for q, b in final_measurements.items() if b == 'Z']
-
-        tag = "noiseless" if noiseless else ""
-
-        # Append gates (No manual noise here)
-        if xs: self.circuit.append("MX", xs, tag=tag)
-        if ys: self.circuit.append("MY", ys, tag=tag)
-        if zs: self.circuit.append("M", zs, tag=tag)
-
-        # Prepare Basis for Tracker (order matches circuit: X then Y then Z)
-        sorted_indices = xs + ys + zs
-        n = self.tracker.num_qubits
-        final_paulis = np.zeros((len(sorted_indices), 2 * n), dtype=np.uint8)
-
-        for i, q in enumerate(sorted_indices):
-            basis = final_measurements[q]
-            if basis == 'X':
-                final_paulis[i, q] = 1
-            elif basis == 'Y':
-                final_paulis[i, q] = 1
-                final_paulis[i, n + q] = 1
-            else:
-                final_paulis[i, n + q] = 1
-
-        # Call Tracker — or, for z_only, build DETECTORs/OBSERVABLEs manually
-        if self.if_detector:
-            if z_only:
-                syn_qubit_indices = self._z_only_syn_qubit_indices
-                no_detector_mask  = self._z_only_no_detector_mask
-                n_meas_per_round  = self._z_only_n_meas_per_round
-                x_anc_set = {q for q, masked in zip(syn_qubit_indices, no_detector_mask) if masked}
-
-                data_indices = sorted_indices  # already M'd above in Z basis
-                data_pos     = {q: i for i, q in enumerate(data_indices)}
-                n_data       = len(data_indices)
-                z_anc_pos    = {q: i for i, q in enumerate(syn_qubit_indices) if q not in x_anc_set}
-
-                for stab in self.system.active_stabilizers_z:
-                    recs = [stim.target_rec(-n_data + data_pos[q]) for q in stab['data_indices']]
-                    recs.append(stim.target_rec(-n_data - n_meas_per_round + z_anc_pos[stab['syn_idx']]))
-                    self.circuit.append("DETECTOR", recs)
-
-                # Delegate observable generation to the tracker so it handles
-                # periodic-boundary codes (e.g. toric) correctly. We snapshot
-                # the circuit length, let the tracker append both DETECTORs and
-                # OBSERVABLE_INCLUDEs, then keep only the OBSERVABLE_INCLUDEs.
-                n_before = len(self.circuit)
-                self.tracker.process_data_measurement(
-                    circuit=self.circuit,
-                    final_paulis=final_paulis,
-                    idx_to_coord_map=self.system.qubit_coords,
-                    syndrome_qubit_indices=self.system.syndrome_indices,
-                )
-                obs_insts = [
-                    inst for inst in list(self.circuit)[n_before:]
-                    if not isinstance(inst, stim.CircuitRepeatBlock)
-                    and inst.name == "OBSERVABLE_INCLUDE"
-                ]
-                self.circuit = self.circuit[:n_before]
-                for inst in obs_insts:
-                    self.circuit.append(inst.name, inst.targets_copy(), inst.gate_args_copy())
-            else:
-                self.tracker.process_data_measurement(
-                    circuit=self.circuit,
-                    final_paulis=final_paulis,
-                    idx_to_coord_map=self.system.qubit_coords,
-                    syndrome_qubit_indices=self.system.syndrome_indices,
-                )
-
-        # Remove measured qubits from active set (ready for reuse)
-        self.system.active_qubit_indices.difference_update(final_measurements.keys())
-
-    # --------------------------------------------------------------------------
-    # F. Final Build & Noise Injection
-    # --------------------------------------------------------------------------
-    def build_noisy_circuit(
-        self, 
-        noise_params: NoiseConfig,
-        noise_model: str = 'circuit_level'
-    ) -> stim.Circuit:
-        """
-        Consumes the clean circuit and applies noise using the specified model strategy.
-        
-        Args:
-            noise_params: Noise parameters (NoiseConfig).
-            noise_model: The name of the factory method in NoiseInjector to use.
-                         e.g., 'circuit_level' -> calls NoiseInjector.from_circuit_level(...)
-                         e.g., 'custom_test'   -> calls NoiseInjector.from_custom_test(...)
-        """
-        # 1. Construct the expected factory method name
-        method_name = f"from_{noise_model}"
-        
-        # 2. Dynamically retrieve the method from the NoiseInjector class
-        if not hasattr(NoiseInjector, method_name):
-            # Fallback or nice error message showing available options
-            valid_methods = [m.replace("from_", "") for m in dir(NoiseInjector) if m.startswith("from_")]
-            raise ValueError(f"Unknown noise model '{noise_model}'. "
-                             f"Expected one of: {valid_methods}")
-        
-        factory_method = getattr(NoiseInjector, method_name)
-        
-        # 3. Inject noise
-        # Assumptions: All factory methods must accept (config, data_qubits)
-        data_indices = [self.system.index_map[coord] for coord in self.system.data_coords]
-        injector = factory_method(noise_params, data_indices)
-        noisy_circuit = injector.inject_noise(self.circuit)
-
-        return noisy_circuit
-
-    # --------------------------------------------------------------------------
-    # G. Helpers
-    # --------------------------------------------------------------------------
-    @staticmethod
-    def _get_initialization_tableau(qubit_indices_x: List[int], qubit_indices_z: List[int], qubit_indices_y: List[int], n: int):
-        """
-        Generates the tableau for the given qubit indices in X, Z, Y basis.
-        Args:
-            qubit_indices_x: List[int]
-            qubit_indices_z: List[int]
-            qubit_indices_y: List[int]
-            n: int
-        Returns:
-            initialized_tableau: np.ndarray
-        """
-        # 1. X Basis: (X=1, Z=0)
-        # Shape is (len, 2n). If len=0, it's safe.
-        t_x = np.zeros((len(qubit_indices_x), 2 * n), dtype=int)
-        if qubit_indices_x:
-            t_x[np.arange(len(qubit_indices_x)), qubit_indices_x] = 1
-
-        # 2. Z Basis: (X=0, Z=1)
-        t_z = np.zeros((len(qubit_indices_z), 2 * n), dtype=int)
-        if qubit_indices_z:
-            # Use list comprehension or numpy add to shift index by n
-            cols = [i + n for i in qubit_indices_z]
-            t_z[np.arange(len(qubit_indices_z)), cols] = 1
-
-        # 3. Y Basis: (X=1, Z=1) -> Critical Fix here
-        t_y = np.zeros((len(qubit_indices_y), 2 * n), dtype=int)
-        if qubit_indices_y:
-            # Set X part
-            t_y[np.arange(len(qubit_indices_y)), qubit_indices_y] = 1
-            # Set Z part (same row!)
-            cols_z = [i + n for i in qubit_indices_y]
-            t_y[np.arange(len(qubit_indices_y)), cols_z] = 1
-
-        # 4. Stack
-        # Since all sub-matrices have 2*n columns, vstack works even if some have 0 rows.
-        return np.vstack([t_x, t_z, t_y])
 
     @staticmethod
     def _get_terminal_reset_paulis(
@@ -1272,6 +1164,349 @@ class CircuitBuilder:
                 measurement_bases,
             )
         return back_pauli, measurement_qubit_indices
+
+
+    def apply_relay_chunk(self, circuit_chunk: stim.Circuit,
+                          noiseless: bool = False):
+        """
+        Process ONE round whose measurements may form an ancilla relay
+        (stabilizers handed between ancillas mid-round, e.g. the Y-basis
+        transition round of arXiv:2302.07395). The standard SE path's
+        per-measurement contract — each back-propagated measurement touches
+        other ancillas only in their reset basis — is unsound for such
+        rounds; this path solves the round's stabilizer flows with stim
+        (Circuit.flow_generators) and merges them with the tracker's
+        record-augmented rows. Detectors, new stabilizer rows and logical
+        transport all come out of one GF(2) solve; on a STANDARD round the
+        result is observationally identical to apply_syndrome_extraction.
+
+        The chunk may freely contain resets, unitaries (incl. XCY/SQRT_X),
+        transversal H regions, and M/MX/MY measurements anywhere.
+        """
+        from .relay_flow import solve_relay_round
+        from .tracker import _append_detector
+        from ..utils.tableau_utils import stabilizers_to_symplectic
+
+        base = self.tracker.total_measurements
+        stab_dicts = [self.system.stabilizers[i]
+                      for i in sorted(self.system.active_stabilizer_indices)]
+        canonical = stabilizers_to_symplectic(
+            self.system, stab_dicts, self.tracker.num_qubits) \
+            if stab_dicts else None
+        result = solve_relay_round(
+            chunk=circuit_chunk,
+            num_qubits=self.tracker.num_qubits,
+            stab_matrix=self.tracker.stabilizers.matrix,
+            stab_records=self.tracker.stabilizers.records,
+            log_matrix=self.tracker.logicals.matrix,
+            log_records=self.tracker.logicals.records,
+            base_record=base,
+            canonical_stabs=canonical,
+        )
+
+        if self.circuit and self.circuit[-1].name != "TICK":
+            self.circuit.append("TICK")
+        if noiseless:
+            for inst in circuit_chunk:
+                if isinstance(inst, stim.CircuitInstruction):
+                    self.circuit.append(inst.name, inst.targets_copy(),
+                                        inst.gate_args_copy(), tag="noiseless")
+                else:
+                    self.circuit.append(inst)
+        else:
+            self.circuit += circuit_chunk
+
+        measured = result.measured_qubits
+        self.tracker.meas_rec_to_idx_map.update(
+            {base + i: q for i, q in enumerate(measured)})
+        self.tracker.total_measurements += len(measured)
+        self.system.active_qubit_indices.update(measured)
+
+        if self.if_detector:
+            self.circuit.append("SHIFT_COORDS", [], [0, 0, 1])
+            total = self.tracker.total_measurements
+            labelled = []
+            for recs, coord_q in result.detectors:
+                coord = self.system.qubit_coords.get(coord_q)
+                coord = (list(coord) if coord is not None else [-1, -1]) + [0]
+                labelled.append((tuple(coord), sorted(recs)))
+            for coord, recs in sorted(labelled):
+                _append_detector(
+                    self.circuit,
+                    [stim.target_rec(r - total) for r in recs],
+                    list(coord),
+                    post_select=tuple(coord)
+                    in self.tracker.post_select_detector_coords,
+                )
+
+        self.tracker.stabilizers.matrix = result.new_stab_matrix
+        self.tracker.stabilizers.records = [list(r)
+                                            for r in result.new_stab_records]
+        self.tracker.logicals.matrix = result.new_log_matrix
+        self.tracker.logicals.records = [list(r)
+                                         for r in result.new_log_records]
+
+        # Logicals measured out by this chunk become logical observables: the
+        # emitted parity is the row's banked seed records XOR the chunk's
+        # measuring records (golden splits the same parity across its two
+        # OBSERVABLE_INCLUDE statements). The budget shrinks symmetrically to
+        # declare_logical's growth, keeping the census identity intact.
+        if result.measured_logicals:
+            total = self.tracker.total_measurements
+            for _, recs in result.measured_logicals:
+                obs_index = self.circuit.num_observables
+                self.circuit.append(
+                    "OBSERVABLE_INCLUDE",
+                    [stim.target_rec(r - total) for r in recs],
+                    [obs_index])
+                self.tracker.expected_num_logicals -= 1
+
+    # --------------------------------------------------------------------------
+    # C. Unitary Block (Logical Gates, Unitary Encoding, etc.)
+    # --------------------------------------------------------------------------
+    def apply_unitary_block(self, unitary_block: stim.Circuit, noiseless: bool = False):
+        """
+        Applies a unitary circuit block and updates the tracker's tableau.
+
+        This method is used for logical operations (e.g., transversal CNOT) that
+        need to update the stabilizer tableau to reflect the unitary transformation.
+
+        Args:
+            unitary_block: A Stim circuit containing only unitary operations (no measurements/resets).
+            noiseless: If True, tag all gate instructions with 'noiseless' so that
+                       noise injection rules skip them.
+        """
+        # Append the unitary block to the circuit
+        if self.circuit[-1].name != "TICK":
+            self.circuit.append("TICK")
+
+        if noiseless:
+            # Re-emit each instruction with the noiseless tag
+            for inst in unitary_block:
+                if isinstance(inst, stim.CircuitInstruction):
+                    self.circuit.append(
+                        inst.name, inst.targets_copy(), inst.gate_args_copy(),
+                        tag="noiseless",
+                    )
+        else:
+            self.circuit += unitary_block
+
+        # Update the tracker's tableau to reflect the unitary transformation
+        self.tracker.process_unitary_block(unitary_block)
+
+    # --------------------------------------------------------------------------
+    # D. Logical Coupler Activity, Stabilizer Masking/Unmasking
+    # --------------------------------------------------------------------------
+    def activate_coupler(self, name: str):
+        """
+        Turn on the logical coupler. A wrapper for QECSystem.activate_coupler.
+        This changes the active stabilizer set for the NEXT round of extraction.
+        """
+        # Call the system's state manager
+        self.system.activate_coupler(name)
+
+    def deactivate_coupler(self, name: str):
+        """
+        Turn off the logical coupler and restore original patch boundaries.
+        A wrapper for QECSystem.deactivate_coupler.
+        """
+        self.system.deactivate_coupler(name)
+
+    def mask_stabilizers(self, ids: Set[int]):
+        """
+        Mask (Deactivate) the stabilizers with the given ids.
+        To be implemented.
+        """
+        pass
+
+    def unmask_stabilizers(self, ids: Set[int]):
+        """
+        Unmask (Activate) the stabilizers with the given ids.
+        To be implemented.
+        """
+        pass
+
+
+    # --------------------------------------------------------------------------
+    # E. Data Qubit Measurement
+    # --------------------------------------------------------------------------
+    def apply_data_readout(self, final_measurements: Dict[int, str] = None, noiseless: bool = False,
+                           z_only: bool = False, resolve_absorbed: bool = True):
+        """
+        Applies destructive measurement on data qubits and calls Tracker to
+        resolve remaining stabilizers into Detectors/Observables.
+
+        Args:
+            final_measurements: Dict mapping qubit index to measurement basis ('X', 'Y', 'Z').
+            noiseless: If True, tag measurement instructions with 'noiseless' so that
+                       noise injection rules skip them.
+            z_only: If True, bypass tracker.process_data_measurement and construct
+                DETECTOR / OBSERVABLE_INCLUDE manually from Z-stabilizers and Z-logicals.
+                Requires apply_syndrome_extraction to have been called with z_only=True.
+        """
+        if final_measurements is None:
+            final_measurements = {q: 'Z' for q in self.system.data_indices}
+
+        # Final destructive data readout must start in a fresh moment. Some
+        # extraction blocks, such as middle-out color-code circuits, end with
+        # data-qubit gauge measurements instead of a trailing TICK.
+        if len(self.circuit) > 0 and self.circuit[-1].name != "TICK":
+            self.circuit.append("TICK")
+
+        xs = [q for q, b in final_measurements.items() if b == 'X']
+        ys = [q for q, b in final_measurements.items() if b == 'Y']
+        zs = [q for q, b in final_measurements.items() if b == 'Z']
+
+        tag = "noiseless" if noiseless else ""
+
+        # Append gates (No manual noise here)
+        if xs: self.circuit.append("MX", xs, tag=tag)
+        if ys: self.circuit.append("MY", ys, tag=tag)
+        if zs: self.circuit.append("M", zs, tag=tag)
+
+        # Prepare Basis for Tracker (order matches circuit: X then Y then Z)
+        sorted_indices = xs + ys + zs
+        n = self.tracker.num_qubits
+        final_paulis = np.zeros((len(sorted_indices), 2 * n), dtype=np.uint8)
+
+        for i, q in enumerate(sorted_indices):
+            basis = final_measurements[q]
+            if basis == 'X':
+                final_paulis[i, q] = 1
+            elif basis == 'Y':
+                final_paulis[i, q] = 1
+                final_paulis[i, n + q] = 1
+            else:
+                final_paulis[i, n + q] = 1
+
+        # Call Tracker — or, for z_only, build DETECTORs/OBSERVABLEs manually
+        if self.if_detector:
+            if z_only:
+                syn_qubit_indices = self._z_only_syn_qubit_indices
+                no_detector_mask  = self._z_only_no_detector_mask
+                n_meas_per_round  = self._z_only_n_meas_per_round
+                x_anc_set = {q for q, masked in zip(syn_qubit_indices, no_detector_mask) if masked}
+
+                data_indices = sorted_indices  # already M'd above in Z basis
+                data_pos     = {q: i for i, q in enumerate(data_indices)}
+                n_data       = len(data_indices)
+                z_anc_pos    = {q: i for i, q in enumerate(syn_qubit_indices) if q not in x_anc_set}
+
+                for stab in self.system.active_stabilizers_z:
+                    recs = [stim.target_rec(-n_data + data_pos[q]) for q in stab['data_indices']]
+                    recs.append(stim.target_rec(-n_data - n_meas_per_round + z_anc_pos[stab['syn_idx']]))
+                    self.circuit.append("DETECTOR", recs)
+
+                # Delegate observable generation to the tracker so it handles
+                # periodic-boundary codes (e.g. toric) correctly. We snapshot
+                # the circuit length, let the tracker append both DETECTORs and
+                # OBSERVABLE_INCLUDEs, then keep only the OBSERVABLE_INCLUDEs.
+                n_before = len(self.circuit)
+                self.tracker.process_data_measurement(
+                    circuit=self.circuit,
+                    final_paulis=final_paulis,
+                    idx_to_coord_map=self.system.qubit_coords,
+                    syndrome_qubit_indices=self.system.syndrome_indices,
+                    resolve_absorbed=resolve_absorbed,
+                )
+                obs_insts = [
+                    inst for inst in list(self.circuit)[n_before:]
+                    if not isinstance(inst, stim.CircuitRepeatBlock)
+                    and inst.name == "OBSERVABLE_INCLUDE"
+                ]
+                self.circuit = self.circuit[:n_before]
+                for inst in obs_insts:
+                    self.circuit.append(inst.name, inst.targets_copy(), inst.gate_args_copy())
+            else:
+                self.tracker.process_data_measurement(
+                    circuit=self.circuit,
+                    final_paulis=final_paulis,
+                    idx_to_coord_map=self.system.qubit_coords,
+                    syndrome_qubit_indices=self.system.syndrome_indices,
+                    resolve_absorbed=resolve_absorbed,
+                )
+
+        # Remove measured qubits from active set (ready for reuse)
+        self.system.active_qubit_indices.difference_update(final_measurements.keys())
+
+    # --------------------------------------------------------------------------
+    # F. Final Build & Noise Injection
+    # --------------------------------------------------------------------------
+    def build_noisy_circuit(
+        self, 
+        noise_params: NoiseConfig,
+        noise_model: str = 'circuit_level'
+    ) -> stim.Circuit:
+        """
+        Consumes the clean circuit and applies noise using the specified model strategy.
+        
+        Args:
+            noise_params: Noise parameters (NoiseConfig).
+            noise_model: The name of the factory method in NoiseInjector to use.
+                         e.g., 'circuit_level' -> calls NoiseInjector.from_circuit_level(...)
+                         e.g., 'custom_test'   -> calls NoiseInjector.from_custom_test(...)
+        """
+        # 1. Construct the expected factory method name
+        method_name = f"from_{noise_model}"
+        
+        # 2. Dynamically retrieve the method from the NoiseInjector class
+        if not hasattr(NoiseInjector, method_name):
+            # Fallback or nice error message showing available options
+            valid_methods = [m.replace("from_", "") for m in dir(NoiseInjector) if m.startswith("from_")]
+            raise ValueError(f"Unknown noise model '{noise_model}'. "
+                             f"Expected one of: {valid_methods}")
+        
+        factory_method = getattr(NoiseInjector, method_name)
+        
+        # 3. Inject noise
+        # Assumptions: All factory methods must accept (config, data_qubits)
+        data_indices = [self.system.index_map[coord] for coord in self.system.data_coords]
+        injector = factory_method(noise_params, data_indices)
+        noisy_circuit = injector.inject_noise(self.circuit)
+
+        return noisy_circuit
+
+    # --------------------------------------------------------------------------
+    # G. Helpers
+    # --------------------------------------------------------------------------
+    @staticmethod
+    def _get_initialization_tableau(qubit_indices_x: List[int], qubit_indices_z: List[int], qubit_indices_y: List[int], n: int):
+        """
+        Generates the tableau for the given qubit indices in X, Z, Y basis.
+        Args:
+            qubit_indices_x: List[int]
+            qubit_indices_z: List[int]
+            qubit_indices_y: List[int]
+            n: int
+        Returns:
+            initialized_tableau: np.ndarray
+        """
+        # 1. X Basis: (X=1, Z=0)
+        # Shape is (len, 2n). If len=0, it's safe.
+        t_x = np.zeros((len(qubit_indices_x), 2 * n), dtype=int)
+        if qubit_indices_x:
+            t_x[np.arange(len(qubit_indices_x)), qubit_indices_x] = 1
+
+        # 2. Z Basis: (X=0, Z=1)
+        t_z = np.zeros((len(qubit_indices_z), 2 * n), dtype=int)
+        if qubit_indices_z:
+            # Use list comprehension or numpy add to shift index by n
+            cols = [i + n for i in qubit_indices_z]
+            t_z[np.arange(len(qubit_indices_z)), cols] = 1
+
+        # 3. Y Basis: (X=1, Z=1) -> Critical Fix here
+        t_y = np.zeros((len(qubit_indices_y), 2 * n), dtype=int)
+        if qubit_indices_y:
+            # Set X part
+            t_y[np.arange(len(qubit_indices_y)), qubit_indices_y] = 1
+            # Set Z part (same row!)
+            cols_z = [i + n for i in qubit_indices_y]
+            t_y[np.arange(len(qubit_indices_y)), cols_z] = 1
+
+        # 4. Stack
+        # Since all sub-matrices have 2*n columns, vstack works even if some have 0 rows.
+        return np.vstack([t_x, t_z, t_y])
+
 
     def to_stim_circuit(self) -> stim.Circuit:
         return self.circuit

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -1254,11 +1254,10 @@ class CircuitBuilder:
         if result.measured_logicals:
             total = self.tracker.total_measurements
             for _, recs in result.measured_logicals:
-                obs_index = self.circuit.num_observables
                 self.circuit.append(
                     "OBSERVABLE_INCLUDE",
                     [stim.target_rec(r - total) for r in recs],
-                    [obs_index])
+                    [self.tracker.allocate_observable()])
                 self.tracker.expected_num_logicals -= 1
 
     # --------------------------------------------------------------------------

--- a/lightstim/ir/qec_patch.py
+++ b/lightstim/ir/qec_patch.py
@@ -301,7 +301,32 @@ class QECPatch(ABC):
 
         # 5. Update accumulated rotation angle and rebuild grid map
         self.rotation_angle = (self.rotation_angle + theta) % (2 * np.pi)
-    
+
+    def rotate_90(self, clockwise: bool = True):
+        """Rotate the whole patch exactly 90° about its bounding-box centre.
+
+        Clockwise (default) sends the base ``X_vertical`` patch to
+        ``X_horizontal``: X̄ vertical→horizontal, Z̄ horizontal→vertical, the
+        checkerboard carried with it and every stabilizer/logical Pauli TYPE
+        preserved (``U_L = I`` — a pure geometric rotation, NOT a Hadamard).
+
+        Only coordinate metadata moves; the index-keyed stabilizer/logical
+        records are untouched (they follow the qubits).  Coordinates are snapped
+        back onto the integer lattice so no float drift accumulates — a rotated
+        patch is byte-identical to the shape the routed coupler builds for a
+        minority patch, so the existing native-lock / bus machinery hosts it.
+        """
+        self.rotate_coords(-np.pi / 2 if clockwise else np.pi / 2)
+        # kill the ~1e-16 float drift from cos/sin(π/2) so coords stay exact
+        self.qubit_coords = {i: self.snap_coord(c)
+                             for i, c in self.qubit_coords.items()}
+        self.index_map = {c: i for i, c in self.qubit_coords.items()}
+        self._rebuild_grid_map()
+        for stab in self.stabilizers:
+            idx = stab.get('syn_idx')
+            if idx is not None and idx in self.qubit_coords:
+                stab['syn_coord'] = self.qubit_coords[idx]
+
     def _get_bounds(self) -> Tuple[float, float, float, float]:
         """Returns (min_x, max_x, min_y, max_y)"""
         xs = [c[0] for c in self.qubit_coords.values()]

--- a/lightstim/ir/qec_system.py
+++ b/lightstim/ir/qec_system.py
@@ -197,6 +197,7 @@ class QECSystem:
         # 2. Global Identity Registration
         local_to_global_map = {}
         self.local_to_global_map[name] = {}
+        reused_indices = []
 
         for global_coord, local_index in patch.index_map.items(): # the patch is already shifted to the global coordinate system
 
@@ -210,6 +211,7 @@ class QECSystem:
                     )
                 # Reuse dormant qubit index (measured, ready for reuse)
                 idx = existing_idx
+                reused_indices.append(idx)
             else:
                 # New qubit — assign fresh index
                 idx = self.next_index
@@ -235,6 +237,29 @@ class QECSystem:
             if hasattr(patch, 'syndrome_indices_z'):
                 if local_index in patch.syndrome_indices_z:
                     self.syndrome_indices_z.add(idx)
+
+        # A reused dormant index must stop counting as retired: the retire
+        # bookkeeping (Fix C absorbed resolution, retired-qubit masking)
+        # would otherwise treat the LIVE qubit as measured-out.  The tracker
+        # rows were eliminated from these columns at retirement, so any
+        # remaining support means the retirement was incomplete — fail loud
+        # rather than build on a stale tableau.
+        tracker = getattr(self, "_tracker", None)
+        if tracker is not None and reused_indices:
+            stale = sorted(q for q in reused_indices
+                           if q in tracker.retired_qubits)
+            if stale:
+                n_t = tracker.num_qubits
+                cols = [q for q in stale] + [n_t + q for q in stale]
+                for tab_label, tab in (("stabilizers", tracker.stabilizers),
+                                       ("logicals", tracker.logicals),
+                                       ("absorbed_ops", tracker.absorbed_ops)):
+                    if tab.count and tab.matrix[:, cols].any():
+                        raise RuntimeError(
+                            f"add_patch('{name}'): reusing retired qubits "
+                            f"{stale}, but tracker {tab_label} rows still "
+                            f"reference them — stale retirement state.")
+                tracker.retired_qubits.difference_update(stale)
 
         # 3. Stabilizer and Logical Operator Translation
         stabilizer_indices = []

--- a/lightstim/ir/qec_system.py
+++ b/lightstim/ir/qec_system.py
@@ -1,4 +1,5 @@
 import stim
+import numpy as np
 from typing import Dict, List, Tuple, Set, Any, Optional
 from dataclasses import dataclass
 from lightstim.ir.qec_patch import QECPatch
@@ -66,6 +67,9 @@ class QECSystem:
         # Define-by-run: optional tracker and builder to auto-sync when add_patch adds new qubits
         self._tracker: Optional[Any] = None
         self._builder: Optional[Any] = None
+
+        # grow_patch bookkeeping for repair_grow_logicals: patch_name -> orphan info
+        self._grow_repairs: Dict[str, Dict[str, Any]] = {}
 
     def register_tracker(self, tracker: Any):
         """Register a SyndromeTracker for define-by-run. When add_patch adds qubits, tracker.expand() is called automatically."""
@@ -182,7 +186,8 @@ class QECSystem:
             name = f"patch_{len(self.patches)+ len(self.coupler_patches)}"
 
         n_old = self.next_index  # for define-by-run: new qubits will be n_old, n_old+1, ...
-        
+        n_log_old = self.num_logicals  # define-by-run: budget grows by THIS patch's logicals
+
         # 1. Store reference
         patch = copy.deepcopy(patch)
         patch.shift_coords(offset[0], offset[1])
@@ -322,16 +327,487 @@ class QECSystem:
                 if coord in self.index_map:
                     stabilizer['syn_idx'] = self.index_map[coord]
 
-        # Define-by-run: auto-expand tracker, sync expected_num_logicals, append QUBIT_COORDS for new qubits
+        # Define-by-run: auto-expand tracker, GROW the logical budget by exactly this
+        # patch's logicals, append QUBIT_COORDS for new qubits.
         if self._tracker is not None:
             n_new = self.num_qubits
             if n_new > self._tracker.num_qubits:
                 self._tracker.expand(n_new - self._tracker.num_qubits)
-            self._tracker.expected_num_logicals = self.num_logicals
+            # Increment, do NOT reset to self.num_logicals: a mid-sequence registration
+            # (after an earlier PPM already consumed logical DOF) must not clobber the
+            # reduced budget back up to the stale static total. For registration before
+            # any consumption this equals the old `expected := num_logicals` (they match
+            # then); a coupler adds 0 logicals, so it leaves the budget untouched.
+            self._tracker.expected_num_logicals += self.num_logicals - n_log_old
         if self._builder is not None and n_old < self.num_qubits:
             self._builder.append_coordinates_for_new_qubits(n_old)
 
         return global_patch
+
+    def grow_patch(self, name: str, new_patch: QECPatch, offset: Tuple[float, float] = (0, 0)):
+        """Grow a LIVE patch onto a LARGER footprint (Litinski's *moving boundaries*,
+        `A Game of Surface Codes` Fig 40c) — the first atom of a patch rotation.
+
+        ``new_patch`` is the enlarged reference geometry (e.g.
+        ``RotatedSurfaceCode(distance_x=d, distance_z=2*d+1)``) placed at ``offset`` so
+        that it COVERS the patch's current qubits at their current coordinates.  Those
+        shared qubits keep their existing global indices, so every index-keyed record and
+        the index-based ``SyndromeTracker`` stay valid, and — because a stabilizer's
+        signature is ``(type, global data indices)`` — every check that the enlarged code
+        shares with the old one **keeps its uid** and therefore its detector history.  That
+        is what anchors the growth: extending a ``d×d`` patch by one tile keeps 7 of its 8
+        checks verbatim (only the weight-2 on the boundary being extended through changes),
+        so there is no blind round.
+
+        The freshly added data qubits are returned; the caller initialises them in the
+        basis OF THE LOGICAL BEING EXTENDED — growth through a Z boundary extends Z̄,
+        so the new region is |0⟩ (NOT |+⟩: that leaves a one-round detector-free
+        handoff window, measured graphlike distance 1) — and runs ``d`` SE rounds with
+        the DIAGONAL schedule (``DiagonalSurfaceCodeExtractionBlock``; every N/Z
+        zigzag caps the deformed patch's distance).  Under that init every new
+        same-type check is first-round deterministic, so the retiring growth-edge
+        lobes' enlarged successors continue their banked values (bridging detectors)
+        and the handoff window is fully detector-spanned — see
+        docs/specs/litinski-patch-rotation.md (bridging detectors).
+
+        Returns ``(new_data_indices, new_syndrome_indices)``.
+        """
+        if name not in self.patches:
+            raise ValueError(f"patch {name!r} is not in the system")
+        old_idxs = {i for i, o in self.index_to_owner_map.items() if o == name}
+        if not old_idxs:
+            raise ValueError(f"patch {name!r} has no qubits in the system")
+
+        grown = copy.deepcopy(new_patch)
+        grown.shift_coords(offset[0], offset[1])
+
+        # every current DATA qubit of the patch must still be covered by the grown
+        # geometry, else the deformation would silently drop live information.
+        # Syndrome ancillas MAY be dropped (move_corners retires boundary lobes whose
+        # ancilla site the new boundary no longer uses) — a dropped ancilla simply
+        # stops appearing in active_syndrome_indices once its check deactivates; its
+        # cell stays owned by the patch until a shrink/retire releases it.
+        grown_coords = set(grown.index_map)
+        # retired data qubits (an earlier shrink's bar, an absorbed corridor)
+        # carry no live information — their records are folded into the
+        # tracker — so they are exempt from the coverage requirement; the
+        # geometry engine below re-initialises any the new geometry re-occupies
+        retired = (self._tracker.retired_qubits if self._tracker is not None
+                   else frozenset())
+        missing = {self.qubit_coords[i] for i in old_idxs
+                   if i in self.data_indices and i not in retired} - grown_coords
+        if missing:
+            raise ValueError(
+                f"grow_patch({name!r}): the new geometry does not cover {len(missing)} "
+                f"of the patch's current data qubits (e.g. {sorted(missing)[:3]}); it "
+                f"must cover them all, placed so shared qubits keep their coordinates")
+        return self._apply_patch_geometry(name, grown, offset)
+
+    def _apply_patch_geometry(self, name: str, grown: QECPatch,
+                              offset: Tuple[float, float]):
+        """Shared deformation engine behind grow_patch / move_corners / shrink_patch.
+
+        ``grown`` is the ALREADY-SHIFTED reference geometry.  Maps its local indices
+        onto global ones (shared coords keep their index), re-registers the
+        stabilizers (identical signatures keep their uid — detector continuity),
+        records retiring-check/orphan bookkeeping in ``_grow_repairs[name]``, swaps in
+        the geometry's logical operator records, and syncs tracker/builder.
+        Returns ``(new_data_indices, new_syndrome_indices)``."""
+        n_old_qubits = self.next_index
+        old_idxs = {i for i, o in self.index_to_owner_map.items() if o == name}
+
+        # ---- 1. map the grown geometry's local indices onto global ones -------------
+        l2g = {}
+        new_data, new_syn = [], []
+        for coord, local_index in grown.index_map.items():
+            existing = self.index_map.get(coord)
+            if existing is not None:
+                owner = self.coord_to_owner_map.get(coord)
+                if owner not in (None, name) and existing in self.active_qubit_indices:
+                    raise ValueError(
+                        f"grow_patch({name!r}): coordinate {coord} is occupied by ACTIVE "
+                        f"patch {owner!r}; the growth region must be free")
+                idx = existing
+                # a DORMANT qubit of this patch (measured out by an earlier shrink,
+                # flagged retired in the tracker) that the new geometry re-occupies is
+                # FRESH again: it needs re-initialisation, so it must be returned in
+                # new_data — the rotation's move-back (Fig 45 step 7→8) regrows the
+                # bar over the cells the first shrink retired.
+                was_retired = (self._tracker is not None
+                               and idx in self._tracker.retired_qubits)
+                fresh = idx not in old_idxs or was_retired
+                if was_retired:
+                    self._tracker.retired_qubits.discard(idx)
+            else:
+                idx = self.next_index
+                self.next_index += 1
+                fresh = True
+            self.index_map[coord] = idx
+            self.qubit_coords[idx] = coord
+            self.coord_to_owner_map[coord] = name
+            self.grid_map[grown.get_grid_key(coord)] = idx
+            self.index_to_owner_map[idx] = name
+            l2g[local_index] = idx
+            if local_index in grown.data_indices:
+                self.data_indices.add(idx)
+                if fresh:
+                    new_data.append(idx)
+            if local_index in grown.syndrome_indices:
+                self.syndrome_indices.add(idx)
+                if fresh:
+                    new_syn.append(idx)
+            if local_index in getattr(grown, 'syndrome_indices_x', ()):
+                self.syndrome_indices_x.add(idx)
+            if local_index in getattr(grown, 'syndrome_indices_z', ()):
+                self.syndrome_indices_z.add(idx)
+            # NOTE: deliberately NOT touching active_qubit_indices — add_patch does not
+            # populate it either (it is the dormant-reuse ledger that retire_* maintains),
+            # and diverging here would make a grown patch behave differently from a
+            # normally-added one when its cells are later reused.
+        self.local_to_global_map[name] = dict(l2g)
+
+        # ---- 2. re-register the stabilizers; shared ones keep their uid -------------
+        old_uids = {uid for uid, s in enumerate(self.stabilizers)
+                    if s.get('patch_name') == name}
+        self.active_stabilizer_indices.difference_update(old_uids)
+        grown_uids = []
+        for stab in grown.stabilizers:
+            g = self._translate_record(stab, l2g)
+            g['patch_name'] = name
+            signature = (g['type'], tuple(sorted(g['data_indices'])))
+            uid = self._stabilizer_signatures.get(signature)
+            if uid is None:
+                uid = len(self.stabilizers)
+                self.stabilizers.append(g)
+                self._stabilizer_signatures[signature] = uid
+            else:
+                # the signature can also match a DEAD region's record (an
+                # absorbed corridor this geometry regrows over) — reclaim
+                # ownership, or every patch_name-keyed scan (shrink coverage
+                # criterion, retire, SE selection) misses the revived check
+                self.stabilizers[uid]['patch_name'] = name
+            grown_uids.append(uid)
+        self.active_stabilizer_indices.update(grown_uids)
+        grown._registered_stabilizer_uids = set(grown_uids)
+
+        # ---- 2b. orphan bookkeeping for repair_grow_logicals ------------------------
+        # A retiring growth-edge check's data qubit is ORPHANED when every same-type
+        # check covering it in the grown code is NEW (first outcome random under the
+        # fresh-qubit init) — the one-round handoff there is not detector-spanned.
+        retiring = old_uids - set(grown_uids)
+        kept = old_uids & set(grown_uids)
+        orphans = set()
+        for uid in retiring:
+            s = self.stabilizers[uid]
+            for q in s['data_indices']:
+                covered = any(
+                    q in self.stabilizers[u]['data_indices']
+                    and self.stabilizers[u]['type'] == s['type']
+                    for u in kept)
+                if not covered:
+                    orphans.add(q)
+        self._grow_repairs[name] = {'orphans': orphans, 'retired_uids': retiring}
+
+        # ---- 3. swap in the enlarged logical operators (the patch still holds 1) ----
+        self.logical_ops = [l for l in self.logical_ops if l.get('patch_name') != name]
+        for op in grown.logical_ops:
+            g = self._translate_record(op, l2g)
+            g['patch_name'] = name
+            self.logical_ops.append(g)
+
+        self.patches[name] = (grown, offset)
+
+        # ---- 4. define-by-run bookkeeping (qubit count only; k is unchanged) --------
+        if self._tracker is not None and self.num_qubits > self._tracker.num_qubits:
+            self._tracker.expand(self.num_qubits - self._tracker.num_qubits)
+        if self._builder is not None and n_old_qubits < self.num_qubits:
+            self._builder.append_coordinates_for_new_qubits(n_old_qubits)
+        return new_data, new_syn
+
+    def grow_init_bases(self, name: str, new_data: List[int], boundary_type: str = 'Z'):
+        """Per-qubit init bases for the qubits added by the last :meth:`grow_patch`.
+
+        Growing through a ``boundary_type`` boundary initialises the new region in the
+        CONJUGATE basis (Z boundary → |+⟩, X boundary → |0⟩) — Fig 40c/41's ancilla
+        prescription, which makes the conjugate-type new checks trivial-outcome
+        (deterministic) on their first round.
+
+        EXCEPT: each RETIRING growth-edge check dissolves into an enlarged successor,
+        and the successor's first outcome must deterministically continue the retired
+        check's banked value, else the handoff window is spanned by no detector and a
+        single data error on the retired check's outer qubit flips the logical frame
+        silently (measured: graphlike distance 1).  The qubits the successor ADDS are
+        therefore initialised in the retiring check's OWN basis (Z lobe → |0⟩), which
+        pins the added factor to +1 and turns the successor's first round into the
+        bridging detector.  This mixed product state is exactly the fused equivalent of
+        the decomposed surgery's "prepare the |+̄⟩ ancilla patch and let its boundary
+        settle, then merge": an X̄ = +1 ancilla state whose merge-facing boundary lobe
+        is already sharp.
+        """
+        info = self._grow_repairs.get(name)
+        conj = {'Z': 'X', 'X': 'Z'}
+        bases = {q: conj[boundary_type] for q in new_data}
+        if info:
+            grown_uids = {uid for uid, s in enumerate(self.stabilizers)
+                          if s.get('patch_name') == name
+                          and uid in self.active_stabilizer_indices}
+            for uid in info['retired_uids']:
+                r = self.stabilizers[uid]
+                r_sup = set(r['data_indices'])
+                for u in grown_uids:
+                    s = self.stabilizers[u]
+                    if s['type'] == r['type'] and r_sup < set(s['data_indices']):
+                        for q in set(s['data_indices']) - r_sup:
+                            if q in bases:
+                                bases[q] = r['type']
+        return bases
+
+    def move_corners(self, name: str, new_patch: QECPatch, offset: Tuple[float, float] = (0, 0)):
+        """Move the corners of a LIVE patch (Litinski Fig 40b; Fig 45 step 5→6) —
+        the second atom of a patch rotation.
+
+        ``new_patch`` is a reference geometry with the SAME data-qubit footprint but a
+        different boundary stabilizer set (e.g. one long edge flipped X↔Z, which slides
+        the same-type corner wrap from one end of the bar to the other).  The bulk and
+        every unchanged boundary check keep their uid — signature-based dedup — so
+        their detector history continues; the retiring boundary checks deactivate and
+        the replacement checks are measured fresh (their first outcomes gauge-fix
+        against the retired anticommuting lobes, so they get no first-round detector).
+        No data qubits are added or removed and nothing is initialised; the caller
+        just runs **d** SE rounds afterwards (diagonal schedule — the deformed
+        logical representatives bend).
+
+        Returns ``(new_data, new_syn)`` from the underlying re-registration;
+        ``new_data`` is asserted empty (``new_syn`` may contain the fresh boundary
+        ancillas).  Retiring-check bookkeeping lands in ``_grow_repairs[name]``,
+        overwriting the previous deformation's entry.
+        """
+        retired = (self._tracker.retired_qubits if self._tracker is not None
+                   else frozenset())
+        old_data_coords = {self.qubit_coords[i]
+                           for i, o in self.index_to_owner_map.items()
+                           if o == name and i in self.data_indices
+                           and i not in retired}
+        shifted = copy.deepcopy(new_patch)
+        shifted.shift_coords(offset[0], offset[1])
+        new_data_coords = {shifted.qubit_coords[i] for i in shifted.data_indices}
+        if new_data_coords != old_data_coords:
+            raise ValueError(
+                f"move_corners({name!r}): data footprint must be unchanged "
+                f"(+{len(new_data_coords - old_data_coords)}/"
+                f"-{len(old_data_coords - new_data_coords)} qubits); "
+                f"use grow_patch/shrink_patch for footprint changes")
+        new_data, new_syn = self.grow_patch(name, new_patch, offset)
+        assert not new_data
+        return new_data, new_syn
+
+    def shrink_patch(self, name: str, new_patch: QECPatch,
+                     offset: Tuple[float, float] = (0, 0)):
+        """Shrink a LIVE patch onto a SMALLER footprint (Fig 40c's shortening;
+        Fig 45 step 6→7) — the third atom of a patch rotation.
+
+        Call AFTER destructively measuring the removed region through the builder::
+
+            removed = [data qubits leaving the patch]
+            builder.apply_data_readout(final_measurements={q: 'X' for q in removed})
+            system.shrink_patch(name, shrunk_geometry, offset)
+
+        The measurement basis is X when the patch was grown/extended through a Z
+        boundary (Fig 40c: "measuring the left two thirds of physical qubits in the
+        X basis"; K&F reference implementation: ``measurement="x"``).
+
+        Mechanics: checks fully inside the surviving footprint keep their uid; checks
+        touching the removed region deactivate; a cut-line check reappears TRUNCATED
+        (same type, support = old ∩ surviving, new uid) and its value continuity is
+        automatic — ``tracker.retire_qubits`` folds the readout records into the
+        truncated row, so its first post-shrink measurement is deterministic (a
+        bridging detector).  The detection-coverage criterion (handoff §3.2) is
+        asserted: every surviving data qubit keeps both-type coverage via kept-uid
+        checks or truncated successors; a violation means a silent handoff window and
+        raises instead of building a distance-broken circuit.
+
+        The removed data qubits become dormant (reusable cells); their indices stay
+        allocated (masked) so global indexing is stable.  Returns them sorted.
+        """
+        if name not in self.patches:
+            raise ValueError(f"patch {name!r} is not in the system")
+        old_idxs = {i for i, o in self.index_to_owner_map.items() if o == name}
+        # retired data qubits (dormant cells from an earlier shrink/absorb) are
+        # not part of the live footprint: they must not enter removed/surviving
+        # or the coverage criterion below would demand checks on dead qubits
+        retired = (self._tracker.retired_qubits if self._tracker is not None
+                   else frozenset())
+        old_data = {i for i in old_idxs
+                    if i in self.data_indices and i not in retired}
+        if not old_data:
+            raise ValueError(f"patch {name!r} has no data qubits in the system")
+        shrunk = copy.deepcopy(new_patch)
+        shrunk.shift_coords(offset[0], offset[1])
+        new_coords = {shrunk.qubit_coords[i] for i in shrunk.data_indices}
+        old_coords = {self.qubit_coords[i] for i in old_data}
+        extra = new_coords - old_coords
+        if extra:
+            raise ValueError(
+                f"shrink_patch({name!r}): the new geometry adds {len(extra)} data "
+                f"qubits (e.g. {sorted(extra)[:3]}); use grow_patch to enlarge")
+        removed = {i for i in old_data if self.qubit_coords[i] not in new_coords}
+        if not removed:
+            raise ValueError(
+                f"shrink_patch({name!r}): nothing to remove — use move_corners for "
+                f"same-footprint boundary changes")
+
+        # snapshot pre-shrink active checks for the coverage criterion below
+        old_active = {u for u in self.active_stabilizer_indices
+                      if self.stabilizers[u].get('patch_name') == name}
+        old_checks = [(self.stabilizers[u]['type'],
+                       frozenset(self.stabilizers[u]['data_indices']))
+                      for u in old_active]
+
+        new_data, new_syn = self._apply_patch_geometry(name, shrunk, offset)
+        assert not new_data, "shrink_patch must not add data qubits"
+
+        # ---- detection-coverage handoff criterion (handoff §3.2) --------------------
+        surviving = old_data - removed
+        safe_checks = []
+        for u in self.active_stabilizer_indices:
+            s = self.stabilizers[u]
+            if s.get('patch_name') != name:
+                continue
+            sup = frozenset(s['data_indices'])
+            kept = u in old_active
+            truncated = any(t == s['type'] and sup == (osup & surviving)
+                            for t, osup in old_checks)
+            if kept or truncated:
+                safe_checks.append((s['type'], sup))
+        holes = []
+        for q in sorted(surviving):
+            for etype, catcher in (('X', 'Z'), ('Z', 'X')):
+                if not any(t == catcher and q in sup for t, sup in safe_checks):
+                    holes.append((q, etype))
+        if holes:
+            raise ValueError(
+                f"shrink_patch({name!r}): detection-coverage handoff broken at "
+                f"{holes[:4]}{'…' if len(holes) > 4 else ''} — a window error there "
+                f"would be silently absorbed (handoff §3.2 criterion)")
+
+        # ---- tracker: retire the measured-out qubits (folds readout records into
+        # truncated stabilizer rows and logical rows), free the cells ---------------
+        if self._tracker is not None:
+            self._tracker.retire_qubits(removed)
+            self.num_logicals = self._tracker.expected_num_logicals
+        self.active_qubit_indices.difference_update(removed)
+        return sorted(removed)
+
+    def repair_grow_logicals(self, name: str, tracker: Optional[Any] = None):
+        """Re-anchor the tracker's logical rows after :meth:`grow_patch`.  Call ONCE,
+        after the first post-grow syndrome-extraction call and before any readout.
+
+        Growing retires the growth-edge boundary checks (their plaquettes gain the new
+        data qubits and become bulk).  A data qubit whose same-type coverage was ONLY
+        those retired checks is ORPHANED across the handoff: the enlarged check that
+        takes over starts with a RANDOM first outcome (fresh |+>/|0> neighbours), so no
+        detector spans the last-old-round → first-new-round window there.  Any logical
+        row whose data support rests on an orphaned qubit is flippable by a SINGLE
+        error in that window (measured: graphlike distance 1 for Z memory across a
+        Z-boundary grow, from the retired lobe's outer corner qubit).
+
+        The repair multiplies each affected logical row by grown-code checks (GF(2)
+        solve) so its support avoids every orphaned qubit, and installs the result via
+        ``tracker.logical_canonicalization``, which folds the correct records — the
+        straddling new check's own banked record replaces the orphaned data legs, and
+        that record IS detector-protected from its second round on.
+        """
+        from lightstim.utils.linear_algebra import solve_linear_decomposition
+
+        tracker = tracker if tracker is not None else self._tracker
+        if tracker is None:
+            raise ValueError(
+                "repair_grow_logicals needs a tracker (register_tracker or pass one)")
+        info = self._grow_repairs.get(name)
+        if not info or not info['orphans']:
+            return
+        orphans = sorted(info['orphans'])
+        n = tracker.num_qubits
+
+        def vec_of(stab):
+            v = np.zeros(2 * n, dtype=np.uint8)
+            for q, p in stab['pauli'].items():
+                v[q if p == 'X' else n + q] = 1
+            return v
+
+        check_rows = [vec_of(self.stabilizers[uid])
+                      for uid in sorted(self.active_stabilizer_indices)
+                      if self.stabilizers[uid].get('patch_name') == name]
+        if not check_rows:
+            return
+        C = np.array(check_rows, dtype=np.uint8)
+        ocols = [q for q in orphans] + [n + q for q in orphans]
+
+        for r in range(tracker.logicals.count):
+            row = tracker.logicals.matrix[r]
+            if not row[ocols].any():
+                continue
+            coeffs, dep, _ = solve_linear_decomposition(
+                basis=C[:, ocols],
+                targets=row[ocols].reshape(1, -1),
+                reduce_weight=False,
+            )
+            if not dep[0]:
+                raise ValueError(
+                    f"repair_grow_logicals({name!r}): logical row {r} cannot be moved "
+                    f"off orphaned qubits {orphans} with the grown checks — no "
+                    f"fault-tolerant representative exists in the grown code")
+            target = ((row + coeffs[0].astype(np.uint8) @ C) % 2).astype(np.uint8)
+            tracker.logical_canonicalization({r: target})
+
+    def rotate_patch(self, name: str, clockwise: bool = True):
+        """Rotate a LIVE patch 90° in place, about its own bounding-box centre.
+
+        Only COORDINATE metadata moves: the patch's qubit coords in the global
+        maps (``qubit_coords`` / ``index_map`` / ``grid_map`` / owner map) are
+        rotated and snapped back onto the integer lattice, and each of the
+        patch's stabilizer ``syn_coord`` is refreshed to its qubit's new coord.
+        The index-keyed stabilizer/logical records are left untouched — they
+        follow the qubits — so the index-based ``SyndromeTracker`` is unaffected.
+
+        A d×d rotated surface-code patch's full qubit footprint is invariant
+        under a 90° turn about its centre (data + syndrome coords map onto the
+        same set), so no coord collides with another patch; only the
+        coord↔index assignment inside this patch permutes.  The resulting
+        checkerboard is byte-identical to the conjugate-convention construction
+        the routed coupler hosts natively (rule-0 lock) — see
+        ``tests/test_patch_rotation.py`` — so a rotated patch merges at full
+        distance when its next coupler is registered with the flipped
+        orientation."""
+        idxs = [i for i, o in self.index_to_owner_map.items() if o == name]
+        if not idxs:
+            raise ValueError(f"patch {name!r} has no qubits in the system")
+        xs = [self.qubit_coords[i][0] for i in idxs]
+        ys = [self.qubit_coords[i][1] for i in idxs]
+        cx, cy = (min(xs) + max(xs)) / 2.0, (min(ys) + max(ys)) / 2.0
+        theta = -np.pi / 2 if clockwise else np.pi / 2
+        old = {i: self.qubit_coords[i] for i in idxs}
+        # drop the pre-rotation coord keys for this patch (footprint is invariant,
+        # so the rotated coords re-fill exactly this set — no leftover, no clash)
+        for i, c in old.items():
+            if self.index_map.get(c) == i:
+                del self.index_map[c]
+            gk = QECPatch.get_grid_key(c)
+            if self.grid_map.get(gk) == i:
+                del self.grid_map[gk]
+            if self.coord_to_owner_map.get(c) == name:
+                del self.coord_to_owner_map[c]
+        for i, c in old.items():
+            nc = QECPatch.snap_coord(QECPatch._rotate_transform(c, theta, (cx, cy)))
+            self.qubit_coords[i] = nc
+            self.index_map[nc] = i
+            self.grid_map[QECPatch.get_grid_key(nc)] = i
+            self.coord_to_owner_map[nc] = name
+        for stab in self.stabilizers:
+            if stab.get('patch_name') == name:
+                si = stab.get('syn_idx')
+                if si is not None and si in self.qubit_coords:
+                    stab['syn_coord'] = self.qubit_coords[si]
 
     # ======================================================================
     # Helper Methods
@@ -540,6 +1016,39 @@ class QECSystem:
         
         # B. Restore Original Stabilizers
         self.active_stabilizer_indices.update(restored_uids)
+
+    def retire_measured_patch(self, name):
+        """After a patch's data qubits have been destructively measured out, free
+        it: deactivate its stabilizers and retire its qubits from the tracker
+        (clean shrink), then re-sync the logical budget to the standing logical
+        count. Qubit indices stay allocated (masked) so global indexing is stable."""
+        # NOTE: unlike remove_coupler, we intentionally do NOT prune data_indices /
+        # index_to_owner_map / qubit_coords here — the retired patch's coords linger
+        # harmlessly (SE only measures ACTIVE stabilizers) and the end-readout + noise
+        # injection still resolve them. Masking (not deleting) keeps global indices stable.
+        dq = {q for q in self.data_indices if self.index_to_owner_map.get(q) == name}
+        if not dq:
+            return
+        dead = {uid for uid in list(self.active_stabilizer_indices)
+                if self.stabilizers[uid].get('patch_name') == name}
+        self.active_stabilizer_indices.difference_update(dead)
+        if self._tracker is not None:
+            self._tracker.retire_qubits(dq)
+            # NOTE: the budget (expected_num_logicals) is NOT touched here. The patch's
+            # destructive readout — apply_data_readout, run just before this call —
+            # already decremented `expected` by exactly the number of live logical DOFs
+            # it resolved (free ones consumed and/or absorbed relations read out). We
+            # deliberately do NOT re-sync expected := standing (+ absorbed): that would
+            # slave the independent budget to the tableau matrices and silently erase any
+            # prior discrepancy the guardrail is meant to catch.
+            # Keep the system's STATIC logical count mirroring the tracker's dynamic
+            # budget so a LATER define-by-run registration (add_patch) grows from the
+            # right base instead of a stale global count.
+            self.num_logicals = self._tracker.expected_num_logicals
+        # Make the retired data qubits DORMANT so their coarse cells can be reused as a
+        # later coupler's corridor: add_patch reuses an existing coord's index only when
+        # that index is NOT in active_qubit_indices (else it raises an ACTIVE collision).
+        self.active_qubit_indices.difference_update(dq)
 
     def remove_coupler(self, coupler_name: str):
         """

--- a/lightstim/ir/relay_flow.py
+++ b/lightstim/ir/relay_flow.py
@@ -1,0 +1,497 @@
+"""Flow-solved processing of ancilla-relay rounds.
+
+A relay round hands stabilizer checks between ancillas mid-round (e.g. the
+Y-basis transition round of arXiv:2302.07395, Fig. 5/7): individual
+measurements are not data-only Pauli observables — only GF(2) COMBINATIONS
+of the round's measurements are. The standard SE path's per-measurement
+contract (each back-propagated measurement touches other ancillas only in
+their reset basis) is unsound there, so this module solves the round's
+stabilizer flows with stim.Circuit.flow_generators() and merges them with
+the tracker's record-augmented account book, emulating WriteBack semantics:
+
+  1. CANONICAL FRESH ROWS — for every registered target stabilizer S' of the
+     post-round configuration, solve   1 -> S' (xor) rec[..]   over the flow
+     group (allowing pinned input rows on the left): the new tracked row is
+     (S', fresh records).
+  2. PER-INPUT-ROW ACCOUNTING — for every tracked input row (S, R), solve
+     S -> q (xor) rec[..]; if the image q is spanned by the fresh rows the
+     relation closes: DETECTOR = R (xor) rec (xor) fresh pinning. Otherwise
+     the row is transported AS IS (no basis blending — surviving free-DOF
+     representatives such as a logical coset row keep pristine records).
+  3. COMPLETION — leftover flow directions (e.g. the Y_L preparation flow of
+     the init transition round) become additional rows with their own
+     records, ready for tracker.declare_logical.
+
+Global signs of flows are ignored: stim's detector/observable sampling is
+relative to the noiseless reference, matching the tracker's convention of
+storing parity relations without a sign column.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+import numpy as np
+import stim
+
+from ..utils.linear_algebra import solve_linear_decomposition
+
+_MEAS_NAMES = {"M", "MX", "MY"}
+
+
+def measured_qubits_in_order(chunk: stim.Circuit) -> List[int]:
+    """Global qubit index of every measurement in the chunk, in record order."""
+    out: List[int] = []
+    for inst in chunk.flattened():
+        if inst.name in _MEAS_NAMES:
+            out.extend(t.value for t in inst.targets_copy())
+    return out
+
+
+def _pauli_to_vec(ps: stim.PauliString, n: int) -> np.ndarray:
+    xs, zs = ps.to_numpy()
+    v = np.zeros(2 * n, dtype=np.uint8)
+    k = min(len(xs), n)
+    v[:k] = xs[:k].astype(np.uint8)
+    v[n:n + k] = zs[:k].astype(np.uint8)
+    return v
+
+
+def _intersection_basis(A: np.ndarray, B: np.ndarray,
+                        preferred: Optional[np.ndarray] = None) -> np.ndarray:
+    """Basis of rowspan(A) ∩ rowspan(B) over GF(2) (Zassenhaus).
+
+    ``preferred`` rows that lie in the intersection are put FIRST in the
+    returned basis (canonical representatives, e.g. registered stabilizers),
+    with the Zassenhaus remainder completing the span.
+    """
+    if A.shape[0] == 0 or B.shape[0] == 0:
+        return np.zeros((0, A.shape[1] if A.size else B.shape[1]),
+                        dtype=np.uint8)
+    w = A.shape[1]
+    top = np.hstack([A, A])
+    bot = np.hstack([B, np.zeros_like(B)])
+    m = np.vstack([top, bot]).astype(np.uint8)
+    # RREF on the left block; rows whose left block vanishes carry an
+    # intersection element in the right block.
+    rank = 0
+    for col in range(w):
+        piv = None
+        for r in range(rank, m.shape[0]):
+            if m[r, col]:
+                piv = r
+                break
+        if piv is None:
+            continue
+        m[[rank, piv]] = m[[piv, rank]]
+        for r in range(m.shape[0]):
+            if r != rank and m[r, col]:
+                m[r] ^= m[rank]
+        rank += 1
+        if rank == m.shape[0]:
+            break
+    inter = [row[w:] for row in m if not row[:w].any() and row[w:].any()]
+    W = (np.array(inter, dtype=np.uint8) if inter
+         else np.zeros((0, w), dtype=np.uint8))
+    if preferred is None or preferred.shape[0] == 0 or W.shape[0] == 0:
+        return W
+    # reorder: preferred members of the intersection first
+    chosen: List[np.ndarray] = []
+    for p in preferred:
+        cA = solve_linear_decomposition(basis=A, targets=p.reshape(1, -1),
+                                        reduce_weight=False)[1][0]
+        cB = solve_linear_decomposition(basis=B, targets=p.reshape(1, -1),
+                                        reduce_weight=False)[1][0]
+        if cA and cB:
+            cur = (np.array(chosen, dtype=np.uint8) if chosen
+                   else np.zeros((0, w), dtype=np.uint8))
+            if _rank(np.vstack([cur, p.reshape(1, -1)])) > _rank(cur):
+                chosen.append(p.astype(np.uint8))
+    for row in W:
+        cur = (np.array(chosen, dtype=np.uint8) if chosen
+               else np.zeros((0, w), dtype=np.uint8))
+        if _rank(np.vstack([cur, row.reshape(1, -1)])) > _rank(cur):
+            chosen.append(row)
+    return np.array(chosen, dtype=np.uint8)
+
+
+def _left_nullspace_basis(mat: np.ndarray) -> np.ndarray:
+    """Basis of {y : y @ mat = 0} over GF(2), via RREF on [mat | I]."""
+    g = mat.shape[0]
+    if g == 0:
+        return np.zeros((0, 0), dtype=np.uint8)
+    aug = np.hstack([mat.copy().astype(np.uint8),
+                     np.eye(g, dtype=np.uint8)])
+    w = mat.shape[1]
+    kept: List[np.ndarray] = []
+    pivots: List[int] = []
+    out: List[np.ndarray] = []
+    for row in aug:
+        row = row.copy()
+        for prow, pcol in zip(kept, pivots):
+            if row[pcol]:
+                row ^= prow
+        nz = np.flatnonzero(row[:w])
+        if nz.size == 0:
+            out.append(row[w:])
+        else:
+            kept.append(row)
+            pivots.append(int(nz[0]))
+    if out:
+        return np.array(out, dtype=np.uint8)
+    return np.zeros((0, g), dtype=np.uint8)
+
+
+def _rank(mat: np.ndarray) -> int:
+    if mat.shape[0] == 0:
+        return 0
+    m = mat.copy()
+    rank = 0
+    for col in range(m.shape[1]):
+        piv = None
+        for r in range(rank, m.shape[0]):
+            if m[r, col]:
+                piv = r
+                break
+        if piv is None:
+            continue
+        m[[rank, piv]] = m[[piv, rank]]
+        for r in range(m.shape[0]):
+            if r != rank and m[r, col]:
+                m[r] ^= m[rank]
+        rank += 1
+        if rank == m.shape[0]:
+            break
+    return rank
+
+
+@dataclass
+class RelayResult:
+    measured_qubits: List[int]
+    # each detector: (absolute record set, global qubit index used for coords)
+    detectors: List[Tuple[Set[int], int]]
+    new_stab_matrix: np.ndarray = None
+    new_stab_records: List[List[int]] = field(default_factory=list)
+    new_log_matrix: np.ndarray = None
+    new_log_records: List[List[int]] = field(default_factory=list)
+    # logicals MEASURED OUT by this chunk (transport flow ends at identity):
+    # (original logical row index, absolute record set of the observable —
+    # the row's banked seed records XOR the chunk's measuring records)
+    measured_logicals: List[Tuple[int, List[int]]] = field(
+        default_factory=list)
+
+
+def solve_relay_round(chunk: stim.Circuit,
+                      num_qubits: int,
+                      stab_matrix: np.ndarray,
+                      stab_records: List[List[int]],
+                      log_matrix: np.ndarray,
+                      log_records: List[List[int]],
+                      base_record: int,
+                      canonical_stabs: Optional[np.ndarray] = None
+                      ) -> RelayResult:
+    n = num_qubits
+    measured = measured_qubits_in_order(chunk)
+    n_meas = len(measured)
+    n_in = stab_matrix.shape[0]
+
+    # --- 0. chunk flows over the full system width -----------------------
+    p_rows: List[np.ndarray] = []
+    q_rows: List[np.ndarray] = []
+    m_sets: List[Set[int]] = []
+    for fl in chunk.flow_generators():
+        p_rows.append(_pauli_to_vec(fl.input_copy(), n))
+        q_rows.append(_pauli_to_vec(fl.output_copy(), n))
+        m_sets.append(set(fl.measurements_copy()))
+    for q in range(chunk.num_qubits, n):        # untouched system qubits
+        for half in (q, n + q):
+            v = np.zeros(2 * n, dtype=np.uint8)
+            v[half] = 1
+            p_rows.append(v.copy())
+            q_rows.append(v.copy())
+            m_sets.append(set())
+    P = np.array(p_rows, dtype=np.uint8)
+    Q = np.array(q_rows, dtype=np.uint8)
+    g = P.shape[0]
+
+    zeros_in = np.zeros((n_in, 2 * n), dtype=np.uint8)
+    # joint solve space: [ p | q ] for generators, [ S | 0 ] for input rows
+    joint = np.hstack([P, Q])
+    if n_in:
+        joint = np.vstack([joint, np.hstack([stab_matrix, zeros_in])])
+
+    def _combo_records(coeff: np.ndarray) -> Set[int]:
+        recs: Set[int] = set()
+        for j in np.flatnonzero(coeff[:g]):
+            recs.symmetric_difference_update(
+                base_record + k for k in m_sets[int(j)])
+        for k in np.flatnonzero(coeff[g:]):
+            recs.symmetric_difference_update(stab_records[int(k)])
+        return recs
+
+    # --- 1. canonical fresh rows: solve [0 | S'] for registered targets --
+    fresh_rows: List[np.ndarray] = []
+    fresh_recs: List[Set[int]] = []
+    if canonical_stabs is not None and canonical_stabs.shape[0]:
+        targets = np.hstack([np.zeros_like(canonical_stabs), canonical_stabs])
+        c, dep, _ = solve_linear_decomposition(
+            basis=joint, targets=targets, reduce_weight=True)
+        for i in range(canonical_stabs.shape[0]):
+            if not dep[i]:
+                continue                    # not established by this round
+            fresh_rows.append(canonical_stabs[i].copy())
+            fresh_recs.append(_combo_records(c[i]))
+    F = (np.array(fresh_rows, dtype=np.uint8) if fresh_rows
+         else np.zeros((0, 2 * n), dtype=np.uint8))
+
+    def _reduce_over_fresh(vec: np.ndarray) -> Tuple[bool, Set[int]]:
+        """Is vec in span(fresh rows)? If so return the pinning records."""
+        if F.shape[0] == 0:
+            return (not vec.any()), set()
+        c, dep, _ = solve_linear_decomposition(
+            basis=F, targets=vec.reshape(1, -1), reduce_weight=True)
+        if not dep[0]:
+            return False, set()
+        recs: Set[int] = set()
+        for i in np.flatnonzero(c[0]):
+            recs.symmetric_difference_update(fresh_recs[int(i)])
+        return True, recs
+
+    # --- 2. intersection accounting -----------------------------------------
+    # W = span(input rows) ∩ span(flow inputs): exactly the pinned information
+    # this round can either re-pin (detector) or carry through (transport).
+    # Input DOFs outside W were randomized by the round's measurements and
+    # vanish silently (the SE path's Case-A replacement).
+    detectors: List[Set[int]] = []
+    seen_detectors: Set[frozenset] = set()
+    transported_rows: List[np.ndarray] = []
+    transported_recs: List[Set[int]] = []
+    if n_in:
+        W = _intersection_basis(stab_matrix, P, preferred=canonical_stabs)
+        for w_vec in W:
+            ch, dh, _ = solve_linear_decomposition(
+                basis=stab_matrix, targets=w_vec.reshape(1, -1),
+                reduce_weight=True)
+            hist: Set[int] = set()
+            for s in np.flatnonzero(ch[0]):
+                hist.symmetric_difference_update(stab_records[int(s)])
+            cy, dy, _ = solve_linear_decomposition(
+                basis=P, targets=w_vec.reshape(1, -1), reduce_weight=True)
+            yg = np.flatnonzero(cy[0])
+            img = (np.bitwise_xor.reduce(Q[yg], axis=0)
+                   if yg.size else np.zeros(2 * n, dtype=np.uint8))
+            recs = set(hist)
+            for j in yg:
+                recs.symmetric_difference_update(
+                    base_record + m for m in m_sets[int(j)])
+            in_span, pin_recs = _reduce_over_fresh(img)
+            if in_span:
+                det = recs ^ pin_recs
+                key = frozenset(det)
+                if det and key not in seen_detectors:
+                    seen_detectors.add(key)
+                    detectors.append(det)
+            else:
+                transported_rows.append(img)
+                transported_recs.append(recs)
+
+    # --- 3. completion: pure preparation flows (e.g. Y_L birth) -------------
+    completion_rows: List[np.ndarray] = []
+    completion_recs: List[Set[int]] = []
+    for j in np.flatnonzero(~P.any(axis=1)):
+        img = Q[int(j)]
+        if not img.any():
+            continue
+        recs = {base_record + m for m in m_sets[int(j)]}
+        completion_rows.append(img)
+        completion_recs.append(recs)
+
+    # --- 4. assemble rows: fresh, then transports, then completions ------
+    def _strip_measured(row: np.ndarray, rec: Set[int]) -> Optional[
+            Tuple[np.ndarray, Set[int]]]:
+        row = row.copy()
+        rec = set(rec)
+        pos = 0
+        for inst in chunk.flattened():
+            if inst.name not in _MEAS_NAMES:
+                continue
+            basis = {"M": "Z", "MX": "X", "MY": "Y"}[inst.name]
+            for t in inst.targets_copy():
+                qb = t.value
+                has_x, has_z = bool(row[qb]), bool(row[n + qb])
+                if has_x or has_z:
+                    comp = ("Y" if has_x and has_z
+                            else "X" if has_x else "Z")
+                    if comp != basis:
+                        return None
+                    row[qb] = 0
+                    row[n + qb] = 0
+                    rec.symmetric_difference_update({base_record + pos})
+                pos += 1
+        return row, rec
+
+    def _clean_by_fresh(row: np.ndarray, rec: Set[int]
+                        ) -> Tuple[np.ndarray, Set[int]]:
+        """If the row's records are exactly a combination of fresh rows'
+        records, XOR those fresh rows in: the surviving coset keeps a
+        records-less (pristine) representative, which downstream promotion
+        machinery requires. Fresh rows themselves are never modified."""
+        if not rec or F.shape[0] == 0:
+            return row, rec
+        universe = sorted(set().union(rec, *fresh_recs))
+        col = {r: i for i, r in enumerate(universe)}
+
+        def _v(s: Set[int]) -> np.ndarray:
+            out = np.zeros(len(universe), dtype=np.uint8)
+            for r in s:
+                out[col[r]] = 1
+            return out
+
+        basis = np.array([_v(fr) for fr in fresh_recs], dtype=np.uint8)
+        c, dep, _ = solve_linear_decomposition(
+            basis=basis, targets=_v(rec).reshape(1, -1), reduce_weight=True)
+        if not dep[0]:
+            return row, rec
+        new_row = row.copy()
+        new_rec = set(rec)
+        for i in np.flatnonzero(c[0]):
+            new_row ^= F[int(i)]
+            new_rec.symmetric_difference_update(fresh_recs[int(i)])
+        if new_rec or not new_row.any():
+            return row, rec
+        return new_row, new_rec
+
+    rows: List[np.ndarray] = list(F)
+    recs_out: List[Set[int]] = [set(r) for r in fresh_recs]
+    for row, rec in list(zip(transported_rows, transported_recs)) + \
+            list(zip(completion_rows, completion_recs)):
+        stripped = _strip_measured(row, rec)
+        if stripped is None:
+            continue
+        row, rec = stripped
+        row, rec = _clean_by_fresh(row, rec)
+        if not row.any():
+            key = frozenset(rec)
+            if rec and key not in seen_detectors:
+                seen_detectors.add(key)
+                detectors.append(rec)
+            continue
+        cur = (np.array(rows, dtype=np.uint8) if rows
+               else np.zeros((0, 2 * n), dtype=np.uint8))
+        if _rank(np.vstack([cur, row.reshape(1, -1)])) > _rank(cur):
+            rows.append(row)                # kept AS IS: no record blending
+            recs_out.append(rec)
+        else:
+            ok, pin = _reduce_over_fresh(row)
+            if not ok:
+                c2, d2, _ = solve_linear_decomposition(
+                    basis=cur, targets=row.reshape(1, -1),
+                    reduce_weight=True)
+                pin = set()
+                if d2[0]:
+                    for i in np.flatnonzero(c2[0]):
+                        pin.symmetric_difference_update(recs_out[int(i)])
+            det = rec ^ pin
+            key = frozenset(det)
+            if det and key not in seen_detectors:
+                seen_detectors.add(key)
+                detectors.append(det)
+
+    # --- 5. transport logical rows; measured-out logicals -> observables --
+    new_log_rows: List[np.ndarray] = []
+    new_log_recs: List[List[int]] = []
+    measured_logicals: List[Tuple[int, List[int]]] = []
+    if log_matrix is not None and log_matrix.shape[0] > 0:
+        basis = np.vstack([P, stab_matrix]) if n_in else P
+        c, d, _ = solve_linear_decomposition(
+            basis=basis, targets=log_matrix, reduce_weight=True)
+        for i in range(log_matrix.shape[0]):
+            if not d[i]:
+                raise NotImplementedError(
+                    "relay chunk destroys a tracked logical row (no "
+                    "transport or measurement flow exists for it)")
+            yg = np.flatnonzero(c[i][:g])
+            img = (np.bitwise_xor.reduce(Q[yg], axis=0)
+                   if yg.size else np.zeros(2 * n, dtype=np.uint8))
+            rec: Set[int] = set(log_records[i])
+            for j in yg:
+                rec.symmetric_difference_update(
+                    base_record + m for m in m_sets[int(j)])
+            for s in np.flatnonzero(c[i][g:]):
+                rec.symmetric_difference_update(stab_records[int(s)])
+            if img.any():
+                stripped = _strip_measured(img, rec)
+                if stripped is None:
+                    raise NotImplementedError(
+                        "logical transport image anticommutes with a chunk "
+                        "measurement")
+                img, rec = stripped
+            if not img.any():
+                # The chunk MEASURED this logical: its value is the parity of
+                # the banked seed records XOR the chunk's measuring records —
+                # a logical observable, not a detector.
+                measured_logicals.append((i, sorted(rec)))
+                continue
+            new_log_rows.append(img)
+            new_log_recs.append(sorted(rec))
+
+    # --- 5b. completeness: the FULL deterministic-parity space ------------
+    # Combos (y over gens, c over input rows) with Σy·p ⊕ Σc·S = 0 AND
+    # Σy·q = 0 form the complete space of deterministic record parities this
+    # round; the canonical detectors above are a subset. Complete the basis
+    # so no coverage dimension is lost (a missing dimension silently reduces
+    # the circuit's fault distance).
+    stacked = np.hstack([P, Q])
+    if n_in:
+        stacked = np.vstack([stacked,
+                             np.hstack([stab_matrix, zeros_in])])
+    null = _left_nullspace_basis(stacked)
+    if null.shape[0]:
+        universe = sorted(
+            {r for det in detectors for r in det}
+            | {base_record + m for ms in m_sets for m in ms}
+            | {r for rs in stab_records for r in rs})
+        col = {r: i for i, r in enumerate(universe)}
+
+        def _rvec(s: Set[int]) -> np.ndarray:
+            v = np.zeros(len(universe), dtype=np.uint8)
+            for r in s:
+                v[col[r]] = 1
+            return v
+
+        chosen = [_rvec(det) for det in detectors]
+        for y in null:
+            recs: Set[int] = set()
+            for j in np.flatnonzero(y[:g]):
+                recs.symmetric_difference_update(
+                    base_record + m for m in m_sets[int(j)])
+            for k in np.flatnonzero(y[g:]):
+                recs.symmetric_difference_update(stab_records[int(k)])
+            if not recs:
+                continue
+            cur = (np.array(chosen, dtype=np.uint8) if chosen
+                   else np.zeros((0, len(universe)), dtype=np.uint8))
+            v = _rvec(recs)
+            if _rank(np.vstack([cur, v.reshape(1, -1)])) > _rank(cur):
+                chosen.append(v)
+                key = frozenset(recs)
+                if key not in seen_detectors:
+                    seen_detectors.add(key)
+                    detectors.append(recs)
+
+    # --- 6. detector coordinate hints -------------------------------------
+    dets_out: List[Tuple[Set[int], int]] = []
+    for recs in detectors:
+        local = [r - base_record for r in recs
+                 if base_record <= r < base_record + n_meas]
+        coord_q = measured[max(local)] if local else -1
+        dets_out.append((recs, coord_q))
+
+    res = RelayResult(measured_qubits=measured, detectors=dets_out)
+    res.new_stab_matrix = (np.array(rows, dtype=np.uint8) if rows
+                           else np.zeros((0, 2 * n), dtype=np.uint8))
+    res.new_stab_records = [sorted(r) for r in recs_out]
+    res.new_log_matrix = (np.array(new_log_rows, dtype=np.uint8)
+                          if new_log_rows
+                          else np.zeros((0, 2 * n), dtype=np.uint8))
+    res.new_log_records = new_log_recs
+    res.measured_logicals = measured_logicals
+    return res

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -1947,12 +1947,26 @@ class SyndromeTracker:
             # account it exactly like a Case-A kill: expected -= 1, and bank
             # the restore credit for a possible same-block resurface.
             _indep = set(new_basis_indices)
+            # Logical POSITIONS whose consumption is already charged to
+            # expected this call: Case-A pivots (the slot now holds the
+            # measured row, not the original direction) plus the
+            # stab-shadowed dependent rows collected below.  A logical-
+            # carrying gauge measurement can still decompose through
+            # these slots, so the absorb accounting (preview here, Fix C
+            # banking later) must zero them exactly like surviving rows,
+            # or the same consumption is priced twice (teleport_8
+            # optimized without liveness: two relay readouts Case-A
+            # killed rows 1,2, the chain joint's log_vec={0,1,2} routed
+            # through both dead slots, banking absorbed on top of the
+            # Case-A charges — standing 1 + absorbed 1 > expected 1).
+            _charged_dead = {int(_p) - num_stabs for _p in _case_a_log_pivots}
             for _ri in range(num_logs):
                 _oi = num_stabs + _ri
                 if (_ri not in _indep and _oi not in _case_a_log_pivots
                         and _oi in _log_rows_anti):
                     self.expected_num_logicals -= 1
                     _restore_credit += 1
+                    _charged_dead.add(_ri)
                     if _dbg:
                         print(f"[pmm#{self._pmm_call}] dependent LOG row "
                               f"{_ri} measured via stab-shadowed pivots: "
@@ -1979,6 +1993,9 @@ class SyndromeTracker:
             for _mp, _lv in _round_cands:
                 _lv2 = _lv.copy()
                 for _j in _surv_pre:
+                    if _j < _lv2.shape[0]:
+                        _lv2[_j] = 0
+                for _j in _charged_dead:
                     if _j < _lv2.shape[0]:
                         _lv2[_j] = 0
                 if not _lv2.any():
@@ -2095,6 +2112,7 @@ class SyndromeTracker:
             new_log_basis_indices = []
             old_stab_basis_indices = []
             self.logicals = PauliTableau(self.num_qubits)  # empty logicals
+            _charged_dead = {int(_p) - num_stabs for _p in _case_a_log_pivots}
 
         # 2. Update Stabilizers
         # Reset stabilizer tableau to the canonical measurement basis.
@@ -2174,6 +2192,12 @@ class SyndromeTracker:
         for _mp, _lv in _round_cands:
             _lv2 = _lv.copy()
             for _j in surviving_log_indices:
+                if _j < _lv2.shape[0]:
+                    _lv2[_j] = 0
+            # positions consumed AND charged by Case A / stab-shadowed
+            # kills this call: their slot content is the measured row,
+            # not a standing direction — never a second absorb
+            for _j in _charged_dead:
                 if _j < _lv2.shape[0]:
                     _lv2[_j] = 0
             if not _lv2.any():

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -198,14 +198,39 @@ class SyndromeTracker:
         self.retired_qubits |= S
 
     def _remap_rows_after_removal(self, removed_sorted):
-        """Shift post_select_row_indices down past removed stabilizer rows."""
+        """Shift stabilizer-row metadata down past removed stabilizer rows.
+
+        Every deletion of stabilizer rows must come through here (or rebuild
+        the sets itself, as the measurement-block paths do): both
+        post_select_row_indices and stabilizer_with_logical_components hold
+        ROW indices, and a stale index silently post-selects or reclassifies
+        a different row.  stabilizer_with_logical_components pairs
+        positionally with _gauge_logical_vectors via sorted order, so
+        entries dropped here drop their paired vector too (the shift is
+        monotone, so surviving pairs stay aligned).
+        """
         removed = sorted(set(removed_sorted))
-        if not self.post_select_row_indices:
+        if not removed:
             return
+        rem = set(removed)
+
         def shift(idx):
             return idx - sum(1 for r in removed if r < idx)
-        self.post_select_row_indices = {shift(i) for i in self.post_select_row_indices
-                                        if i not in set(removed)}
+
+        if self.post_select_row_indices:
+            self.post_select_row_indices = {
+                shift(i) for i in self.post_select_row_indices
+                if i not in rem}
+        if self.stabilizer_with_logical_components:
+            swlc_sorted = sorted(self.stabilizer_with_logical_components)
+            vectors = list(self._gauge_logical_vectors)
+            paired = list(zip(swlc_sorted, vectors)) if vectors else \
+                [(i, None) for i in swlc_sorted]
+            kept = [(i, v) for i, v in paired if i not in rem]
+            self.stabilizer_with_logical_components = {
+                shift(i) for i, _ in kept}
+            if vectors:
+                self._gauge_logical_vectors = [v for _, v in kept]
 
     def reset_records_for_qubits(self, qubit_indices):
         """
@@ -251,9 +276,31 @@ class SyndromeTracker:
             else:
                 tableau.matrix = np.zeros((0, 2 * n), dtype=np.uint8)
             tableau.records = new_records
+            return new_indices
 
-        _clean_rows(self.stabilizers)
+        n_stab_before = self.stabilizers.count
+        kept = set(_clean_rows(self.stabilizers))
         _clean_rows(self.logicals)
+        self._remap_rows_after_removal(
+            [i for i in range(n_stab_before) if i not in kept])
+
+    def _reject_pending_row_metadata(self, context: str) -> None:
+        """Basis recombination replaces rows by linear combinations, so old
+        row indices carry no meaning afterwards — a shift cannot fix them.
+        Fail loud instead of silently post-selecting or reclassifying a
+        recombined row.  (The measurement-block paths that CAN remap by
+        decomposition do so themselves and never call this.)"""
+        if self.post_select_row_indices:
+            raise RuntimeError(
+                f"{context}: post_select_row_indices is non-empty but the "
+                f"stabilizer basis is about to be recombined; row indices "
+                f"would silently point at different rows. Resolve or clear "
+                f"the post-selection marks first.")
+        if self.stabilizer_with_logical_components:
+            raise RuntimeError(
+                f"{context}: stabilizer_with_logical_components is non-empty "
+                f"but the stabilizer basis is about to be recombined; the "
+                f"pending gauge/logical classification would be lost.")
 
     def stabilizer_canonicalization(
         self,
@@ -268,6 +315,7 @@ class SyndromeTracker:
 
         Call after encoding, before SE. Raises if logical count does not match expected.
         """
+        self._reject_pending_row_metadata("stabilizer_canonicalization")
         n = self.num_qubits
         if stabilizer_uids is not None:
             stab_dicts = [system.stabilizers[i] for i in range(len(system.stabilizers)) if i in stabilizer_uids]
@@ -513,6 +561,7 @@ class SyndromeTracker:
         drop = pinning[-1]
         self.stabilizers.matrix = np.delete(self.stabilizers.matrix, drop, axis=0)
         self.stabilizers.records.pop(drop)
+        self._remap_rows_after_removal([drop])
         self.logicals.add_stabilizers(pauli_vec, [list(records)])
         self.expected_num_logicals += 1
         return list(records)
@@ -1364,6 +1413,7 @@ class SyndromeTracker:
         This differs from :meth:`stabilizer_canonicalization`, which may insert
         unmeasured canonical rows when preparing a code for its first SE round.
         """
+        self._reject_pending_row_metadata("rebase_stabilizers_onto_code_basis")
         n = self.num_qubits
         if stabilizer_uids is None:
             stabilizer_uids = set(system.active_stabilizer_indices)
@@ -2367,8 +2417,13 @@ class SyndromeTracker:
             self.logicals.matrix = np.zeros((0, 2 * self.num_qubits), dtype=np.uint8)
             self.logicals.records = []
 
+        # Rows consumed by this readout leave; surviving rows keep their
+        # post-select marking for any later readout at their new positions.
+        self._remap_rows_after_removal(
+            [k for k in range(num_stabs) if k in rows_to_remove])
         # Reset per-call tracking that uses row indices (now invalidated)
         self.stabilizer_with_logical_components = set()
+        self._gauge_logical_vectors = []
 
         # A PATCH readout retires however many live logical DOFs it actually read out
         # (free ones consumed + absorbed relations resolved). A CORRIDOR/bus readout

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -102,19 +102,44 @@ class SyndromeTracker:
         self.expected_num_logicals = k
 
     def num_absorbed_dof(self) -> int:
-        """Number of live logical DOFs currently folded into the stabilizer group
-        (cross-round persistent), counted UP TO logical equivalence: two
-        representatives that differ by a stabilizer are ONE relation, and a
-        relation that has itself become an element of the stabilizer group
-        holds no DOF and contributes zero.  Computed as
-        rank([stabilizers; absorbed]) - rank(stabilizers) over GF(2)."""
-        A = self.absorbed_ops.matrix
-        if A.shape[0] == 0:
-            return 0
-        S = self.stabilizers.matrix
-        if S.shape[0] == 0:
-            return _gf2_rank(A)
-        return _gf2_rank(np.vstack([S, A])) - _gf2_rank(S)
+        """Number of banked absorbed logical DOFs (cross-round persistent):
+        the GF(2) rank of the ledger itself.
+
+        Deliberately NOT quotiented by the current stabilizer bank: after a
+        merge the joint's CLOSURE row (same relation, carrying the merge
+        records) legitimately lives in the bank, and modding the ledger by
+        the bank would cancel the banked DOF against its own reflection
+        (found the hard way: the census tripped on a measurement-block
+        round over post-PPM state).  Logical-equivalence deduplication
+        happens at INSERTION instead — see record_absorbed_op — so two
+        representatives differing by a stabilizer never both enter the
+        ledger, while a banked relation keeps counting regardless of how
+        the group later expresses it."""
+        return _gf2_rank(self.absorbed_ops.matrix)
+
+    def record_absorbed_op(self, op: np.ndarray, records=()) -> bool:
+        """Bank one absorbed logical relation, deduplicated up to logical
+        equivalence AT THIS MOMENT: the operator is reduced against the
+        current stabilizer rows and the already-banked relations, and only
+        an irreducible residue is recorded.  A second representative of an
+        already-banked relation (differing by stabilizers) reduces to zero
+        and is skipped.  Returns True iff a new row was banked."""
+        op = np.asarray(op, dtype=np.uint8).reshape(1, -1)
+        if not op.any():
+            return False
+        A = self.absorbed_ops
+        basis_parts = [M for M in (self.stabilizers.matrix, A.matrix)
+                       if M.shape[0] > 0]
+        if basis_parts:
+            basis = np.vstack(basis_parts)
+            _, dep, _ = solve_linear_decomposition(basis=basis, targets=op,
+                                                   reduce_weight=False)
+            if dep[0]:
+                return False
+        A.matrix = (np.vstack([A.matrix, op]).astype(np.uint8)
+                    if A.count else op.astype(np.uint8))
+        A.records = list(A.records) + [list(records)]
+        return True
 
     def allocate_observable(self) -> int:
         """Reserve and return the next OBSERVABLE_INCLUDE index.
@@ -871,13 +896,8 @@ class SyndromeTracker:
                 n_logs = old_logicals_current_frame.shape[0]
                 ops = (gauge_matrix[:, :n_logs]
                        @ old_logicals_current_frame) % 2
-                ops = ops[ops.any(axis=1)].astype(np.uint8)
-                if ops.shape[0]:
-                    A = self.absorbed_ops
-                    A.matrix = (np.vstack([A.matrix, ops]).astype(np.uint8)
-                                if A.count else ops)
-                    A.records = list(A.records) + [
-                        [] for _ in range(ops.shape[0])]
+                for op in ops:
+                    self.record_absorbed_op(op)
 
         if surviving_logical_indices and self._gauge_logical_vectors:
             rows_to_remove = set()

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -297,6 +297,40 @@ class SyndromeTracker:
         self._remap_rows_after_removal(
             [i for i in range(n_stab_before) if i not in kept])
 
+        # Absorbed relations are Pauli strings too: a re-init destroys any
+        # support they carry on the reset qubits.  A relation is only
+        # defined modulo the stabilizer group, so first try to re-express
+        # each touched row off the reset columns using the (cleaned)
+        # surviving group; a relation that cannot be re-expressed is
+        # annihilated by the reset — drop it, and let the census alarm
+        # catch the loss unless the caller adjusted the budget for an
+        # intentional discard.
+        A = self.absorbed_ops
+        if A.count:
+            cols = ([q for q in qubit_set]
+                    + [n + q for q in qubit_set])
+            touched = [r for r in range(A.count) if A.matrix[r, cols].any()]
+            if touched:
+                A.matrix = A.matrix.copy()
+                if self.stabilizers.count:
+                    coeffs, dep, _ = solve_linear_decomposition(
+                        basis=self.stabilizers.matrix[:, cols],
+                        targets=A.matrix[np.ix_(touched, cols)],
+                        reduce_weight=False)
+                    for k, r in enumerate(touched):
+                        if dep[k]:
+                            comb = (coeffs[k][None, :]
+                                    @ self.stabilizers.matrix) % 2
+                            A.matrix[r] = (A.matrix[r] + comb[0]) % 2
+                A.matrix = A.matrix.astype(np.uint8)
+                keep_rows = [r for r in range(A.count)
+                             if not A.matrix[r, cols].any()]
+                if len(keep_rows) != A.count:
+                    A.matrix = (A.matrix[keep_rows] if keep_rows
+                                else np.zeros((0, 2 * n), dtype=np.uint8))
+                    A.records = ([A.records[r] for r in keep_rows]
+                                 if A.records else [])
+
     def _reject_pending_row_metadata(self, context: str) -> None:
         """Basis recombination replaces rows by linear combinations, so old
         row indices carry no meaning afterwards — a shift cannot fix them.

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -38,6 +38,38 @@ def _gf2_rank(M):
     return r
 
 
+def _gf2_rref(M):
+    """GF(2) reduced row-echelon form of a 0/1 matrix.
+
+    Returns (R, pivots): R the non-zero reduced rows, pivots the pivot
+    column of each row of R (each pivot column is zero in every other
+    row of R).
+    """
+    M = (np.asarray(M, dtype=np.uint8) % 2).copy()
+    if M.size == 0:
+        return M.reshape(0, -1), []
+    rows, cols = M.shape
+    r = 0
+    pivots = []
+    for c in range(cols):
+        piv = None
+        for i in range(r, rows):
+            if M[i, c]:
+                piv = i
+                break
+        if piv is None:
+            continue
+        M[[r, piv]] = M[[piv, r]]
+        mask = M[:, c].astype(bool).copy()
+        mask[r] = False
+        M[mask] ^= M[r]
+        pivots.append(c)
+        r += 1
+        if r == rows:
+            break
+    return M[:r], pivots
+
+
 def _append_detector(
     circuit: stim.Circuit,
     args: list,
@@ -1804,6 +1836,17 @@ class SyndromeTracker:
                                                 'STAB')
                                         _parts.append(f"{kind}@{c}(rec={recs if len(recs) < 4 else recs[:3]+['…']})")
                                     print(f"[cand-debug] meas#{i} decomposes -> {_parts}")
+                                    _fr = _gf2_rank(full_matrix)
+                                    print(f"[rank-debug] full_matrix rows={full_matrix.shape[0]} "
+                                          f"rank={_fr} deficiency={full_matrix.shape[0] - _fr}")
+                                    _nq = full_matrix.shape[1] // 2
+                                    for c in comp_indices:
+                                        if c < num_stabs and len(full_records[c]) > 2:
+                                            _r = full_matrix[c]
+                                            _sup = sorted(set(np.where(_r[:_nq])[0].tolist())
+                                                          | set(np.where(_r[_nq:])[0].tolist()))
+                                            print(f"[rank-debug] carrier STAB@{c} w={len(_sup)} "
+                                                  f"sup={_sup}")
                                 continue
                             # Otherwise, purely depends on stabilizers, construct a detector
                             # Use set-based XOR for O(1) toggle instead of O(n) list scan
@@ -1950,6 +1993,7 @@ class SyndromeTracker:
                     _pend_n += 1
                     _pending += 1
             _n_promoted = 0
+            _gauge_filed = []
             for ri in new_basis_indices:
                 orig_idx = _remap(ri)
                 orig_record = reordered_records[ri]
@@ -2006,6 +2050,7 @@ class SyndromeTracker:
                         # global parity would attach an irreducible third
                         # symptom to every one of them).
                         old_stab_basis_indices.append(orig_idx)
+                        _gauge_filed.append(orig_idx)
                         # sentinel record -1 marks the UNWATCHED gauge row
                         # explicitly (readout must not infer gauge-ness from
                         # an empty record list: legitimately records-less
@@ -2019,6 +2064,30 @@ class SyndromeTracker:
                 else:
                     # Stab row with records → stays as old stabilizer
                     old_stab_basis_indices.append(orig_idx)
+
+            # Shadow-row purge: a gauge row filed above must carry NO
+            # standing-logical content.  The row is a free combination the
+            # rebuild happened to emit (e.g. logical x corridor-ribbon x
+            # checks); filed verbatim, a later measurement's UNIQUE
+            # decomposition over the full tableau routes that logical
+            # component through the stab section, so its log_vec misses
+            # the bit and the absorb census loses the DOF (measured:
+            # steane program-order M(Z3Z4Z5) decomposed as logicals {3,4}
+            # with q5 hidden in a gauge row — Logical Count Mismatch at
+            # block end).  XORing standing logicals into the row changes
+            # neither the span nor its independence, and gauge x free DOF
+            # is still value-undefined, so the records-less filing
+            # semantics are untouched.  After the purge no records-less
+            # stab row (nor any XOR of them) overlaps a logical pivot
+            # column: the logical part of every decomposition is forced
+            # through the logical section.
+            if _gauge_filed and new_log_basis_indices:
+                _log_rref, _log_pivots = _gf2_rref(
+                    full_matrix[new_log_basis_indices])
+                for _gi in _gauge_filed:
+                    for _k, _c in enumerate(_log_pivots):
+                        if full_matrix[_gi, _c]:
+                            full_matrix[_gi] ^= _log_rref[_k]
 
             self.logicals.matrix = full_matrix[new_log_basis_indices]
             self.logicals.records = [full_records[i] for i in new_log_basis_indices]
@@ -2263,8 +2332,42 @@ class SyndromeTracker:
             n = self.num_qubits
             meas_q = set(int(c % n) for c in np.where(final_paulis.any(axis=0))[0])
             mcols = [q for q in meas_q] + [q + n for q in meas_q]
+            _half_read_rems = []
             if resolve_absorbed:
-                keep = [r for r in range(A.count) if not A.matrix[r, mcols].any()]
+                # A relation touched by a patch readout resolves only on the
+                # measured columns.  Fold the measured support out via the
+                # stabilizers PLUS this readout: a nonzero remainder is a
+                # direction the records now DETERMINE.  Dropping the row
+                # without re-pricing that remainder leaves any standing
+                # logical it overlaps dependent on the stabilizer span — a
+                # rank-deficient tableau whose decompositions are ambiguous
+                # (steane no_sched: the retired patch's half of Z3~Zp was
+                # read out, q3's row stayed standing, and the next window's
+                # M(Z3Z4Z5) decomposition hid the q3 component inside a
+                # record-bearing stab row; the banking census then lost the
+                # DOF — Logical Count Mismatch).  Remainders are re-priced
+                # after the pruning below: one standing representative is
+                # folded out and the remainder enters absorbed_ops, so
+                # standing + absorbed stays balanced and the tableau keeps
+                # full rank.
+                keep = []
+                _fold_basis = np.vstack([self.stabilizers.matrix,
+                                         final_paulis])
+                for r in range(A.count):
+                    if not A.matrix[r, mcols].any():
+                        keep.append(r)
+                        continue
+                    _cf, _depf, _ = solve_linear_decomposition(
+                        basis=_fold_basis[:, mcols],
+                        targets=A.matrix[r:r + 1][:, mcols],
+                        reduce_weight=False)
+                    if _depf[0]:
+                        _comb = (_cf[0][None, :] @ _fold_basis) % 2
+                        _rem = ((A.matrix[r] + _comb[0]) % 2).astype(np.uint8)
+                        _rem[mcols] = 0
+                        if _rem.any():
+                            _half_read_rems.append(_rem)
+                    # no isolatable remainder: legacy drop (fully resolved)
             else:
                 A.matrix = A.matrix.copy()
                 # An absorbed relation is only defined MOD the stabilizer group; a
@@ -2292,6 +2395,44 @@ class SyndromeTracker:
             if len(keep) != A.count:
                 A.matrix = A.matrix[keep] if keep else np.zeros((0, 2 * n), dtype=np.uint8)
                 A.records = [A.records[r] for r in keep] if A.records else []
+
+            # Re-price the half-read remainders: each is a determined
+            # direction; if it overlaps the standing logicals, that DOF is
+            # now folded into the stabilizer group — fold ONE participating
+            # standing row out (any representative works: the others keep
+            # spanning the quotient) and hold the remainder in absorbed_ops.
+            # Books: standing -1, absorbed net 0 per remainder, so the
+            # budget delta at the end retires exactly the fully-read slot.
+            for _rem in _half_read_rems:
+                if not self.logicals.count:
+                    break
+                _full = np.vstack([self.stabilizers.matrix,
+                                   self.logicals.matrix])
+                _c2, _dep2, _ = solve_linear_decomposition(
+                    basis=_full, targets=_rem.reshape(1, -1),
+                    reduce_weight=False)
+                if not _dep2[0]:
+                    continue
+                _ns = self.stabilizers.count
+                _lcomp = [int(j) - _ns for j in np.where(_c2[0])[0]
+                          if j >= _ns]
+                if not _lcomp:
+                    continue        # pure stab content: fully resolved
+                if not (_gf2_rank(np.vstack([A.matrix, _rem])) > A.count
+                        if A.count else True):
+                    continue        # direction already priced
+                # prefer a records-less representative (record-pinned rows
+                # carry value information the ledger must not discard)
+                _kill = next((j for j in reversed(_lcomp)
+                              if not any(rr >= 0
+                                         for rr in self.logicals.records[j])),
+                             _lcomp[-1])
+                self.logicals.matrix = np.delete(
+                    self.logicals.matrix, _kill, axis=0)
+                self.logicals.records.pop(_kill)
+                A.matrix = (np.vstack([A.matrix, _rem]) if A.count
+                            else _rem.reshape(1, -1).astype(np.uint8))
+                A.records = list(A.records) + [[]]
 
         num_stabs = self.stabilizers.count
         num_logs = self.logicals.count

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -13,6 +13,31 @@ POST_SELECT_TAG = "post-select"
 UNMEASURED_STAB_RECORD = -1
 
 
+def _gf2_rank(M):
+    """GF(2) row rank of a 0/1 matrix."""
+    M = (np.asarray(M, dtype=np.uint8) % 2).copy()
+    if M.size == 0:
+        return 0
+    rows, cols = M.shape
+    r = 0
+    for c in range(cols):
+        piv = None
+        for i in range(r, rows):
+            if M[i, c]:
+                piv = i
+                break
+        if piv is None:
+            continue
+        M[[r, piv]] = M[[piv, r]]
+        mask = M[:, c].astype(bool).copy()
+        mask[r] = False
+        M[mask] ^= M[r]
+        r += 1
+        if r == rows:
+            break
+    return r
+
+
 def _append_detector(
     circuit: stim.Circuit,
     args: list,
@@ -42,6 +67,7 @@ class SyndromeTracker:
         self.expected_num_logicals = expected_num_logicals
         # Total number of measurements
         self.total_measurements = 0
+        self.total_observables = 0
         self.meas_rec_to_idx_map = {}
         
         # Track the current stabilizers and logicals of the system 
@@ -49,28 +75,33 @@ class SyndromeTracker:
         # Note 2: Stabilizer tableau allows linear dependencies between rows (e.g. toric code, BB code), but logicals do not in general..
         self.stabilizers = PauliTableau(num_qubits)
         self.logicals = PauliTableau(num_qubits)
+        # Absorbed logical operators (Fix C): the measured Pauli strings that were folded
+        # into the stabilizer group by a merge (e.g. a joint ZZ over two |0>) and STILL
+        # hold a trapped logical DOF. Persisted across rounds/PPMs, so an absorb that an
+        # intervening round does not re-measure is not lost (this is what the old per-round
+        # gauge tally missed — pitfall B). The count of still-trapped DOFs is `rank(absorbed_ops)`
+        # (see num_absorbed_dof). Self-correcting: once an absorbed relation is read out
+        # (process_data_measurement) or its qubits retired (retire_qubits), its row is
+        # dropped and stops being counted.
+        self.absorbed_ops = PauliTableau(num_qubits)
         self.stabilizer_with_logical_components = set()  # Row indices of stabilizers that contain logical components
         self._gauge_logical_vectors = []  # GF(2) vectors over logical indices for rank computation
         self._absorbed_logical_dofs = 0
         self.post_select_detector_coords = post_select_detector_coords or set()
         self.post_select_row_indices = set()  # Stabilizer row indices to post-select in process_data_measurement
+        self.retired_qubits = set()
 
     def set_expected_logicals(self, k: int):
         """
-        Call this after the logical count is adjusted  
+        Call this after the logical count is adjusted
         (e.g. some logicals are fixed into stabilizers)
         """
         self.expected_num_logicals = k
 
-    def validate_logical_count(self, *, context: str = "tracker state") -> None:
-        """Check that explicit and measurement-absorbed logical DOFs add up."""
-        actual = self.logicals.count + self._absorbed_logical_dofs
-        if actual != self.expected_num_logicals:
-            raise RuntimeError(
-                f"After {context}: logical count {self.logicals.count} plus "
-                f"absorbed logical DOFs {self._absorbed_logical_dofs} != "
-                f"expected {self.expected_num_logicals}."
-            )
+    def num_absorbed_dof(self) -> int:
+        """Number of live logical DOFs currently folded into the stabilizer group
+        (cross-round persistent). Independent of the standing (free) logicals."""
+        return _gf2_rank(self.absorbed_ops.matrix)
 
     def expand(self, delta: int):
         """
@@ -81,7 +112,85 @@ class SyndromeTracker:
             return
         self.stabilizers.expand(delta)
         self.logicals.expand(delta)
+        self.absorbed_ops.expand(delta)
         self.num_qubits += delta
+
+    @property
+    def num_active_qubits(self):
+        return self.num_qubits - len(self.retired_qubits)
+
+    def retire_qubits(self, qubit_indices):
+        """Clean shrink (inverse of expand+init). Eliminate the destructively-
+        measured qubits' support from every surviving stabilizer/logical row —
+        folding each readout stabilizer's records into the row it clears — then
+        drop the pure-S readout stabilizer rows. Columns are masked (zeroed),
+        not removed, so global qubit indices stay stable.
+        """
+        n = self.num_qubits
+        S = set(int(q) for q in qubit_indices)
+        scol = [q for q in S] + [n + q for q in S]        # S's X and Z columns
+        other = [c for c in range(2 * n) if c not in set(scol)]
+        stab = self.stabilizers
+
+        # pivots = stabilizer rows supported ENTIRELY on S (the destructive-readout
+        # stabilizers). With X/Z-only Paulis each is a single S-column operator.
+        if stab.count:
+            on_other = stab.matrix[:, other].any(axis=1) if other else np.zeros(stab.count, bool)
+            on_s = stab.matrix[:, scol].any(axis=1)
+            pivot_rows = [r for r in range(stab.count) if on_s[r] and not on_other[r]]
+        else:
+            pivot_rows = []
+        pivot_set = set(pivot_rows)
+
+        # clear each S column from every non-pivot stabilizer row and every logical row,
+        # folding the pivot's records
+        for col in scol:
+            piv = next((p for p in pivot_rows if stab.matrix[p, col] == 1
+                        and stab.matrix[p].sum() == 1), None)
+            if piv is None:
+                continue
+            for r in range(stab.count):
+                if r not in pivot_set and stab.matrix[r, col] == 1:
+                    stab.update_row_from_external(r, stab.matrix[piv].copy(), stab.records[piv])
+            for r in range(self.logicals.count):
+                if self.logicals.matrix[r, col] == 1:
+                    self.logicals.update_row_from_external(r, stab.matrix[piv].copy(), stab.records[piv])
+
+        # residual: no surviving (non-pivot) row may still touch S's columns
+        survivors = [r for r in range(stab.count) if r not in pivot_set]
+        resid = False
+        if survivors:
+            resid = resid or stab.matrix[np.ix_(survivors, scol)].any()
+        if self.logicals.count:
+            resid = resid or self.logicals.matrix[:, scol].any()
+        if resid:
+            raise ValueError(
+                f"retire_qubits: residual support on qubits {sorted(S)} after "
+                f"elimination — under-determined or measured in an invalid basis.")
+
+        # drop the readout pivot rows; keep post_select_row_indices consistent
+        stab.remove_rows(pivot_rows)
+        self._remap_rows_after_removal(pivot_rows)
+        # Fix C: an absorbed relation supported on a retired qubit is RESOLVED by that
+        # qubit's destructive readout (its value enters an observable) — drop it from
+        # absorbed_ops so it stops being counted as still-trapped.
+        A = self.absorbed_ops
+        if A.count:
+            keep = [r for r in range(A.count) if not A.matrix[r, scol].any()]
+            if len(keep) != A.count:
+                A.matrix = A.matrix[keep] if keep else np.zeros((0, 2 * n), dtype=np.uint8)
+                A.records = [A.records[r] for r in keep] if A.records else []
+        self.retired_qubits |= S
+
+    def _remap_rows_after_removal(self, removed_sorted):
+        """Shift post_select_row_indices down past removed stabilizer rows."""
+        removed = sorted(set(removed_sorted))
+        if not self.post_select_row_indices:
+            return
+        def shift(idx):
+            return idx - sum(1 for r in removed if r < idx)
+        self.post_select_row_indices = {shift(i) for i in self.post_select_row_indices
+                                        if i not in set(removed)}
 
     def reset_records_for_qubits(self, qubit_indices):
         """
@@ -209,162 +318,6 @@ class SyndromeTracker:
         self.logicals.records = new_log_records
 
         self.validate_logical_count(context="stabilizer canonicalization")
-
-    def rebase_stabilizers_onto_code_basis(
-        self,
-        system: Any,
-        stabilizer_uids: Optional[Set[int]] = None,
-    ) -> None:
-        """Re-express tracked stabilizers in the active code's canonical basis.
-
-        Every requested code stabilizer must already be in the current tracked
-        stabilizer span. Reconstructing the canonical rows from that span also
-        reconstructs their measurement-record parities. Independent remaining
-        directions become the logical tableau.
-
-        This differs from :meth:`stabilizer_canonicalization`, which may insert
-        unmeasured canonical rows when preparing a code for its first SE round.
-        """
-        n = self.num_qubits
-        if stabilizer_uids is None:
-            stabilizer_uids = set(system.active_stabilizer_indices)
-        stab_dicts = [
-            system.stabilizers[uid]
-            for uid in sorted(stabilizer_uids)
-        ]
-        canonical_basis = stabilizers_to_symplectic(system, stab_dicts, n)
-        if canonical_basis.shape[0] == 0:
-            return
-        if self.stabilizers.count == 0:
-            raise RuntimeError(
-                "Cannot rebase an empty stabilizer tableau onto the code basis."
-            )
-
-        canonical_coeffs, is_dependent, _ = solve_linear_decomposition(
-            basis=self.stabilizers.matrix,
-            targets=canonical_basis,
-            reduce_weight=False,
-        )
-        missing = np.flatnonzero(~is_dependent)
-        if len(missing):
-            raise RuntimeError(
-                "Cannot rebase onto the active code basis; canonical rows "
-                f"{missing.tolist()} are missing from the tracker stabilizer span."
-            )
-
-        canonical_records = []
-        for coeffs in canonical_coeffs:
-            records = set()
-            for row_idx in np.flatnonzero(coeffs):
-                records.symmetric_difference_update(
-                    self.stabilizers.records[row_idx]
-                )
-            canonical_records.append(sorted(records))
-
-        if self.logicals.count:
-            full_matrix = np.vstack([
-                self.stabilizers.matrix,
-                self.logicals.matrix,
-            ])
-            full_records = self.stabilizers.records + self.logicals.records
-        else:
-            full_matrix = self.stabilizers.matrix.copy()
-            full_records = list(self.stabilizers.records)
-
-        _, _, logical_indices = solve_linear_decomposition(
-            basis=canonical_basis,
-            targets=full_matrix,
-            reduce_weight=False,
-        )
-        self.stabilizers.matrix = canonical_basis
-        self.stabilizers.records = canonical_records
-        self.logicals.matrix = full_matrix[logical_indices]
-        self.logicals.records = [
-            full_records[idx]
-            for idx in logical_indices
-        ]
-
-        self.validate_logical_count(context="code-basis rebase")
-
-    def promote_stabilizer_rows_to_logicals(
-        self,
-        row_indices: Set[int],
-    ) -> None:
-        """Move selected tracked stabilizer rows into the logical table.
-
-        This is a basis-classification operation, not a measurement update.
-        ``process_mid_measurement`` identifies rows that are eligible for this
-        classification, and the Builder chooses whether its physical protocol
-        has reached a boundary where they should be promoted.
-        """
-        promoted_indices = sorted(row_indices)
-        invalid_indices = [
-            idx
-            for idx in promoted_indices
-            if idx < 0 or idx >= self.stabilizers.count
-        ]
-        if invalid_indices:
-            raise IndexError(
-                "Cannot promote stabilizer rows outside the tracked tableau: "
-                f"{invalid_indices}."
-            )
-        if not promoted_indices:
-            self.validate_logical_count(
-                context="stabilizer-row classification"
-            )
-            return
-
-        promoted_set = set(promoted_indices)
-        kept_indices = [
-            idx
-            for idx in range(self.stabilizers.count)
-            if idx not in promoted_set
-        ]
-        promoted_matrix = self.stabilizers.matrix[promoted_indices]
-        promoted_records = [
-            self.stabilizers.records[idx]
-            for idx in promoted_indices
-        ]
-
-        if self.logicals.count:
-            self.logicals.matrix = np.vstack([
-                self.logicals.matrix,
-                promoted_matrix,
-            ])
-            self.logicals.records.extend(promoted_records)
-        else:
-            self.logicals.matrix = promoted_matrix.copy()
-            self.logicals.records = promoted_records
-
-        old_to_new = {
-            old_idx: new_idx
-            for new_idx, old_idx in enumerate(kept_indices)
-        }
-        if kept_indices:
-            self.stabilizers.matrix = self.stabilizers.matrix[kept_indices]
-        else:
-            self.stabilizers.matrix = np.zeros(
-                (0, 2 * self.num_qubits),
-                dtype=np.uint8,
-            )
-        self.stabilizers.records = [
-            self.stabilizers.records[idx]
-            for idx in kept_indices
-        ]
-        self.post_select_row_indices = {
-            old_to_new[idx]
-            for idx in self.post_select_row_indices
-            if idx in old_to_new
-        }
-        self.stabilizer_with_logical_components = {
-            old_to_new[idx]
-            for idx in self.stabilizer_with_logical_components
-            if idx in old_to_new
-        }
-
-        self.validate_logical_count(
-            context="stabilizer-row classification"
-        )
     
     def logical_canonicalization(
         self,
@@ -488,6 +441,67 @@ class SyndromeTracker:
         self.logicals.matrix = full_matrix[num_stabs:]
         self.logicals.records = full_records[num_stabs:]
 
+    def declare_logical(self, pauli_vec: np.ndarray,
+                        records: Optional[List[int]] = None) -> List[int]:
+        """
+        Promote a DETERMINED operator to a logical observable row
+        (record-seeded logical birth, e.g. the in-place Y-basis
+        initialization of arXiv:2302.07395).
+
+        The operator must lie in span(self.stabilizers): a birth protocol has
+        pinned its value, generally to the XOR of measurement records carried
+        by the pinning rows. The implicit promotion path (WriteBack) only
+        births records-less rows, so a record-pinned logical needs this
+        explicit declaration. The row moves to ``self.logicals`` carrying the
+        pinning records; ONE pinning stabilizer row is removed so the tracked
+        group's rank is unchanged; ``expected_num_logicals`` grows by 1 (the
+        budget change happens at declare time, NOT at patch registration —
+        before the declaration the born observable is genuinely a stabilizer
+        of the state, not a free logical DOF).
+
+        Args:
+            pauli_vec: (2N,) GF(2) symplectic vector of the operator.
+            records: explicit record list overriding the derived pinning
+                records (escape hatch for tests/interop).
+
+        Returns:
+            The record list attached to the new logical row.
+
+        Raises:
+            ValueError: if the operator is not determined by the current
+                stabilizer rows (birth incomplete, or wrong operator).
+        """
+        pauli_vec = np.asarray(pauli_vec, dtype=np.uint8).reshape(1, -1)
+        if pauli_vec.shape[1] != 2 * self.num_qubits:
+            raise ValueError(
+                f"pauli_vec has length {pauli_vec.shape[1]}, expected "
+                f"{2 * self.num_qubits}")
+        coeffs, is_dependent, _ = solve_linear_decomposition(
+            basis=self.stabilizers.matrix,
+            targets=pauli_vec,
+            reduce_weight=True,
+        )
+        if not is_dependent[0]:
+            raise ValueError(
+                "declare_logical: operator is not determined by the current "
+                "stabilizer rows (not in span) — the birth protocol is "
+                "incomplete or the operator is wrong.")
+        pinning = [int(i) for i in np.flatnonzero(coeffs[0])]
+        if records is None:
+            rec_set = set()
+            for i in pinning:
+                rec_set.symmetric_difference_update(self.stabilizers.records[i])
+            records = sorted(rec_set)
+        # Drop one pinning row: the operator leaves span(stabilizers) and the
+        # combined group rank stays constant. Any pinning row works; take the
+        # last for determinism.
+        drop = pinning[-1]
+        self.stabilizers.matrix = np.delete(self.stabilizers.matrix, drop, axis=0)
+        self.stabilizers.records.pop(drop)
+        self.logicals.add_stabilizers(pauli_vec, [list(records)])
+        self.expected_num_logicals += 1
+        return list(records)
+
     def process_initialization(self, init_tableau: np.ndarray):
         """
         Registers new stabilizers from initialization into the tracker.
@@ -500,6 +514,12 @@ class SyndromeTracker:
         """
         self.stabilizers.add_stabilizers(init_tableau)
 
+
+    def process_unitary_block(self, circuit_chunk: stim.Circuit):
+        """Forward-propagate the tracked state through a Clifford circuit."""
+        self._apply_symplectic_matrix(
+            self.get_forward_symplectic_matrix(circuit_chunk, self.num_qubits)
+        )
 
     @staticmethod
     def get_forward_symplectic_matrix(
@@ -558,12 +578,12 @@ class SyndromeTracker:
         if self.logicals.count > 0:
             self.logicals.matrix = (self.logicals.matrix @ symplectic_matrix) % 2
             self.logicals.matrix = self.logicals.matrix.astype(np.uint8)
-
-    def process_unitary_block(self, circuit_chunk: stim.Circuit):
-        """Forward-propagate the tracked state through a Clifford circuit."""
-        self._apply_symplectic_matrix(
-            self.get_forward_symplectic_matrix(circuit_chunk, self.num_qubits)
-        )
+        # Fix C: the absorbed operators are Pauli strings too — apply the same
+        # Clifford so they stay in the current frame (else the span overlap
+        # with stabilizers drifts).
+        if self.absorbed_ops.count > 0:
+            self.absorbed_ops.matrix = (self.absorbed_ops.matrix @ symplectic_matrix) % 2
+            self.absorbed_ops.matrix = self.absorbed_ops.matrix.astype(np.uint8)
 
     def process_resets(
         self,
@@ -736,7 +756,7 @@ class SyndromeTracker:
                     rows_to_remove.add(row_idx)
             self.stabilizer_with_logical_components -= rows_to_remove
 
-    def process_mid_measurement(
+    def process_measurement_block(
         self,
         circuit: stim.Circuit,
         forward_symplectic_matrix: np.ndarray,
@@ -1224,11 +1244,818 @@ class SyndromeTracker:
             for position in promotable_old_positions
         }
 
+    def promote_stabilizer_rows_to_logicals(
+        self,
+        row_indices: Set[int],
+    ) -> None:
+        """Move selected tracked stabilizer rows into the logical table.
+
+        This is a basis-classification operation, not a measurement update.
+        ``process_mid_measurement`` identifies rows that are eligible for this
+        classification, and the Builder chooses whether its physical protocol
+        has reached a boundary where they should be promoted.
+        """
+        promoted_indices = sorted(row_indices)
+        invalid_indices = [
+            idx
+            for idx in promoted_indices
+            if idx < 0 or idx >= self.stabilizers.count
+        ]
+        if invalid_indices:
+            raise IndexError(
+                "Cannot promote stabilizer rows outside the tracked tableau: "
+                f"{invalid_indices}."
+            )
+        if not promoted_indices:
+            self.validate_logical_count(
+                context="stabilizer-row classification"
+            )
+            return
+
+        promoted_set = set(promoted_indices)
+        kept_indices = [
+            idx
+            for idx in range(self.stabilizers.count)
+            if idx not in promoted_set
+        ]
+        promoted_matrix = self.stabilizers.matrix[promoted_indices]
+        promoted_records = [
+            self.stabilizers.records[idx]
+            for idx in promoted_indices
+        ]
+
+        if self.logicals.count:
+            self.logicals.matrix = np.vstack([
+                self.logicals.matrix,
+                promoted_matrix,
+            ])
+            self.logicals.records.extend(promoted_records)
+        else:
+            self.logicals.matrix = promoted_matrix.copy()
+            self.logicals.records = promoted_records
+
+        old_to_new = {
+            old_idx: new_idx
+            for new_idx, old_idx in enumerate(kept_indices)
+        }
+        if kept_indices:
+            self.stabilizers.matrix = self.stabilizers.matrix[kept_indices]
+        else:
+            self.stabilizers.matrix = np.zeros(
+                (0, 2 * self.num_qubits),
+                dtype=np.uint8,
+            )
+        self.stabilizers.records = [
+            self.stabilizers.records[idx]
+            for idx in kept_indices
+        ]
+        self.post_select_row_indices = {
+            old_to_new[idx]
+            for idx in self.post_select_row_indices
+            if idx in old_to_new
+        }
+        self.stabilizer_with_logical_components = {
+            old_to_new[idx]
+            for idx in self.stabilizer_with_logical_components
+            if idx in old_to_new
+        }
+
+        self.validate_logical_count(
+            context="stabilizer-row classification"
+        )
+
+    def validate_logical_count(self, *, context: str = "tracker state") -> None:
+        """Check that explicit and measurement-absorbed logical DOFs add up."""
+        actual = self.logicals.count + self._absorbed_logical_dofs
+        if actual != self.expected_num_logicals:
+            raise RuntimeError(
+                f"After {context}: logical count {self.logicals.count} plus "
+                f"absorbed logical DOFs {self._absorbed_logical_dofs} != "
+                f"expected {self.expected_num_logicals}."
+            )
+
+    def rebase_stabilizers_onto_code_basis(
+        self,
+        system: Any,
+        stabilizer_uids: Optional[Set[int]] = None,
+    ) -> None:
+        """Re-express tracked stabilizers in the active code's canonical basis.
+
+        Every requested code stabilizer must already be in the current tracked
+        stabilizer span. Reconstructing the canonical rows from that span also
+        reconstructs their measurement-record parities. Independent remaining
+        directions become the logical tableau.
+
+        This differs from :meth:`stabilizer_canonicalization`, which may insert
+        unmeasured canonical rows when preparing a code for its first SE round.
+        """
+        n = self.num_qubits
+        if stabilizer_uids is None:
+            stabilizer_uids = set(system.active_stabilizer_indices)
+        stab_dicts = [
+            system.stabilizers[uid]
+            for uid in sorted(stabilizer_uids)
+        ]
+        canonical_basis = stabilizers_to_symplectic(system, stab_dicts, n)
+        if canonical_basis.shape[0] == 0:
+            return
+        if self.stabilizers.count == 0:
+            raise RuntimeError(
+                "Cannot rebase an empty stabilizer tableau onto the code basis."
+            )
+
+        canonical_coeffs, is_dependent, _ = solve_linear_decomposition(
+            basis=self.stabilizers.matrix,
+            targets=canonical_basis,
+            reduce_weight=False,
+        )
+        missing = np.flatnonzero(~is_dependent)
+        if len(missing):
+            raise RuntimeError(
+                "Cannot rebase onto the active code basis; canonical rows "
+                f"{missing.tolist()} are missing from the tracker stabilizer span."
+            )
+
+        canonical_records = []
+        for coeffs in canonical_coeffs:
+            records = set()
+            for row_idx in np.flatnonzero(coeffs):
+                records.symmetric_difference_update(
+                    self.stabilizers.records[row_idx]
+                )
+            canonical_records.append(sorted(records))
+
+        if self.logicals.count:
+            full_matrix = np.vstack([
+                self.stabilizers.matrix,
+                self.logicals.matrix,
+            ])
+            full_records = self.stabilizers.records + self.logicals.records
+        else:
+            full_matrix = self.stabilizers.matrix.copy()
+            full_records = list(self.stabilizers.records)
+
+        _, _, logical_indices = solve_linear_decomposition(
+            basis=canonical_basis,
+            targets=full_matrix,
+            reduce_weight=False,
+        )
+        self.stabilizers.matrix = canonical_basis
+        self.stabilizers.records = canonical_records
+        self.logicals.matrix = full_matrix[logical_indices]
+        self.logicals.records = [
+            full_records[idx]
+            for idx in logical_indices
+        ]
+
+        self.validate_logical_count(context="code-basis rebase")
+
+    def process_mid_measurement(self,
+                                circuit: stim.Circuit,
+                                back_propagated_paulis: np.ndarray,
+                                syn_coords: list,
+                                no_detector_mask: Optional[np.ndarray] = None):
+        """
+        Handles Mid-circuit measurements (assumed to be on syndrome qubits).
+
+        Args:
+            no_detector_mask: Optional boolean array of length num_meas. When
+                no_detector_mask[i] is True the measurement still updates the
+                stabilizer tableau (Step 3) but no DETECTOR instruction is
+                emitted for it (Step 2). Useful for Z-only / X-only memory
+                experiments where one ancilla type is measured without detectors.
+        """
+        num_meas = back_propagated_paulis.shape[0]
+        current_base_idx = self.total_measurements
+        self.total_measurements += num_meas
+
+        # Reset per-round tracking (these are only meaningful within a single PMM call)
+        self.stabilizer_with_logical_components = set()
+        self._gauge_logical_vectors = []
+
+        # Reorder stabilizer rows: empty-record rows first.
+        # Fresh init rows (rec=[]) represent newly introduced qubits whose DOF should
+        # be consumed first by measurements, before established stabilizers with SE records.
+        # This produces cleaner detectors and correct logical observable construction.
+        num_stabs_pre = self.stabilizers.count
+        if num_stabs_pre > 0:
+            empty_indices = [i for i in range(num_stabs_pre) if self.stabilizers.records[i] == []]
+            other_indices = [i for i in range(num_stabs_pre) if self.stabilizers.records[i] != []]
+            if empty_indices and other_indices:  # only reorder if there's a mix
+                reorder = empty_indices + other_indices
+                self.stabilizers.matrix = self.stabilizers.matrix[reorder]
+                self.stabilizers.records = [self.stabilizers.records[i] for i in reorder]
+                # Remap post_select_row_indices
+                if self.post_select_row_indices:
+                    idx_map = {old: new for new, old in enumerate(reorder)}
+                    self.post_select_row_indices = {
+                        idx_map.get(k, k) for k in self.post_select_row_indices
+                    }
+
+        # ======================================================================
+        # Step 1: Combine Stabilizers and Logicals into Full Tableau
+        # ======================================================================
+        num_stabs = self.stabilizers.count
+        num_logs = self.logicals.count
+        
+        # If logicals is empty, full_tableau is just stabilizers
+        if num_logs > 0:
+            full_matrix = np.vstack([self.stabilizers.matrix, self.logicals.matrix])
+            # Flatten records list
+            full_records = self.stabilizers.records + self.logicals.records
+        else:
+            full_matrix = self.stabilizers.matrix.copy() # Copy to avoid reference issues during loop
+            full_records = list(self.stabilizers.records) # Deep copy of list structure
+
+        import os as _os
+        import sys as _sys
+        _dbg = _os.environ.get('LIGHTSTIM_DEBUG_PMM')
+        self._pmm_call = getattr(self, '_pmm_call', 0) + 1
+        if _dbg:
+            print(f"[pmm#{self._pmm_call}] entry: num_stabs={num_stabs} "
+                  f"num_logs={num_logs} expected={self.expected_num_logicals} "
+                  f"absorbed_rank={_gf2_rank(self.absorbed_ops.matrix)}", file=_sys.stderr)
+        if _os.environ.get('LIGHTSTIM_DEBUG_ROW'):
+            _n = self.num_qubits
+            for _k in range(num_logs):
+                _r = self.logicals.matrix[_k]
+                _terms = []
+                for _q in range(_n):
+                    _x, _z = _r[_q], _r[_n + _q]
+                    if _x or _z:
+                        _terms.append(f"{'Y' if _x and _z else ('X' if _x else 'Z')}{_q}")
+                print(f"[row] pmm#{self._pmm_call} log{_k}: {' '.join(_terms)}",
+                      file=_sys.stderr)
+        
+        # ======================================================================
+        # Step 2: Process Back-propagated Pauli measurements (Update / Detector)
+        # ======================================================================
+        # Use a temporary tableau view so we can call update_row / replace_row.
+        temp_full = PauliTableau(self.num_qubits)
+        temp_full.matrix = full_matrix
+        temp_full.records = full_records
+
+        _round_cands = []  # Fix C: (meas_row, log_vec) of logical-carrying measurements
+        _restore_credit = 0  # logical rows eaten by Case A this call (see below)
+        _case_a_log_pivots = set()  # logical-position pivots Case A accounted
+        _log_rows_anti = set()      # logical rows update_row'd for anticommuting
+
+        for i in range(num_meas):
+            meas_pauli = back_propagated_paulis[i]
+            meas_row = meas_pauli.reshape(1, -1)
+            meas_abs_idx = current_base_idx + i
+
+            # Check commutativity against existing stabilizers and logicals
+            comm_check = check_commutativity(meas_row, full_matrix)
+            anti_comm_indices = np.where(comm_check[0])[0]
+            if _os.environ.get('LIGHTSTIM_DEBUG_ROW'):
+                _anti_log = [int(j) - num_stabs for j in anti_comm_indices
+                             if j >= num_stabs]
+                if _anti_log:
+                    _anti_stab = [int(j) for j in anti_comm_indices
+                                  if j < num_stabs]
+                    print(f"[row] pmm#{self._pmm_call} meas{i}: anti with "
+                          f"LOG rows {_anti_log}, stab rows {_anti_stab[:6]}"
+                          f"{'...' if len(_anti_stab) > 6 else ''} "
+                          f"-> pivot={'LOG' if anti_comm_indices[0] >= num_stabs else 'STAB'}",
+                          file=_sys.stderr)
+
+            if len(anti_comm_indices) > 0:
+                # --- Case A: Anti-commutes (State Update) ---
+                pivot = anti_comm_indices[0]
+                # Update other anti-commuting rows
+                for other in anti_comm_indices[1:]:
+                    temp_full.update_row(other, pivot) # (target, source)
+                    if other >= num_stabs:
+                        _log_rows_anti.add(int(other))
+
+                # Replace the pivot with the back_propagated_paulis
+                temp_full.replace_row(pivot, meas_pauli, [meas_abs_idx])
+
+                if pivot >= num_stabs and _dbg:
+                    print(f"[pmm#{self._pmm_call}] CaseA meas{i}: LOGICAL pivot="
+                          f"{pivot} (log_row {pivot - num_stabs}) "
+                          f"anti={anti_comm_indices.tolist()}", file=_sys.stderr)
+                # NOTE: the replaced pivot row now equals the measured Pauli,
+                # so it is linearly dependent on the measurement basis and
+                # never re-enters the WriteBack independent basis — no
+                # explicit demotion bookkeeping is needed.
+                if pivot >= num_stabs:
+                    _case_a_log_pivots.add(int(pivot))
+                    # A logical row was eaten by the measurement: one tracked
+                    # observable slot gone.  Also bank a RESTORE CREDIT: if
+                    # the same block kicks a previously promoted joint out of
+                    # the stabilizer group, the freed direction resurfaces in
+                    # WriteBack as an independent records-less row with no
+                    # budget slot left (kill-then-restore exchange, fig5
+                    # all-X PPM4) — the credit lets WriteBack re-promote it
+                    # and put the slot back.
+                    self.expected_num_logicals -= 1
+                    _restore_credit += 1
+
+            else:
+                # --- Case B: Commutes (Detector) ---
+                # Detector is formed by decomposing Back-propagated Pauli Measurements into existing STABILIZERS only (rows in the stabilizer tableau).
+                # (Logicals do not contribute to the decomposition)
+
+                if not meas_row.any():
+                    # Identity back-propagation: the measured operator
+                    # terminates entirely on same-chunk resets (K&F-style
+                    # flag / relay ancilla).  Deterministic every round ->
+                    # single-measurement detector, K&F's flag semantics.
+                    if no_detector_mask is None or not no_detector_mask[i]:
+                        coords = list(syn_coords[i]) + [0]
+                        _append_detector(
+                            circuit,
+                            [stim.target_rec(meas_abs_idx - self.total_measurements)],
+                            coords,
+                            post_select=tuple(coords) in self.post_select_detector_coords,
+                        )
+                    continue
+
+                if num_stabs > 0:
+                    # First check if meas_row is exactly one row in curr_stab_matrix
+                    # Directly compare meas_row against current stabilizer rows
+                    curr_stab_matrix = full_matrix[:num_stabs]
+                    matching_rows = np.where(np.all(curr_stab_matrix == meas_row, axis=1))[0]
+                    if len(matching_rows) > 0:
+                        # Raise warning if there are multiple identical stabilizer rows matching this measurement
+                        if len(matching_rows) > 1:
+                            warnings.warn(
+                                f"Found {len(matching_rows)} identical stabilizer rows matching this measurement. "
+                                "Check that the stabilizer tableau has no duplicate rows.",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                        # Directly construct the detector
+                        row_idx = matching_rows[0]  # Take the first matching row
+                        args = [stim.target_rec(meas_abs_idx - self.total_measurements)]
+                        for r in full_records[row_idx]:
+                            if r >= 0:
+                                args.append(stim.target_rec(r - self.total_measurements))
+                        if no_detector_mask is None or not no_detector_mask[i]:
+                            coords = list(syn_coords[i]) + [0]
+                            _append_detector(
+                                circuit, args, coords,
+                                post_select=tuple(coords) in self.post_select_detector_coords,
+                            )
+                    else: # meas_row is not exactly one row in curr_stab_matrix, but a linear combination of rows in the full matrix
+                        # decompose meas_row into existing stabilizers
+                        coeffs, is_dependent, _ = solve_linear_decomposition(
+                            basis=full_matrix,
+                            targets=meas_row
+                        )
+                        # Note: Here we use the full matrix as the basis, not just the stabilizer tableau.
+                        # The back-propagated Pauli may contain present logical operator components. e.g., Logical ZZ over two |0> states, then
+                        # the last Z gauge operator consisting ZZ measurements can be written as the linear combination of previous Z gauges and two logical Z operators of two patches.
+                        # If we don't use the full matrix as the basis, these measurements will be identified as independent basis and treated as logicals, which is incorrect.
+                        # However, these measurements, although they can be decomposed, cannot be detectors, because their logical operator components cannot be measured in the middle of the circuit
+                        # and cannot give syndrome information. This will be identified when we construct detectors.
+
+                        # Construct a detector
+                        if is_dependent[0]:
+                            args = [stim.target_rec(meas_abs_idx - self.total_measurements)]
+                            comp_indices = np.where(coeffs[0])[0]
+                            if max(comp_indices) >= num_stabs:
+                                # The measurement contains a logical component, and cannot be a detector
+                                # Flag this row for further logical observable construction
+                                self.stabilizer_with_logical_components.add(i)
+                                # Track which logical indices this measurement involves (for rank computation)
+                                log_vec = np.zeros(num_logs, dtype=np.uint8)
+                                for c in comp_indices:
+                                    if c >= num_stabs:
+                                        log_vec[c - num_stabs] = 1
+                                self._gauge_logical_vectors.append(log_vec)
+                                # Fix C: defer the add — decide AFTER the rebuild whether
+                                # this measurement GENUINELY absorbed (its logical content
+                                # still contains a NON-surviving logical = it trapped a DOF),
+                                # not merely carries a logical component (banked/redundant).
+                                _round_cands.append((meas_row.copy(), log_vec.copy()))
+                                import os as _os
+                                if _os.environ.get('LIGHTSTIM_DEBUG_ABSORB'):
+                                    _parts = []
+                                    for c in comp_indices:
+                                        recs = full_records[c]
+                                        kind = ('LOG' if c >= num_stabs else
+                                                'STAB-norec' if recs == [] else
+                                                'STAB-unmeas' if any(r < 0 for r in recs) else
+                                                'STAB')
+                                        _parts.append(f"{kind}@{c}(rec={recs if len(recs) < 4 else recs[:3]+['…']})")
+                                    print(f"[cand-debug] meas#{i} decomposes -> {_parts}")
+                                continue
+                            # Otherwise, purely depends on stabilizers, construct a detector
+                            # Use set-based XOR for O(1) toggle instead of O(n) list scan
+                            args_set = set(args)
+                            for c_idx in comp_indices:
+                                # Map back to full records (skip UNMEASURED_STAB_RECORD)
+                                for r in full_records[c_idx]:
+                                    if r < 0:
+                                        continue
+                                    rec_to_append = stim.target_rec(r - self.total_measurements)
+                                    if rec_to_append in args_set:
+                                        args_set.remove(rec_to_append)
+                                    else:
+                                        args_set.add(rec_to_append)  # addition modulo 2
+                            args = list(args_set)
+
+                            if no_detector_mask is None or not no_detector_mask[i]:
+                                coords = list(syn_coords[i]) + [0]
+                                _append_detector(
+                                    circuit, args, coords,
+                                    post_select=tuple(coords) in self.post_select_detector_coords,
+                                )
+                        else:
+                            # Measurement row commute but is independent of the current full tableau,
+                            # but this should never happen in a well-defined full tableau, unless there are degrees of freedom missing.
+                            raise RuntimeError(
+                                f"Measurement {i} commutes with all rows in the current full tableau (stabilizers + logicals) but is linearly independent.\n"
+                                f"This implies the Full (Stabilizer + Logicals) Tableau is incomplete (Rank < num_qubits).\n"
+                                f"Please ensure all qubits are initialized and added to the tracker before measurement."
+                            )
+
+        # ======================================================================
+        # Step 3: Write Back with "Clean" Basis
+        # ======================================================================
+        # After detector construction, we always decompose the system into the "Clean Basis" of the measurements we just performed.
+        # - Dependent rows in Full Tableau -> Replaced by Clean Measurements (Stabilizers).
+        # - Independent rows in Full Tableau -> Identified as Logicals.
+        # This automatically determines the right logicals, e.g. after first round of syndrome extraction
+
+        # Basis: The clean measurements (Back-propagated Paulis)
+        # Targets: The updated Full Tableau (System State)
+        # new_basis_indices: Indices in full_matrix that form the Logical Basis.
+        #
+        # IMPORTANT: Reorder targets so logical rows come BEFORE stabilizer rows.
+        # This gives logicals priority for RREF pivots, preventing stabilizer rows
+        # from "stealing" a logical's pivot when they share the same independent direction.
+        # Without this, logicals can be lost (e.g., PQRM logical Z in CrossLS Z-state).
+        if num_logs > 0:
+            reordered_targets = np.vstack([full_matrix[num_stabs:], full_matrix[:num_stabs]])
+            reordered_records = full_records[num_stabs:] + full_records[:num_stabs]
+        else:
+            reordered_targets = full_matrix
+            reordered_records = full_records
+
+        _, is_dependent, new_basis_indices = solve_linear_decomposition(
+            basis=back_propagated_paulis,
+            targets=reordered_targets
+        )
+
+        # Map reordered indices back to original full_matrix semantics:
+        # reordered[0..num_logs-1]       = original logicals  (full_matrix[num_stabs..end])
+        # reordered[num_logs..num_logs+num_stabs-1] = original stabs (full_matrix[0..num_stabs-1])
+        def _remap(idx):
+            if idx < num_logs:
+                return num_stabs + idx          # logical row
+            else:
+                return idx - num_logs            # stabilizer row
+
+        # 1. Update Logicals
+        # Independent rows fall into:
+        # (a) Logical rows: stay as logicals
+        # (b) Stab rows with records: stay as old stabilizers (not measured this round)
+        # (c) Stab rows without records: become logicals
+        if len(new_basis_indices) > 0:
+            new_log_basis_indices = []
+            old_stab_basis_indices = []
+
+            # Promotion budget: a records-less row may be promoted to a
+            # logical ONLY while there is an unfilled logical slot
+            # (deferred-init recognition).  A block whose group leaves an
+            # ancilla-region gauge direction unmeasured (e.g. the corridor
+            # ribbon between two walls) produces the SAME row signature with
+            # no slot left — it must stay a records-less stabilizer, not
+            # inflate the logical census.  solve_linear_decomposition does
+            # NOT return basis rows in target order (a promotion candidate
+            # can precede a surviving logical row — fig5 all-X PPM4), so
+            # the surviving logicals are counted UP FRONT; counting only
+            # the already-seen ones would hand their slots to earlier
+            # candidates and inflate the census.
+            _absorbed_pre = _gf2_rank(self.absorbed_ops.matrix)
+            # A logical row that went DEPENDENT without being a Case-A pivot
+            # was measured through stab-shadowed pivots: every anticommuting
+            # measurement found a lower-indexed stabilizer pivot, so the row
+            # was update_row'd into the (measurements + stabs) span instead
+            # of being replaced.  The DOF is consumed all the same (measured:
+            # the M(Z1Z2)-then-M(X1X2) pair — four lobes anticommute with
+            # the surviving Z-string row, all four pivots land on stabs) —
+            # account it exactly like a Case-A kill: expected -= 1, and bank
+            # the restore credit for a possible same-block resurface.
+            _indep = set(new_basis_indices)
+            for _ri in range(num_logs):
+                _oi = num_stabs + _ri
+                if (_ri not in _indep and _oi not in _case_a_log_pivots
+                        and _oi in _log_rows_anti):
+                    self.expected_num_logicals -= 1
+                    _restore_credit += 1
+                    if _dbg:
+                        print(f"[pmm#{self._pmm_call}] dependent LOG row "
+                              f"{_ri} measured via stab-shadowed pivots: "
+                              f"expected->{self.expected_num_logicals}",
+                              file=_sys.stderr)
+            _n_surviving = sum(1 for ri in new_basis_indices
+                               if _remap(ri) >= num_stabs)
+            # Slots about to be CONSUMED by this round's GENUINE absorbs.
+            # Fix C appends them only AFTER the WriteBack, but the promotion
+            # budget must already see them: a live logical measured this
+            # round frees its basis slot for the absorb, NOT for a
+            # deferred-init promotion (measured: Z33Z34 right after the
+            # six-body X joint — the freed slot got a records-less stab
+            # promoted into it, the absorb then landed on top, census
+            # expected+1).  Mirrors Fix C's gates exactly: zero the
+            # surviving bits, dedup by logical content, count only physical
+            # rank growth over the persistent absorbed_ops.
+            _surv_pre = {_remap(ri) - num_stabs for ri in new_basis_indices
+                         if _remap(ri) >= num_stabs}
+            _pend_lvs = np.zeros((0, num_logs), dtype=np.uint8)
+            _pend_mat = self.absorbed_ops.matrix
+            _pend_n = self.absorbed_ops.count
+            _pending = 0
+            for _mp, _lv in _round_cands:
+                _lv2 = _lv.copy()
+                for _j in _surv_pre:
+                    if _j < _lv2.shape[0]:
+                        _lv2[_j] = 0
+                if not _lv2.any():
+                    continue
+                if _gf2_rank(np.vstack([_pend_lvs, _lv2])) == \
+                        _pend_lvs.shape[0]:
+                    continue
+                _pend_lvs = np.vstack([_pend_lvs, _lv2])
+                if _gf2_rank(np.vstack([_pend_mat, _mp])) > _pend_n:
+                    _pend_mat = (np.vstack([_pend_mat, _mp]) if _pend_n
+                                 else _mp.astype(np.uint8).reshape(1, -1))
+                    _pend_n += 1
+                    _pending += 1
+            _n_promoted = 0
+            for ri in new_basis_indices:
+                orig_idx = _remap(ri)
+                orig_record = reordered_records[ri]
+                if _dbg and (orig_idx >= num_stabs or orig_record == []):
+                    _r = full_matrix[orig_idx]
+                    _n = _r.shape[0] // 2
+                    _sup = sorted(set(np.where(_r[:_n])[0].tolist())
+                                  | set(np.where(_r[_n:])[0].tolist()))
+                    print(f"[pmm#{self._pmm_call}] WriteBack row orig_idx="
+                          f"{orig_idx} ({'LOG' if orig_idx >= num_stabs else 'STAB'}) "
+                          f"rec={orig_record} "
+                          f"w={len(_sup)} sup={_sup[:8]}{'...' if len(_sup) > 8 else ''}", file=_sys.stderr)
+                if orig_idx >= num_stabs:
+                    # Logical row → stays as logical
+                    new_log_basis_indices.append(orig_idx)
+                elif orig_record == []:
+                    if (_n_surviving + _n_promoted + _absorbed_pre + _pending
+                            < self.expected_num_logicals):
+                        # Stab row without records → becomes logical
+                        new_log_basis_indices.append(orig_idx)
+                        _n_promoted += 1
+                        if _os.environ.get('LIGHTSTIM_DEBUG_ABSORB'):
+                            _r = full_matrix[orig_idx]
+                            _n = _r.shape[0] // 2
+                            _sup = sorted(set(np.where(_r[:_n])[0].tolist())
+                                          | set(np.where(_r[_n:])[0].tolist()))
+                            print(f"[promote-debug] record-less row@{orig_idx} promoted "
+                                  f"to logical, support qubits={_sup}")
+                    elif _restore_credit > 0:
+                        # no free slot BUT a logical row was eaten by Case A
+                        # this block: the eaten slot's DOF resurfaced here (a
+                        # kill-then-restore exchange with a previously
+                        # promoted joint — the measurement kicked the joint
+                        # out of the stabilizer group and its direction is
+                        # independent again).  Re-promote and put the slot
+                        # back; net census change of the block is zero.
+                        new_log_basis_indices.append(orig_idx)
+                        _n_promoted += 1
+                        self.expected_num_logicals += 1
+                        _restore_credit -= 1
+                        if _dbg:
+                            print(f"[pmm#{self._pmm_call}] restore-credit "
+                                  f"promote row {orig_idx}, expected->"
+                                  f"{self.expected_num_logicals}",
+                                  file=_sys.stderr)
+                    else:
+                        # no free slot: ancilla-gauge direction — keep it as a
+                        # records-less stabilizer row (still needed as a basis
+                        # element for future decompositions).  Tagged: its
+                        # init-vs-readout parity involves the UNWATCHED gauge
+                        # direction, so relations through it must not become
+                        # detectors (each gauge-flipping error is already a
+                        # 2-symptom event on the neighbouring checks; the
+                        # global parity would attach an irreducible third
+                        # symptom to every one of them).
+                        old_stab_basis_indices.append(orig_idx)
+                        # sentinel record -1 marks the UNWATCHED gauge row
+                        # explicitly (readout must not infer gauge-ness from
+                        # an empty record list: legitimately records-less
+                        # rows exist in other flows, e.g. color-code
+                        # rebased closures) — negative records are skipped
+                        # by every record consumer.
+                        reordered_records[ri] = [-1]
+                        if _os.environ.get('LIGHTSTIM_DEBUG_ABSORB'):
+                            print(f"[promote-debug] record-less row@{orig_idx} budget full,"
+                                  f" kept as gauge stabilizer row (not promoted)")
+                else:
+                    # Stab row with records → stays as old stabilizer
+                    old_stab_basis_indices.append(orig_idx)
+
+            self.logicals.matrix = full_matrix[new_log_basis_indices]
+            self.logicals.records = [full_records[i] for i in new_log_basis_indices]
+        else:
+            new_log_basis_indices = []
+            old_stab_basis_indices = []
+            self.logicals = PauliTableau(self.num_qubits)  # empty logicals
+
+        # 2. Update Stabilizers
+        # Reset stabilizer tableau to the canonical measurement basis.
+        new_stab_records = [[self.total_measurements - num_meas + i] for i in range(num_meas)]
+
+        # Build old_stab part: rows with records that stayed as stabilizers
+        old_stab_matrix = full_matrix[old_stab_basis_indices]
+        old_stab_records = [full_records[i] for i in old_stab_basis_indices]
+
+        self.stabilizers.matrix = np.vstack([back_propagated_paulis, old_stab_matrix])
+        self.stabilizers.records = new_stab_records + old_stab_records
+
+        # Update post_select_row_indices: map old full_matrix indices to new stabilizer indices.
+        # - Old stab rows in old_stab_basis_indices → new indices num_meas, num_meas+1, ...
+        # - Dependent rows (absorbed into measurement basis) → find which measurement rows captured them
+        if self.post_select_row_indices:
+            new_ps = set()
+            # Map old stab rows that survived
+            for j, old_idx in enumerate(old_stab_basis_indices):
+                if old_idx in self.post_select_row_indices:
+                    new_ps.add(num_meas + j)
+            # Map dependent rows: decompose against measurement basis to find which rows captured them
+            # Map dependent rows: decompose against measurement basis to find which rows captured them
+            # Note: is_dependent uses reordered indices; map post_select old_idx to reordered idx
+            coeffs_ps, _, _ = solve_linear_decomposition(
+                basis=back_propagated_paulis,
+                targets=full_matrix,
+                reduce_weight=False,
+            )
+            for old_idx in self.post_select_row_indices:
+                if old_idx < full_matrix.shape[0]:
+                    # Decompose against original full_matrix (not reordered)
+                    row = full_matrix[old_idx:old_idx+1]
+                    c, dep, _ = solve_linear_decomposition(basis=back_propagated_paulis, targets=row, reduce_weight=False)
+                    if dep[0]:
+                        meas_indices = np.where(c[0])[0]
+                        new_ps.update(int(m) for m in meas_indices)
+            self.post_select_row_indices = new_ps
+
+        # 3. Final Sanity Check (The Guardrail)
+        # Determine which logical indices survived in the logicals tableau
+        surviving_log_indices = set(
+            i - num_stabs for i in new_log_basis_indices
+            if i >= num_stabs
+        ) if new_log_basis_indices else set()
+
+        # Fix C: add operators that GENUINELY absorbed this round — those whose logical
+        # content, after zeroing the SURVIVING (still-free) logicals, is non-zero (they
+        # trapped a DOF). A measurement that only involves surviving logicals is banked /
+        # redundant and is NOT added. Dedup by physical rank.
+        import os as _os
+        if _os.environ.get('LIGHTSTIM_DEBUG_ABSORB'):
+            print(f"[absorb-debug] round cands={len(_round_cands)} "
+                  f"surviving_log_indices={sorted(surviving_log_indices)} "
+                  f"num_stabs={num_stabs} num_logs={num_logs} "
+                  f"logicals.count(post)={len(new_log_basis_indices) if new_log_basis_indices else 0}")
+            for _k, (_mp, _lv) in enumerate(_round_cands):
+                print(f"[absorb-debug]   cand{_k}: log_vec={np.where(_lv)[0].tolist()} "
+                      f"weight={int(_mp.sum())}")
+            if len(_round_cands) > 1:
+                # sum of candidate rows (physical): is it decomposable against this
+                # round's measurement basis / the stabilizer basis?
+                _sum = _round_cands[0][0].copy()
+                for _mp, _ in _round_cands[1:]:
+                    _sum = _sum ^ _mp
+                _, _dep_m, _ = solve_linear_decomposition(
+                    basis=back_propagated_paulis, targets=_sum.reshape(1, -1))
+                _, _dep_s, _ = solve_linear_decomposition(
+                    basis=full_matrix[:num_stabs], targets=_sum.reshape(1, -1))
+                _lvsum = _round_cands[0][1].copy()
+                for _, _lv in _round_cands[1:]:
+                    _lvsum = _lvsum ^ _lv
+                print(f"[sum-debug] candidate sum: log_vec={np.where(_lvsum)[0].tolist()} "
+                      f"in_measurement_span={bool(_dep_m[0])} "
+                      f"in_stabilizer_span={bool(_dep_s[0])}")
+        _round_lvs = np.zeros((0, num_logs), dtype=np.uint8)
+        for _mp, _lv in _round_cands:
+            _lv2 = _lv.copy()
+            for _j in surviving_log_indices:
+                if _j < _lv2.shape[0]:
+                    _lv2[_j] = 0
+            if not _lv2.any():
+                continue
+            # dedup by LOGICAL content within the round: two measurement rows
+            # trapping the SAME logical relation (physical representatives that
+            # differ by stabilizers — e.g. an N-fold joint seen through several
+            # wall checks) are ONE absorbed DOF, not two
+            if _gf2_rank(np.vstack([_round_lvs, _lv2])) == _round_lvs.shape[0]:
+                continue
+            _round_lvs = np.vstack([_round_lvs, _lv2])
+            _A = self.absorbed_ops
+            if _gf2_rank(np.vstack([_A.matrix, _mp])) > _A.count:
+                _A.matrix = np.vstack([_A.matrix, _mp]) if _A.count else _mp.astype(np.uint8).copy()
+                _A.records = list(_A.records) + [[]]
+
+        # Combination absorption: a SUBSET of this round's logical-carrying
+        # measurements can trap a combined relation even though every single
+        # row's tail survives (e.g. an N-fold joint whose arms each carry one
+        # patch tail, reset-truncated at the corridor).  The combination is
+        # code-determined iff the pure logical part of its tail sum lies in
+        # the span of this round's measurements plus RECORD-BEARING stabilizer
+        # rows (records-less rows are init-only gauge directions — needing one
+        # means the combination is NOT measured by the code).  On success the
+        # sum row is absorbed and ONE participating logical row is folded out
+        # of the rebuilt tableau (the combination is no longer free).
+        if len(_round_cands) >= 2 and num_logs > 0 and len(_round_cands) <= 8:
+            import itertools as _it
+            _rec_rows = [k for k in range(num_stabs) if full_records[k]]
+            _det_basis = (np.vstack([back_propagated_paulis,
+                                     full_matrix[_rec_rows]])
+                          if _rec_rows else back_propagated_paulis)
+            for _size in range(2, len(_round_cands) + 1):
+                for _combo in _it.combinations(range(len(_round_cands)), _size):
+                    _lvsum = _round_cands[_combo[0]][1].copy()
+                    _mpsum = _round_cands[_combo[0]][0].copy()
+                    for _k in _combo[1:]:
+                        _lvsum = _lvsum ^ _round_cands[_k][1]
+                        _mpsum = _mpsum ^ _round_cands[_k][0]
+                    if not _lvsum.any():
+                        continue
+                    _bits = set(np.where(_lvsum)[0].tolist())
+                    if not _bits <= surviving_log_indices:
+                        continue        # partially consumed by the rebuild
+                    if _gf2_rank(np.vstack([_round_lvs, _lvsum])) == \
+                            _round_lvs.shape[0]:
+                        continue        # relation already accounted
+                    _t = np.zeros_like(_mpsum)
+                    for _j in _bits:
+                        _t = _t ^ full_matrix[num_stabs + _j]
+                    _, _dep, _ = solve_linear_decomposition(
+                        basis=_det_basis, targets=_t.reshape(1, -1))
+                    if not _dep[0]:
+                        continue        # not measured by the code
+                    _A = self.absorbed_ops
+                    if _gf2_rank(np.vstack([_A.matrix, _mpsum])) > _A.count:
+                        _A.matrix = (np.vstack([_A.matrix, _mpsum])
+                                     if _A.count
+                                     else _mpsum.astype(np.uint8).copy())
+                        _A.records = list(_A.records) + [[]]
+                        # fold one participating row out of the logicals
+                        for _j in sorted(_bits, reverse=True):
+                            if (num_stabs + _j) in new_log_basis_indices:
+                                _pos = new_log_basis_indices.index(
+                                    num_stabs + _j)
+                                self.logicals.matrix = np.delete(
+                                    self.logicals.matrix, _pos, axis=0)
+                                self.logicals.records.pop(_pos)
+                                new_log_basis_indices.pop(_pos)
+                                surviving_log_indices.discard(_j)
+                                break
+                        import os as _os
+                        if _os.environ.get('LIGHTSTIM_DEBUG_ABSORB'):
+                            print(f"[combo-debug] combo absorb log_vec="
+                                  f"{sorted(_bits)} (cands={list(_combo)})")
+                    _round_lvs = np.vstack([_round_lvs, _lvsum])
+
+        # Number of live logical DOFs currently folded into the stabilizer group. Counted
+        # from the PERSISTENT absorbed_ops (rank), which — unlike the old per-round gauge
+        # tally — survives across rounds/PPMs that do not re-measure an earlier absorb.
+        num_absorbed = _gf2_rank(self.absorbed_ops.matrix)
+
+        if _dbg:
+            print(f"[pmm#{self._pmm_call}] exit: logicals={self.logicals.count} "
+                  f"absorbed={num_absorbed} expected={self.expected_num_logicals}", file=_sys.stderr)
+
+        if (num_absorbed + self.logicals.count) != self.expected_num_logicals:
+            raise RuntimeError(
+                 f"[Error] Logical Count Mismatch!\n"
+                 f"Expected: {self.expected_num_logicals}, \n"
+                 f"Found: (1) Logicals {self.logicals.count}, \n"
+                 f"(2) Absorbed Logical DOF (rank) {num_absorbed}\n"
+                 f"(3) Measurements with Logical Components {len(self.stabilizer_with_logical_components)}\n"
+             )
+
+        # 4. Clear redundant swlc entries for surviving logicals.
+        # If a gauge measurement's logical components ALL survived as logicals,
+        # the logical itself will be the observable — the swlc row is redundant.
+        if surviving_log_indices and self._gauge_logical_vectors:
+            swlc_sorted = sorted(self.stabilizer_with_logical_components)
+            swlc_to_remove = set()
+            for meas_idx, log_vec in zip(swlc_sorted, self._gauge_logical_vectors):
+                log_indices = set(np.where(log_vec)[0])
+                if log_indices.issubset(surviving_log_indices):
+                    swlc_to_remove.add(meas_idx)
+            self.stabilizer_with_logical_components -= swlc_to_remove
+
     def process_data_measurement(self,
                                   circuit: stim.Circuit,
                                   final_paulis: np.ndarray,
                                   idx_to_coord_map: Dict[int, Tuple[float, float]],
-                                  syndrome_qubit_indices: set = None):
+                                  syndrome_qubit_indices: set = None,
+                                  resolve_absorbed: bool = True):
         """
         Handles Final Data Qubit Measurements using Gaussian Elimination.
 
@@ -1249,7 +2076,61 @@ class SyndromeTracker:
         num_new_meas = final_paulis.shape[0]
         base_meas_idx = self.total_measurements
         self.total_measurements += num_new_meas
-        
+
+        # Budget delta (independent, matrix-driven): a PATCH readout that reads out a live
+        # logical removes exactly that many DOFs from the live set. Snapshot the free
+        # (standing) and absorbed counts BEFORE the readout mutates them; at the end we
+        # decrement `expected_num_logicals` by however many were actually resolved. This is
+        # a pure delta — it never re-syncs expected to standing+absorbed, so `expected`
+        # stays an independent budget and a prior matrix discrepancy is preserved for the
+        # guardrail to catch rather than silently erased.
+        _std_before = self.logicals.count
+        _abs_before = self.num_absorbed_dof()
+
+        # Fix C: reconcile absorbed_ops with this readout.
+        #   - PATCH readout (resolve_absorbed=True): the readout reads out a patch's logical
+        #     value, so any absorbed relation supported on the measured qubits is RECORDED —
+        #     drop those rows from absorbed_ops.
+        #   - CORRIDOR/bus readout (resolve_absorbed=False): only the bus is measured out; the
+        #     patch-patch relation persists. But an absorbed op stored on the bus qubits would
+        #     otherwise dangle on measured-out columns, so FOLD the bus support out (zero the
+        #     measured columns), leaving the patch-part of the relation. A later patch readout
+        #     (or retire) then resolves that patch-part.
+        A = self.absorbed_ops
+        if A.count and num_new_meas:
+            n = self.num_qubits
+            meas_q = set(int(c % n) for c in np.where(final_paulis.any(axis=0))[0])
+            mcols = [q for q in meas_q] + [q + n for q in meas_q]
+            if resolve_absorbed:
+                keep = [r for r in range(A.count) if not A.matrix[r, mcols].any()]
+            else:
+                A.matrix = A.matrix.copy()
+                # An absorbed relation is only defined MOD the stabilizer group; a
+                # stored rep may sit entirely on bus qubits (e.g. the joint of a
+                # colour-wall corridor reduces to a weight-2 bus operator).  Before
+                # folding the bus columns out, re-express each touched row off the
+                # measured qubits wherever the group allows — the patch-patch
+                # relation survives the bus readout.  Rows whose measured-column
+                # pattern the stabilizers cannot cancel keep the fold-and-drop
+                # behaviour below.
+                touched = [r for r in range(A.count) if A.matrix[r, mcols].any()]
+                if touched and self.stabilizers.count:
+                    coeffs, dep, _ = solve_linear_decomposition(
+                        basis=self.stabilizers.matrix[:, mcols],
+                        targets=A.matrix[np.ix_(touched, mcols)],
+                        reduce_weight=False)
+                    for k, r in enumerate(touched):
+                        if dep[k]:
+                            comb = (coeffs[k][None, :]
+                                    @ self.stabilizers.matrix) % 2
+                            A.matrix[r] = (A.matrix[r] + comb[0]) % 2
+                A.matrix = A.matrix.astype(np.uint8)
+                A.matrix[:, mcols] = 0
+                keep = [r for r in range(A.count) if A.matrix[r].any()]
+            if len(keep) != A.count:
+                A.matrix = A.matrix[keep] if keep else np.zeros((0, 2 * n), dtype=np.uint8)
+                A.records = [A.records[r] for r in keep] if A.records else []
+
         num_stabs = self.stabilizers.count
         num_logs = self.logicals.count
 
@@ -1316,7 +2197,7 @@ class SyndromeTracker:
         )
 
         num_rows = full_matrix.shape[0]
-        logical_observable_idx = 0
+        logical_observable_idx = self.total_observables
         _used_final_coords: set = set()  # dedup: each final detector gets a unique (x,y) coord
         for k in range(num_rows):
             # Condition 1: Must NOT be destroyed (anti-commuted).
@@ -1385,6 +2266,22 @@ class SyndromeTracker:
 
             # 3. Output:
             if k < num_stabs and k not in self.stabilizer_with_logical_components:
+                # Measurement-promoted joint closures (support > check weight)
+                # are emitted like every other row, matching upstream main:
+                # the long-range parity is real syndrome information (paired-
+                # noise MWPM LER is ~30% better with it; review blocker #1).
+                if -1 in full_records[k]:
+                    # An UNWATCHED gauge direction's close-out (sentinel-
+                    # tagged row = WriteBack's no-slot gauge branch).  Its
+                    # only content is init-parity == readout-parity, nobody
+                    # re-measured it in between; per the gauge-branch rule
+                    # such relations must not become detectors - each error
+                    # along it is already a 2-symptom event on neighbouring
+                    # checks and this global parity attaches an irreducible
+                    # extra symptom (fig5 all-X D937: the diagonal 4-qubit
+                    # X-string sliver, 6th symptom of the non-decomposable
+                    # Y(x)Y mechanism).  Same user ruling as above.
+                    continue
                 _used_final_coords.add(det_coord)
                 coords = list(det_coord) + [1]
                 _append_detector(
@@ -1395,6 +2292,8 @@ class SyndromeTracker:
             else:
                 circuit.append("OBSERVABLE_INCLUDE", args, [logical_observable_idx])
                 logical_observable_idx += 1
+
+        self.total_observables = logical_observable_idx
 
         # ======================================================================
         # Step 4: Partial reduction of remaining rows (incremental support)
@@ -1458,3 +2357,19 @@ class SyndromeTracker:
 
         # Reset per-call tracking that uses row indices (now invalidated)
         self.stabilizer_with_logical_components = set()
+
+        # A PATCH readout retires however many live logical DOFs it actually read out
+        # (free ones consumed + absorbed relations resolved). A CORRIDOR/bus readout
+        # (resolve_absorbed=False) resolves no ABSORBED relation (their support is
+        # reduced onto the patches, not read out) — but a LOGICAL row REMOVED by it
+        # is a consumed DOF all the same: a restore-credit promotion can put a
+        # corridor-ribbon direction into the logicals, and the split then destroys
+        # it (anticommuting bus-basis readout) or emits it (row entirely on the
+        # measured corridor).  Legacy corridor splits removed no logical rows, so
+        # this term was always zero before.
+        if resolve_absorbed:
+            resolved = ((_std_before - self.logicals.count)
+                        + (_abs_before - self.num_absorbed_dof()))
+            self.expected_num_logicals -= resolved
+        else:
+            self.expected_num_logicals -= (_std_before - self.logicals.count)

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -79,14 +79,17 @@ class SyndromeTracker:
         # into the stabilizer group by a merge (e.g. a joint ZZ over two |0>) and STILL
         # hold a trapped logical DOF. Persisted across rounds/PPMs, so an absorb that an
         # intervening round does not re-measure is not lost (this is what the old per-round
-        # gauge tally missed — pitfall B). The count of still-trapped DOFs is `rank(absorbed_ops)`
-        # (see num_absorbed_dof). Self-correcting: once an absorbed relation is read out
+        # gauge tally missed — pitfall B). THE census ledger: every path that absorbs a
+        # logical DOF records the operator here, and the count is always DERIVED via
+        # num_absorbed_dof() (rank mod the stabilizer group) — there is deliberately no
+        # separately maintained integer, because a bare counter demands perfect
+        # increment/decrement pairing from every path and drifts silently when one
+        # forgets. Self-correcting: once an absorbed relation is read out
         # (process_data_measurement) or its qubits retired (retire_qubits), its row is
         # dropped and stops being counted.
         self.absorbed_ops = PauliTableau(num_qubits)
         self.stabilizer_with_logical_components = set()  # Row indices of stabilizers that contain logical components
         self._gauge_logical_vectors = []  # GF(2) vectors over logical indices for rank computation
-        self._absorbed_logical_dofs = 0
         self.post_select_detector_coords = post_select_detector_coords or set()
         self.post_select_row_indices = set()  # Stabilizer row indices to post-select in process_data_measurement
         self.retired_qubits = set()
@@ -100,8 +103,18 @@ class SyndromeTracker:
 
     def num_absorbed_dof(self) -> int:
         """Number of live logical DOFs currently folded into the stabilizer group
-        (cross-round persistent). Independent of the standing (free) logicals."""
-        return _gf2_rank(self.absorbed_ops.matrix)
+        (cross-round persistent), counted UP TO logical equivalence: two
+        representatives that differ by a stabilizer are ONE relation, and a
+        relation that has itself become an element of the stabilizer group
+        holds no DOF and contributes zero.  Computed as
+        rank([stabilizers; absorbed]) - rank(stabilizers) over GF(2)."""
+        A = self.absorbed_ops.matrix
+        if A.shape[0] == 0:
+            return 0
+        S = self.stabilizers.matrix
+        if S.shape[0] == 0:
+            return _gf2_rank(A)
+        return _gf2_rank(np.vstack([S, A])) - _gf2_rank(S)
 
     def allocate_observable(self) -> int:
         """Reserve and return the next OBSERVABLE_INCLUDE index.
@@ -795,8 +808,17 @@ class SyndromeTracker:
     def _record_measurement_logical_effects(
         self,
         surviving_logical_indices: Set[int],
+        old_logicals_current_frame: Optional[np.ndarray] = None,
     ) -> None:
-        """Account for logical DOFs consumed by the current measurement block."""
+        """Account for logical DOFs consumed by the current measurement block.
+
+        The consumed combinations are RECORDED as operator rows in
+        absorbed_ops (the single census ledger); the census count is always
+        derived from that ledger via num_absorbed_dof().  Callers pass the
+        pre-block logical rows already pushed into the current frame
+        (i.e. after the block's forward symplectic), so the recorded
+        operators live in the same frame as every other tableau row.
+        """
         if self._gauge_logical_vectors:
             gauge_matrix = np.array(
                 self._gauge_logical_vectors,
@@ -805,9 +827,23 @@ class SyndromeTracker:
             for logical_idx in surviving_logical_indices:
                 if logical_idx < gauge_matrix.shape[1]:
                     gauge_matrix[:, logical_idx] = 0
-            self._absorbed_logical_dofs += int(
-                np.linalg.matrix_rank(gauge_matrix.astype(float))
-            )
+            if gauge_matrix.any():
+                if old_logicals_current_frame is None:
+                    raise ValueError(
+                        "_record_measurement_logical_effects: gauge "
+                        "measurements consumed logical DOFs but the caller "
+                        "did not supply the pre-block logical rows — the "
+                        "absorbed operators cannot be recorded.")
+                n_logs = old_logicals_current_frame.shape[0]
+                ops = (gauge_matrix[:, :n_logs]
+                       @ old_logicals_current_frame) % 2
+                ops = ops[ops.any(axis=1)].astype(np.uint8)
+                if ops.shape[0]:
+                    A = self.absorbed_ops
+                    A.matrix = (np.vstack([A.matrix, ops]).astype(np.uint8)
+                                if A.count else ops)
+                    A.records = list(A.records) + [
+                        [] for _ in range(ops.shape[0])]
 
         if surviving_logical_indices and self._gauge_logical_vectors:
             rows_to_remove = set()
@@ -1151,7 +1187,9 @@ class SyndromeTracker:
                 if idx >= num_stabs
             }
             self._record_measurement_logical_effects(
-                surviving_logical_indices
+                surviving_logical_indices,
+                old_logicals_current_frame=(
+                    full_matrix[num_stabs:] @ forward_symplectic_matrix) % 2,
             )
             return set()
 
@@ -1302,7 +1340,11 @@ class SyndromeTracker:
             i - num_stabs for i in new_log_basis_indices
             if i >= num_stabs
         ) if new_log_basis_indices else set()
-        self._record_measurement_logical_effects(surviving_log_indices)
+        self._record_measurement_logical_effects(
+            surviving_log_indices,
+            old_logicals_current_frame=(
+                full_matrix[num_stabs:] @ forward_symplectic_matrix) % 2,
+        )
         return {
             num_output_stabilizers + position
             for position in promotable_old_positions
@@ -1390,11 +1432,12 @@ class SyndromeTracker:
 
     def validate_logical_count(self, *, context: str = "tracker state") -> None:
         """Check that explicit and measurement-absorbed logical DOFs add up."""
-        actual = self.logicals.count + self._absorbed_logical_dofs
+        absorbed = self.num_absorbed_dof()
+        actual = self.logicals.count + absorbed
         if actual != self.expected_num_logicals:
             raise RuntimeError(
                 f"After {context}: logical count {self.logicals.count} plus "
-                f"absorbed logical DOFs {self._absorbed_logical_dofs} != "
+                f"absorbed logical DOFs {absorbed} != "
                 f"expected {self.expected_num_logicals}."
             )
 

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -103,6 +103,21 @@ class SyndromeTracker:
         (cross-round persistent). Independent of the standing (free) logicals."""
         return _gf2_rank(self.absorbed_ops.matrix)
 
+    def allocate_observable(self) -> int:
+        """Reserve and return the next OBSERVABLE_INCLUDE index.
+
+        Every emitter of a NEW observable must allocate here — never from
+        circuit.num_observables — so that two independent logical results
+        can never share an ID (a shared ID XORs them into one observable,
+        and the XOR of two deterministic bits stays deterministic, so p=0
+        sampling cannot catch the collision).  Re-using a previously
+        allocated index to ACCUMULATE into the same observable remains
+        legal and does not go through this method.
+        """
+        idx = self.total_observables
+        self.total_observables += 1
+        return idx
+
     def expand(self, delta: int):
         """
         Expand the tracker to include delta new qubits (define-by-run).
@@ -2197,7 +2212,6 @@ class SyndromeTracker:
         )
 
         num_rows = full_matrix.shape[0]
-        logical_observable_idx = self.total_observables
         _used_final_coords: set = set()  # dedup: each final detector gets a unique (x,y) coord
         for k in range(num_rows):
             # Condition 1: Must NOT be destroyed (anti-commuted).
@@ -2290,10 +2304,8 @@ class SyndromeTracker:
                                  or k in self.post_select_row_indices),
                 )
             else:
-                circuit.append("OBSERVABLE_INCLUDE", args, [logical_observable_idx])
-                logical_observable_idx += 1
-
-        self.total_observables = logical_observable_idx
+                circuit.append("OBSERVABLE_INCLUDE", args,
+                               [self.allocate_observable()])
 
         # ======================================================================
         # Step 4: Partial reduction of remaining rows (incremental support)

--- a/lightstim/protocols/__init__.py
+++ b/lightstim/protocols/__init__.py
@@ -8,6 +8,8 @@ from .ls_distillation import (
     run_simulation as run_ls_simulation,
     LS_MAGIC_NAMES,
 )
+from .ppm import (PatchSpec, PPMStep, origin_of, cell_index,
+                  SequentialPPMExperiment)
 from .tg_distillation import (
     build_distillation_circuit as build_tg_distillation_circuit,
     inject_noise as inject_tg_noise,

--- a/lightstim/protocols/ppm/__init__.py
+++ b/lightstim/protocols/ppm/__init__.py
@@ -13,6 +13,9 @@ from .seam_rules import (MergeRule, PatchView, RotatedSeamWallCoupler,
                          wall_spec)
 from .coupler import (MultiPatchLayout, RotatedRoutedMultiPatchCoupler,
                       SubsetRoute, route_and_build)
+from .lowering import (LoweringCertificate, LoweringPlan, PPMRequest,
+                       UnsupportedPauliError, apply_plan,
+                       is_cell_adjacent_pair, lower_ppm)
 from .sequential import SequentialPPMExperiment
 
 __all__ = [
@@ -21,5 +24,8 @@ __all__ = [
     "MergeRule", "PatchView", "RotatedSeamWallCoupler", "SeamRuleError",
     "WallSpec", "classify_seam", "patch_view", "wall_spec",
     "MultiPatchLayout", "RotatedRoutedMultiPatchCoupler", "SubsetRoute",
-    "route_and_build", "SequentialPPMExperiment",
+    "route_and_build",
+    "LoweringCertificate", "LoweringPlan", "PPMRequest",
+    "UnsupportedPauliError", "apply_plan", "is_cell_adjacent_pair",
+    "lower_ppm", "SequentialPPMExperiment",
 ]

--- a/lightstim/protocols/ppm/__init__.py
+++ b/lightstim/protocols/ppm/__init__.py
@@ -1,0 +1,25 @@
+# protocols/ppm/__init__.py
+#
+# Sequential PPM stack — joint Pauli-product measurements on rotated routed
+# surface-code patches with explicit corridor routes.  Copied from
+# https://github.com/John-YuehanZhang/CircLS @ 8802a5b (the author's own
+# repository); minimal explicit-route variant, intentionally independent of
+# CircLS.
+
+from .spec import (BentLayoutError, PatchSpec, PPMStep, cell, cell_index,
+                   conjugate_patch_records, origin_of, place_patch)
+from .seam_rules import (MergeRule, PatchView, RotatedSeamWallCoupler,
+                         SeamRuleError, WallSpec, classify_seam, patch_view,
+                         wall_spec)
+from .coupler import (MultiPatchLayout, RotatedRoutedMultiPatchCoupler,
+                      SubsetRoute, route_and_build)
+from .sequential import SequentialPPMExperiment
+
+__all__ = [
+    "BentLayoutError", "PatchSpec", "PPMStep", "cell", "cell_index",
+    "conjugate_patch_records", "origin_of", "place_patch",
+    "MergeRule", "PatchView", "RotatedSeamWallCoupler", "SeamRuleError",
+    "WallSpec", "classify_seam", "patch_view", "wall_spec",
+    "MultiPatchLayout", "RotatedRoutedMultiPatchCoupler", "SubsetRoute",
+    "route_and_build", "SequentialPPMExperiment",
+]

--- a/lightstim/protocols/ppm/coupler.py
+++ b/lightstim/protocols/ppm/coupler.py
@@ -1,0 +1,2046 @@
+# protocols/ppm/coupler.py
+#
+# Copied from https://github.com/John-YuehanZhang/CircLS @ 8802a5b — the
+# author's own repository (John Yuehan Zhang).  Source: circls/
+# multi_patch_coupler.py, the EXPLICIT-ROUTE branch of ``route_and_build``
+# and its transitive closure only (deterministic rule constructor, physics
+# oracle ``MultiPatchLayout.verify``, seam-table wall dispatch,
+# ``RotatedRoutedMultiPatchCoupler``).
+#
+# Intentionally NOT copied: the automatic router (corridor graph, Steiner /
+# EMV candidate search, geometry caches) — in this LightStim variant
+# ``route`` is REQUIRED (pass ``[]`` for cell-adjacent targets) and
+# ``route=None`` raises ``BentLayoutError``.
+
+from dataclasses import dataclass, field
+import itertools
+from types import SimpleNamespace
+
+import numpy as np
+
+from lightstim.ir.coupler import LogicalCouplerProtocol as _LCP
+from lightstim.qec_code.surface_code.rotated.code_patch import RotatedSurfaceCode
+
+from .spec import (BentLayoutError, PatchSpec, _FLIP, _pitch, cell,
+                       cell_index, origin_of, place_patch)
+
+__all__ = ["route_and_build", "SubsetRoute", "MultiPatchLayout",
+           "RotatedRoutedMultiPatchCoupler", "rule_based_joint_checks",
+           "path_to_corridor"]
+
+
+
+
+
+
+
+
+#: Post-routing seam-table dispatch (route first, then classify every attach
+#: seam on the path by rule-table v3).  Same-letter type-split joints:
+#: the minority-type target is REGISTERED in the recolour convention and its
+#: seam carries the verified mixed wall family — the rule-table row algebra
+#: row2 = row4 o row3 (user-confirmed, measured full-distance end-to-end on
+#: straight, L-bend and T-junction geometries, 2026-07-29).
+TABLE_WALL_DISPATCH = True
+
+
+def _bent_plaquettes(data, retype, phase):
+    """Every (even,even) plaquette center with >=2 data corners, typed by the re-typing model.
+
+    Base type at center ``(cx, cy)`` is 'X' if ``((cx+cy)//2 + phase)`` is odd else 'Z'.
+    Each corner's Pauli equals the base type, flipped (X<->Z) if the corner lies in the
+    re-typed set ``retype`` (the X-side arm).  All-equal corner Paulis -> a pure check of
+    that type; mixed -> a domain-wall check of type 'M'.  ``phase`` (0/1) absorbs the
+    position-dependent parity of ``(cx+cy)//2`` so the construction is translation-correct.
+    """
+    xs = [c for c, _ in data]
+    ys = [r for _, r in data]
+    out = []
+    for cx in range(min(xs) - 1, max(xs) + 2):
+        for cy in range(min(ys) - 1, max(ys) + 2):
+            if cx % 2 or cy % 2:
+                continue
+            present = [(cx + a, cy + b) for a in (-1, 1) for b in (-1, 1)
+                       if (cx + a, cy + b) in data]
+            if len(present) < 2:
+                continue
+            base = "X" if ((cx + cy) // 2 + phase) % 2 == 1 else "Z"
+            pauli = {q: (_FLIP[base] if q in retype else base) for q in sorted(present)}
+            types = set(pauli.values())
+            t = next(iter(types)) if len(types) == 1 else "M"
+            out.append({"syn": (cx, cy), "type": t, "pauli": pauli,
+                        "corners": sorted(pauli)})
+    return out
+
+
+def _commute(a, b, n):
+    return int((a[:n] & b[n:]).sum() + (a[n:] & b[:n]).sum()) % 2 == 0
+
+
+
+
+
+
+def _symplectic(data):
+    idx = {c: i for i, c in enumerate(sorted(data))}
+    n = len(idx)
+
+    def sv(pauli):
+        v = np.zeros(2 * n, np.uint8)
+        for c, P in pauli.items():
+            if P in ("X", "Y"):
+                v[idx[c]] ^= 1
+            if P in ("Z", "Y"):
+                v[n + idx[c]] ^= 1
+        return v
+    return sv, n
+
+
+def _no_tick_collision(circuit):
+    """True iff no qubit is touched by two operations within the same TICK window."""
+    skip = {"QUBIT_COORDS", "DETECTOR", "OBSERVABLE_INCLUDE", "SHIFT_COORDS", "TICK",
+            "DEPOLARIZE1", "DEPOLARIZE2", "X_ERROR", "Z_ERROR", "Y_ERROR"}
+    seen = set()
+    for op in circuit.flattened():
+        if op.name == "TICK":
+            seen = set()
+            continue
+        if op.name in skip:
+            continue
+        for t in op.targets_copy():
+            if t.is_qubit_target:
+                if t.value in seen:
+                    return False
+                seen.add(t.value)
+    return True
+
+
+# -----------------------------------------------------------------------------
+# bit-packed GF(2) machinery — Pauli vectors as Python ints (X in bits 0..n-1, Z in n..2n-1).
+# Int XOR / int.bit_count() are C-level, so the boundary search scales to N=5/6 and d=5.
+# -----------------------------------------------------------------------------
+
+def _int_symplectic(data):
+    """Return ``(isv, n)`` where ``isv({coord: pauli})`` packs a Pauli into a 2n-bit int."""
+    idx = {c: i for i, c in enumerate(sorted(data))}
+    n = len(idx)
+
+    def isv(pauli):
+        v = 0
+        for c, P in pauli.items():
+            i = idx[c]
+            if P in ("X", "Y"):
+                v |= 1 << i
+            if P in ("Z", "Y"):
+                v |= 1 << (n + i)
+        return v
+    return isv, n
+
+
+def _icommute(a, b, n):
+    mask = (1 << n) - 1
+    return (((a & mask) & (b >> n)).bit_count() + ((a >> n) & (b & mask)).bit_count()) & 1 == 0
+
+
+class _IntBasis:
+    """An incremental GF(2) row basis over bit-packed ints (reduction by highest set bit)."""
+    __slots__ = ("piv",)
+
+    def __init__(self):
+        self.piv = {}                      # highest-set-bit -> reduced row int
+
+    def copy(self):
+        b = _IntBasis()
+        b.piv = dict(self.piv)
+        return b
+
+    def reduce(self, v):
+        while v:
+            r = self.piv.get(v.bit_length() - 1)
+            if r is None:
+                return v
+            v ^= r
+        return v
+
+    def add(self, v):                      # returns True iff v is independent (and adds it)
+        r = self.reduce(v)
+        if r:
+            self.piv[r.bit_length() - 1] = r
+            return True
+        return False
+
+    def contains(self, v):
+        return self.reduce(v) == 0
+
+    @property
+    def rank(self):
+        return len(self.piv)
+
+
+def _cols(d):
+    return sorted({c for c, _ in d})
+
+
+def _rows(d):
+    return sorted({r for _, r in d})
+
+
+def _connected(region):
+    """True iff ``region`` (a set of (odd,odd) coords) is connected via the plaquette graph."""
+    region = set(region)
+    if not region:
+        return True
+    start = next(iter(region))
+    seen = {start}; stack = [start]
+    while stack:
+        x, y = stack.pop()
+        for nx, ny in ((x + 2, y), (x - 2, y), (x, y + 2), (x, y - 2),
+                       (x + 2, y + 2), (x + 2, y - 2), (x - 2, y + 2), (x - 2, y - 2)):
+            if (nx, ny) in region and (nx, ny) not in seen:
+                seen.add((nx, ny)); stack.append((nx, ny))
+    return len(seen) == len(region)
+
+
+
+
+def _logical_direction(pauli, orientation):
+    """The direction the measured ``pauli`` logical string must run, per the patch ``orientation``.
+
+    ``orientation`` names the X̄ direction (``"X_horizontal"`` ⇒ X̄ runs along a row, ``"X_vertical"``
+    ⇒ X̄ runs up a column); Z̄ is perpendicular to X̄.  So a measured ``X`` on an ``X_horizontal``
+    patch runs ``"horizontal"``, a measured ``Z`` on an ``X_horizontal`` patch runs ``"vertical"``,
+    and vice-versa for ``X_vertical``.
+    """
+    x_is_horizontal = orientation == "X_horizontal"
+    if pauli == "X":
+        return "horizontal" if x_is_horizontal else "vertical"
+    return "vertical" if x_is_horizontal else "horizontal"
+
+
+def _patch_rep(patch, pauli, direction, F, sv, n):
+    """A patch-spanning ``pauli`` string **in the requested ``direction``** commuting with bulk ``F``.
+
+    The orientation declared on the ``PatchSpec`` is honoured: an ``X_horizontal`` X-logical is
+    represented by a horizontal string, an ``X_vertical`` X-logical by a vertical one (and Z̄
+    perpendicular).  Returns the support, or ``None`` if no string in that direction commutes — the
+    caller tries the other parity phase, and if both fail the placement is rejected rather than the
+    logical being silently re-oriented.
+    """
+    c, r = _cols(patch), _rows(patch)
+    cands = ([[(x, y) for y in r] for x in c] if direction == "vertical"
+             else [[(x, y) for x in c] for y in r])
+    for sup in cands:
+        v = sv({q: pauli for q in sup})
+        if all(_commute(v, f, n) for f in F):
+            return sup
+    return None
+def _readout_chain(data, checks, logicals):
+    """Check syndromes whose GF(2) product equals the joint ``∏ᵢ P̄ᵢ`` (for highlighting/readout)."""
+    from lightstim.utils.linear_algebra import solve_linear_decomposition
+    sv, n = _symplectic(data)
+    basis = np.array([sv(ch["pauli"]) for ch in checks], np.uint8)
+    target = np.zeros(2 * n, np.uint8)
+    for P, sup in logicals:
+        target ^= sv({c: P for c in sup})
+    co, dep, _ = solve_linear_decomposition(basis=basis, targets=target.reshape(1, -1),
+                                             reduce_weight=True)
+    if not dep[0]:
+        return set()
+    return {checks[i]["syn"] for i in np.where(co[0])[0]}
+
+
+# -----------------------------------------------------------------------------
+# layout + builder
+# -----------------------------------------------------------------------------
+
+@dataclass
+class MultiPatchLayout:
+    """A rotated N-patch joint-measurement layout (``M(∏ᵢ P̄ᵢ)``).
+
+    ``logicals`` is a list of ``(name, measured_pauli, support)`` — one per patch.
+    ``x_observable`` is the X-type logical the X-memory circuit reads.
+    """
+    distance: int
+    data: list
+    checks: list
+    logicals: list
+    x_observable: list
+    readout_chain: set = field(default_factory=set)
+    specs: list = field(default_factory=list)
+    target: list = field(default_factory=list)
+    #: orientation-domain map (data coord -> 'X_horizontal' | 'X_vertical') used
+    #: by the hook-benign scheduler; empty means "all default (X_horizontal)".
+    domains: dict = field(default_factory=dict)
+    #: the native (corridor) Pauli basis this layout was built for.  ``None`` means
+    #: "majority target basis (tie -> X)"; an explicit 'X'/'Z' is a PLANNED bus that
+    #: forces which patches attach through mixed walls / are conjugated.
+    bus: str = None
+    #: bus data qubits on the RECOLOURED side of a corridor-internal colour wall
+    #: (segment recolouring, flip_cells): they are initialized/read out in the
+    #: OPPOSITE basis of the rest of the bus.  Empty for uniform corridors.
+    retyped: frozenset = frozenset()
+
+    @property
+    def N(self):
+        return len(self.logicals)
+
+    def build_circuit(self, rounds=None, p=0.0):
+        """No-MPP gate-level syndrome-extraction circuit.
+
+        The memory experiment runs in the **bus basis** — the majority target basis
+        (tie -> X), matching the corridor's native type.  ``x_observable`` holds a
+        bus-basis logical representative (see ``_construct_phase``), so basis and
+        tracked observable always agree; running the opposite-basis experiment on a
+        bus layout is ill-posed (a single measurement flip would flip the observable
+        undetected).
+
+        WARNING: standalone builder (wraps ``RotatedBentJointMeasurement.circuit``);
+        its observable is a single bus-basis logical, NOT the ``SyndromeTracker``
+        joint m.  Good for single-patch memory + determinism/collision checks, but
+        its MULTI-PATCH graphlike distance is NOT the real joint distance -- use
+        :class:`RoutedMultiPatchLSExperiment` for joint distance / LER."""
+        from lightstim.qec_code.surface_code.rotated.bent_joint_se import RotatedBentJointMeasurement
+        if rounds is None:
+            rounds = self.distance
+        if self.bus is not None:
+            basis = self.bus
+        else:
+            n_x = sum(1 for _, P, _ in self.logicals if P == "X")
+            basis = "X" if n_x >= len(self.logicals) - n_x else "Z"
+        return RotatedBentJointMeasurement(
+            list(self.data), self.checks, list(self.x_observable),
+            domains=self.domains,
+        ).circuit(rounds=rounds, p=p, basis=basis)
+
+    def verify(self, rounds=None):
+        """The eleven N-patch acceptance checks; returns a dict of booleans (all True == valid)."""
+        isv, n = _int_symplectic(self.data)
+        S = [isv(ch["pauli"]) for ch in self.checks]
+        singles = [isv({c: P for c in sup}) for _, P, sup in self.logicals]
+        joint = 0
+        for v in singles:
+            joint ^= v
+        N = len(self.logicals)
+        subs = []                                       # all proper non-empty subset products
+        for r in range(1, N):
+            for comb in itertools.combinations(range(N), r):
+                v = 0
+                for k in comb:
+                    v ^= singles[k]
+                subs.append(v)
+        B = _IntBasis()
+        for v in S:
+            B.add(v)
+        commute = all(_icommute(S[i], S[j], n) for i in range(len(S)) for j in range(i + 1, len(S)))
+        twist = any(P == "Y" for ch in self.checks for P in ch["pauli"].values())
+
+        def w1():
+            for q in self.data:
+                for P in "XZ":
+                    v = isv({q: P})
+                    if B.reduce(v) != 0 and all(_icommute(v, b, n) for b in B.piv.values()):
+                        return True
+            return False
+
+        out = dict(
+            commute=commute,
+            joint=B.contains(joint),
+            no_single=not any(B.contains(v) for v in singles),
+            no_subjoint=not any(B.contains(v) for v in subs),
+            no_twist=not twist,
+            logical_count=len(self.data) - B.rank == N - 1,
+            no_weight1_logical=not w1(),
+        )
+        if any(ch.get('kf') for ch in self.checks):
+            # a layout hosting stretched (kf) checks cannot run the bent
+            # standalone builder — the circuit-level items are covered by the
+            # end-to-end diagonal pipeline instead; the algebraic oracle above
+            # is the acceptance decision here
+            return out
+        circuit = self.build_circuit(rounds=rounds)
+        out["no_mpp"] = "MPP" not in str(circuit)
+        out["no_tick_collision"] = _no_tick_collision(circuit)
+        try:
+            dem = circuit.detector_error_model(decompose_errors=True)
+            dem_ok = (dem.num_detectors == circuit.num_detectors
+                      and dem.num_observables == circuit.num_observables)
+        except Exception:
+            dem_ok = False
+        det, obs = circuit.compile_detector_sampler(seed=0).sample(200, separate_observables=True)
+        out["dem_valid"] = dem_ok and not det.any() and not obs.any()
+        return out
+
+
+_ORTH = ((2, 0), (-2, 0), (0, 2), (0, -2))
+
+
+def _corner_qubits(dset):
+    """Exposed corner data qubits: ≤2 orthogonal data neighbours."""
+    return {q for q in dset
+            if sum(((q[0] + dx, q[1] + dy) in dset) for dx, dy in _ORTH) <= 2}
+
+
+class _Builder:
+    """One deterministic greedy construction on a fixed region and phase.
+
+    ``forbidden`` is a set of syndrome sites the boundary may NOT use — the ancilla
+    qubits already owned by neighbouring idle patches; vetoing them makes the
+    alternating pattern interleave with the neighbour on a shared ancilla line, so
+    edge-adjacent placement is physically collision-free whenever the parity allows.
+    """
+
+    def __init__(self, placed, target, orient, data, retype, phase, forbidden=frozenset(),
+                 native_lock=False, bus=None, conj_names=None, extra_forced=(),
+                 retire_lobes=frozenset()):
+        self.data = sorted(data)
+        self.forbidden = frozenset(forbidden)
+        self.target = target
+        self.patchq = set().union(*[placed[nm] for nm, _ in target])
+        self._placed = placed
+        self._orient = orient
+        self._retype = set(retype)
+        if bus is None:
+            n_x = sum(1 for _, P in target if P == "X")
+            bus = "X" if n_x >= len(target) - n_x else "Z"
+        self._bus = bus
+        self.plaqs = _bent_plaquettes(self.data, retype, phase)
+        self.forced = [p for p in self.plaqs if len(p["pauli"]) >= 4]
+        # injected forced checks (e.g. a corridor-internal stretched wall's kf
+        # records): they join the forced set verbatim, so the rank/joint
+        # acceptance metric and the logical representatives account for them;
+        # their feet are protected from the convex-corner cut rule like patch
+        # qubits (a cut foot would orphan the wall record)
+        self.forced = self.forced + [dict(e) for e in extra_forced]
+        self.patchq |= {q for e in extra_forced for q in e["pauli"]}
+        self.pool = sorted((p for p in self.plaqs if len(p["pauli"]) < 4),
+                           key=lambda p: p["syn"])
+        if retire_lobes:
+            # the wall band's two ancilla lines belong to the wall (same
+            # retire semantics as the patch|patch wall coupler): no rule tile
+            # may sit there
+            self.pool = [p for p in self.pool if p["syn"] not in retire_lobes]
+        if extra_forced:
+            # the injected records' apparatus sites (syn + kf flag/shared) are
+            # occupied — expel pool tiles there; anything else (e.g. the corner
+            # lobe at the wall band's free end) stays available to the rules
+            occ = set()
+            for e in extra_forced:
+                occ.add(tuple(e["syn"]))
+                kf = e.get("kf") or {}
+                for k in ("flag", "shared"):
+                    if k in kf:
+                        occ.add(tuple(kf[k]))
+            self.pool = [p for p in self.pool if p["syn"] not in occ]
+        # rule 0 -- native lock: a target patch whose interior matches the global
+        # checkerboard (not retyped, phase-compatible) keeps its TEXTBOOK standalone
+        # construction verbatim: its native boundary semicircles are seeded as forced
+        # picks, and non-native tiles fully inside the patch are expelled from the
+        # pool.  The one exception is a facing semicircle whose forced-bulk extension
+        # (superset whose extra corners lie OUTSIDE the patch, i.e. seam/corridor
+        # qubits) exists -- the extension replaces it, per joint-measurement rank.
+        self.native_seed, self.locked_cells = [], set()
+        if native_lock:
+            forced_by_sup = {frozenset(p["pauli"]): p for p in self.forced}
+            pool_by_key = {(frozenset(p["pauli"]), p["type"]): p for p in self.pool}
+            if bus is None:
+                n_x = sum(1 for _, P in target if P == "X")
+                bus = "X" if n_x >= len(target) - n_x else "Z"
+            _FLIP_O = {"X_horizontal": "X_vertical", "X_vertical": "X_horizontal"}
+            _FLIP_P = {"X": "Z", "Z": "X"}
+            for nm, _P in target:
+                cells = placed[nm]
+                # conjugate-registered patch: its lock target is the CONJUGATE-
+                # CONVENTION construction (transposed native, types swapped).
+                # conj_names is the explicit registration set; None infers it
+                # from the measured Pauli (minority basis), the historical rule.
+                flipped = (nm in conj_names) if conj_names is not None \
+                    else (_P != bus)
+                dd = len({x for x, _ in cells})
+                o = (min(x for x, _ in cells), min(y for _, y in cells))
+                onm = _FLIP_O[orient[nm]] if flipped else orient[nm]
+                try:
+                    nat = place_patch(SimpleNamespace(
+                        origin=o, distance=dd, orientation=onm))["checks"]
+                except Exception:
+                    continue
+                if flipped:
+                    nat = [dict(c, type=_FLIP_P[c["type"]],
+                                pauli={q: _FLIP_P[P] for q, P in c["pauli"].items()})
+                           for c in nat]
+                seeds, ok = [], True
+                for c in nat:
+                    sup = frozenset(c["pauli"])
+                    if len(sup) >= 4:              # interior: must equal a forced tile
+                        f = forced_by_sup.get(sup)
+                        if f is None or f["type"] != c["type"]:
+                            ok = False
+                            break
+                    else:                          # boundary semicircle / corner tile
+                        if tuple(c["syn"]) in retire_lobes:
+                            continue               # facing an ARM WALL: the lobe is
+                                                   # retired, the wall records replace it
+                        if any(sup < frozenset(f["pauli"])
+                               and not ((frozenset(f["pauli"]) - sup) & cells)
+                               for f in self.forced):
+                            continue               # facing: replaced by its extension
+                        cand = pool_by_key.get((sup, c["type"]))
+                        if cand is None:
+                            ok = False
+                            break
+                        seeds.append(cand)
+                if not ok:                         # rule 0 is HARD: a phase that cannot
+                    self.fail = (f"native lock: patch {nm} textbook construction is "
+                                 f"incompatible with checkerboard phase {phase}")
+                    return                         # host a native patch is rejected
+                self.native_seed.extend(seeds)
+                self.locked_cells |= cells
+            if self.locked_cells:
+                nset = {(frozenset(p["pauli"]), p["type"]) for p in self.native_seed}
+                self.pool = [p for p in self.pool
+                             if not (set(p["pauli"]) <= self.locked_cells
+                                     and (frozenset(p["pauli"]), p["type"]) not in nset)]
+        self.seed_syns = {p["syn"] for p in self.native_seed}
+        self.isv, self.n = _int_symplectic(self.data)
+        sv, _ = _symplectic(self.data)
+        F = [sv(p["pauli"]) for p in self.forced]
+        self.reps = {}
+        for nm, P in target:
+            sup = _patch_rep(placed[nm], P, _logical_direction(P, orient[nm]), F, sv, self.n)
+            if sup is None:
+                self.fail = (f"no {P}-representative for patch {nm} commutes with the "
+                             f"forced bulk (checkerboard phase {phase})")
+                return
+            self.reps[nm] = (P, sup)
+        self.fail = None
+        self.repv = [self.isv({q: P for q in sup}) for P, sup in self.reps.values()]
+        self.fvecs = [self.isv(p["pauli"]) for p in self.forced]
+
+    def _seg_letter(self, p):
+        """Boundary LETTER for candidate ``p``, or None to fall back to
+        parity.  Measured ground truth (engine dump, docs §2.6): the merged
+        complex's free boundary carries the BUS letter everywhere outside
+        the patches — bus-letter lobes forbid dual-letter chains from
+        terminating across the corridor, which is what protects the joint
+        measurement.  The patches keep their native lobes verbatim (rule-0
+        anchors); any other all-inside-patch slot belongs to the native
+        construction, not to this rule.  Mixed (domain-wall) tiles fall back
+        to the parity scan."""
+        if p["type"] not in "XZ":
+            return None                       # mixed/domain-wall tile
+        for nm, _P in self.target:
+            if all(q in self._placed[nm] for q in p["pauli"]):
+                if self.native_seed:
+                    return None               # locked: seeds own the patches
+                # UNLOCKED ladder fallback (native constructions cannot share
+                # the attempt's phase): the patch boundary is re-derived like
+                # an ordinary patch at this phase — each side keeps its
+                # orientation-determined letter (X̄-horizontal: E/W carry X,
+                # N/S carry Z; X̄-vertical swaps), measured from the engine's
+                # unlocked successes (docs §2.6)
+                cells = self._placed[nm]
+                xs = [x for x, _ in cells]
+                ys = [y for _, y in cells]
+                fx = {x for x, _ in p["pauli"]}
+                fy = {y for _, y in p["pauli"]}
+                if fx == {min(xs)} or fx == {max(xs)}:
+                    side_ew = True
+                elif fy == {min(ys)} or fy == {max(ys)}:
+                    side_ew = False
+                else:
+                    return None               # corner-spanning tile: undecided
+                o = self._orient[nm]
+                # OPEN (docs §2.6): in the unlocked fallback ONE of the
+                # patches (the parity law's recoloured minority) follows the
+                # FLIPPED side map — the selection criterion is not yet
+                # transcribed; until it is, the orientation map is used for
+                # all patches and the residual per-patch lobe deltas are the
+                # known gap (cross-check harness tracks them).
+                return ("X" if side_ew else "Z") if o == "X_horizontal" \
+                    else ("Z" if side_ew else "X")
+        if self._bus not in ("X", "Z"):
+            return self._bus                  # legacy abutting: no bus letter
+        feet = p["pauli"]
+        inside = sum(1 for q in feet if q in self._retype)
+        if inside == len(feet):
+            # recoloured corridor: the M column flips letter AND colour
+            # together (component ledger, docs §2.6), so the region's own
+            # colour dictates the conjugate bus letter here
+            return "X" if self._bus == "Z" else "Z"
+        if inside:
+            return None                       # straddles the recolour boundary
+        return self._bus
+
+    def direct_build(self):
+        """Handbook §10.4 DIRECT boundary construction — zero search, zero
+        per-tile commutation tests.
+
+        The patches' native weight-2 stabilizers (rule-0 seeds) anchor the
+        boundary pattern; wall records' feet count as occupied.  Every other
+        boundary candidate is visited outward from the anchors (multi-source
+        BFS over the foot-sharing chain graph, lexicographic within each
+        layer) and placed iff it shares NO data foot with an already-placed
+        boundary stabilizer.  Sharing a foot IS the paper's "one lattice
+        spacing" (skip); disjoint is "two spacings" (place): straight-edge
+        alternation and the concave weight-3 rule are local instances of this
+        single test, and the convex-corner criterion stays with rule 6 in the
+        caller.  The engine's sub-product exclusion is deliberately absent —
+        the rules are supposed to make it unreachable (cross-checked against
+        :meth:`build` by the regression harness).
+
+        Returns the same ``(selected, corner_picks, metric, w1)`` tuple as
+        :meth:`build`; the metric is computed ONCE at the end (it gates the
+        caller's phase/cut ladders, it steers nothing here)."""
+        n, isv = self.n, self.isv
+        selected = []
+        placed_feet = set()
+        placed_pauli = {}                          # qubit -> letter already laid
+        for p in self.native_seed:                 # rule 0: anchors, verbatim
+            selected.append(p)
+            placed_feet.update(p["pauli"])
+            placed_pauli.update(p["pauli"])
+        for e in self.forced:                      # wall/kf records own their feet
+            if len(e["pauli"]) < 4:
+                placed_feet.update(e["pauli"])
+                placed_pauli.update(e["pauli"])
+
+        # parity-propagating BFS over the whole boundary graph.  Nodes: every
+        # pool position (anchors included; forbidden positions participate as
+        # TRANSIT nodes — a neighbouring patch's own lobe sits there, so the
+        # alternation parity flows through but nothing of ours is placed).
+        # Edges: sharing a data foot (one lattice spacing), with a Chebyshev-2
+        # fallback so the wave crosses seam endpoints where no common foot
+        # survives.  A node at even chain-distance from an anchor is a "place"
+        # slot, odd is a "skip" slot; a foot conflict with anything already
+        # placed vetoes regardless (waves meeting out of phase — the parity
+        # law's edge case — resolve to skip, like the paper's spacing rule).
+        # ---- transient chain graph (the user's anchored-walk counting) ----
+        # nodes: integer slots (pool candidates, untouched records) plus ONE
+        # node per wall band (the single-slot rule).  Edges: sharing a data
+        # foot — physical one-lattice-spacing adjacency ONLY (unstitched gaps
+        # break chains; no geometric shortcuts).  The count walks outward
+        # from the patch-native anchors: even = place slot, odd = skip slot;
+        # a wall band advances the count by exactly one.
+        nodes = {p["syn"]: p for p in self.pool}
+        for p in self.native_seed:
+            nodes.setdefault(p["syn"], p)
+        # wall band -> one node PER FOOT-LINE (the pair of feet at one
+        # along-wall coordinate).  A crossing chain pays exactly one slot
+        # (enter 1, leave 0); consecutive lines of the same wall are one
+        # slot apart along the wall.  A single blob node is wrong twice
+        # over: symmetric costs make a crossing cost two slots, and any
+        # shared node lets same-side tiles far apart along the wall borrow
+        # a one-slot shortcut through it.
+        band_feet = {}                       # line id -> foot pair
+        for e in self.forced:
+            if e.get('kf'):
+                feet = set(map(tuple, e["pauli"]))
+                xs = frozenset(x for x, _ in feet)
+                ys = frozenset(y for _, y in feet)
+                if len(xs) == 2:             # vertical wall: lines by y
+                    for yv in sorted(ys):
+                        band_feet.setdefault(('bl', 'v', xs, yv), set()).update(
+                            (x, yv) for x in xs)
+                else:                        # horizontal wall: lines by x
+                    for xv in sorted(xs):
+                        band_feet.setdefault(('bl', 'h', ys, xv), set()).update(
+                            (xv, y) for y in ys)
+        by_foot = {}
+        for s, p in nodes.items():
+            for q in p["pauli"]:
+                by_foot.setdefault(q, []).append(s)
+        for bid, bf in band_feet.items():
+            for q in bf:
+                by_foot.setdefault(q, []).append(bid)
+
+        def _feet(nid):
+            return band_feet[nid] if nid in band_feet else set(nodes[nid]["pauli"])
+
+        def _line_neighbours(nid):
+            # consecutive foot-lines of the SAME wall: one slot apart
+            _tag, ax, span, v = nid
+            for dv in (-2, 2):
+                nb = ('bl', ax, span, v + dv)
+                if nb in band_feet:
+                    yield nb
+
+        # 0-1 BFS: a STRAIGHT neighbour step advances the count by one slot;
+        # a DIAGONAL corner step keeps it ((cx+cy)/2 unchanged — corner slots
+        # share the corner foot at the SAME parity, the corner-w3 lesson);
+        # entering a wall band costs one slot (the single-slot rule)
+        from collections import deque
+        def _w(s, t):
+            if t in band_feet:
+                return 1                  # entering the line: the single slot
+            if s in band_feet:
+                return 0                  # leaving is free - one slot in total
+            return 0 if (abs(s[0] - t[0]) == 2 and abs(s[1] - t[1]) == 2) else 1
+        depth = {}
+        dq = deque()
+        for s in sorted(s for s in self.seed_syns if s in nodes):
+            depth[s] = 0
+            dq.append(s)
+        while dq:
+            s = dq.popleft()
+            nbrs = [t for q in _feet(s) for t in by_foot.get(q, ()) if t != s]
+            if s in band_feet:
+                nbrs.extend(_line_neighbours(s))
+            for t in nbrs:
+                w = 1 if (s in band_feet and t in band_feet) else _w(s, t)
+                nd = depth[s] + w
+                if t not in depth or nd < depth[t]:
+                    depth[t] = nd
+                    (dq.appendleft if w == 0 else dq.append)(t)
+        order = sorted((s for s in depth if s not in band_feet),
+                       key=lambda s: (depth[s], s))
+        order += sorted(set(nodes) - set(depth))        # anchorless: fallback
+
+        walked = set(depth)
+        for s in order:
+            if s in self.seed_syns:
+                continue                            # anchors already placed
+            if s in self.forbidden:
+                continue                            # neighbour-owned site
+            p = nodes[s]
+            if s in walked:
+                # letter-driven placement (slice-3 bus-boundary rule): the
+                # slot's letter is the REGION's letter (bus letter, conjugate
+                # inside a recoloured region — the M column flips letter and
+                # colour together, so the colour shortcut tracks it), XOR'd
+                # by the kf-crossing parity (a kf wall flips the letter only,
+                # invisible to colour).  The walk count sequences the scan
+                # and decides only the letter-undecided slots (recolour-
+                # boundary straddlers, mixed tiles).
+                if p["type"] in "XZ":
+                    letter = self._seg_letter(p)
+                    if letter is None:
+                        if depth[s] % 2 == 1:
+                            continue            # letter-undecided: count rules
+                    else:
+                        if p["type"] != letter:
+                            continue
+                        if any(placed_pauli.get(q, P) != P
+                               for q, P in p["pauli"].items()):
+                            continue            # region-junction guard: a
+                                                # shared foot with a DIFFERENT
+                                                # letter anticommutes; corner
+                                                # slots legitimately share a
+                                                # same-letter foot
+                else:
+                    if depth[s] % 2 == 1:
+                        continue
+                    if not placed_feet.isdisjoint(p["pauli"]):
+                        continue                # mixed tile foot veto
+            else:
+                # anchorless chain: wall-free by construction — the
+                # checkerboard-letter shortcut is exact there
+                if p["type"] in "XZ":
+                    letter = self._seg_letter(p)
+                    if letter is None or p["type"] != letter:
+                        continue
+                else:
+                    if not placed_feet.isdisjoint(p["pauli"]):
+                        continue
+            selected.append(p)
+            placed_feet.update(p["pauli"])
+            placed_pauli.update(p["pauli"])
+
+        # acceptance metric, computed once (same contract as build())
+        B = _IntBasis()
+        svecs = list(self.fvecs)
+        for v in self.fvecs:
+            B.add(v)
+        for p in selected:
+            v = isv(p["pauli"])
+            svecs.append(v)
+            B.add(v)
+        w1 = []
+        for q in self.data:
+            for P in "XZ":
+                v = isv({q: P})
+                if B.reduce(v) != 0 and all(_icommute(v, s, n) for s in svecs):
+                    w1.append(q)
+        N = len(self.target)
+        deficit = (len(self.data) - B.rank) - (N - 1)
+        joint = 0
+        for v in self.repv:
+            joint ^= v
+        metric = (max(deficit, 0), len(w1), 0 if B.contains(joint) else 1)
+        return selected, [], metric, w1
+
+
+def _direct_metric(bl, selected):
+    """Acceptance metric over the CURRENT forced+selected sets — vectors
+    only, no re-scan (the local corner-cut semantics modifies a forced
+    plaquette in place and re-checks acceptance without rebuilding)."""
+    B = _IntBasis()
+    svecs = []
+    for p in bl.forced:
+        v = bl.isv(p["pauli"])
+        svecs.append(v)
+        B.add(v)
+    for p in selected:
+        v = bl.isv(p["pauli"])
+        svecs.append(v)
+        B.add(v)
+    w1 = []
+    for q in bl.data:
+        for P in "XZ":
+            v = bl.isv({q: P})
+            if B.reduce(v) != 0 and all(_icommute(v, s, bl.n) for s in svecs):
+                w1.append(q)
+    N = len(bl.target)
+    deficit = (len(bl.data) - B.rank) - (N - 1)
+    joint = 0
+    for v in bl.repv:
+        joint ^= v
+    return (max(deficit, 0), len(w1), 0 if B.contains(joint) else 1), w1
+
+
+def _convex_corner_cuts_local(bl, selected, w1):
+    """Fig 34 label 2, the user's EXACT scope (2026-07-31): a convex bus
+    corner is cut iff a NEIGHBOURING boundary stabilizer — one sharing a
+    data foot with the corner plaquette, i.e. at ONE lattice spacing —
+    exists; two spacings (no shared foot) means no cut.  A weight-1
+    leftover on a bus corner also cuts.  (The retired Chebyshev-2 test
+    was wider: in dense geometries it counted unrelated pieces at
+    diagonal distance as neighbours and over-cut.)"""
+    corner_q = _corner_qubits(set(bl.data)) - bl.patchq
+    cuts = {q for q in w1 if q in corner_q}
+    for q in corner_q:
+        w4 = next((p for p in bl.forced if q in p["pauli"]), None)
+        if w4 is None:
+            continue
+        w4_feet = set(w4["pauli"])
+        for p in selected:
+            feet = set(p["pauli"])
+            if q in feet:
+                continue
+            if w4_feet & feet:
+                cuts.add(q)      # one lattice spacing: shares a foot
+                break
+    return cuts
+
+
+def _construct_phase(placed, target, orient, dset, retype, phase, forbidden=frozenset(),
+                     native_lock=False, bus=None, conj_names=None, extra_forced=(),
+                     retire_lobes=frozenset()):
+    """One deterministic construction attempt (direct scan + LOCAL corner
+    cuts).  Returns ``("ok", checks, logicals, x_obs, applied_cuts)`` or
+    ``("fail", reason)``."""
+    bl = _Builder(placed, target, orient, dset, retype, phase, forbidden,
+                  native_lock=native_lock, bus=bus, conj_names=conj_names,
+                  extra_forced=extra_forced, retire_lobes=retire_lobes)
+    if bl.fail is not None:
+        return ("fail", bl.fail)
+
+    applied_cuts = set()
+    # 10.4 direct construction, slice-3 letter rule: a slot's letter is
+    # its REGION's letter (bus letter, conjugate inside a recoloured
+    # region), so the placement is a lookup, not a propagated count; the
+    # walk count sequences the scan and decides only letter-undecided
+    # slots.  Wall-carrying builds count each kf band foot-line as ONE
+    # slot (enter 1 / leave 0); retired-lobe reuse builds go through the
+    # same rules.  (The legacy greedy engine and its rule-5 re-anchoring
+    # are deleted: census showed zero reachable customers.)
+    selected, picks, metric, w1 = bl.direct_build()
+    if metric != (0, 0, 0):
+        # rule 6, LOCAL semantics (user ruling 2026-07-31): a convex
+        # corner that fails the neighbour-spacing test is cut IN PLACE
+        # - the corner plaquette drops that foot (w4 -> w3), nothing
+        # else moves, no region rebuild.  The old rebuild ladder
+        # re-clipped the outline after every cut, manufactured phantom
+        # corners at the notch and cascaded (the 'corner-cut
+        # avalanche' was an artifact of that loop, not geometry).
+        cuts = _convex_corner_cuts_local(bl, selected, w1)
+        for q in sorted(cuts):
+            if any(q in p["pauli"] for p in selected):
+                continue          # a laid boundary piece owns this foot
+            w4 = next((p for p in bl.forced
+                       if q in p["pauli"] and len(p["pauli"]) >= 4), None)
+            if w4 is None:
+                continue
+            del w4["pauli"][q]    # w4 -> w3, in place
+            applied_cuts.add(q)
+        if applied_cuts:
+            bl.data = [q for q in bl.data if q not in applied_cuts]
+            metric, w1 = _direct_metric(bl, selected)
+        if metric != (0, 0, 0) and applied_cuts:
+            # variant 2 - cut-then-RELAY: the region is FIRST reduced by
+            # the round-one cut demands, then the boundary is laid ONCE
+            # on the final region (fresh scan; no further cuts, so no
+            # iteration and no cascade).  Some wall-adjacent layouts
+            # only form the JOINT product in the relaid pattern
+            # (measured: the role-switch south wall), while the flanked
+            # corner family needs the kept pattern (variant 1).  Both
+            # variants are bounded rule evaluations.
+            bl2 = _Builder(placed, target, orient,
+                           set(bl.data), {q for q in retype
+                                          if q in set(bl.data)},
+                           phase, forbidden, native_lock=native_lock,
+                           bus=bus, conj_names=conj_names,
+                           extra_forced=extra_forced,
+                           retire_lobes=retire_lobes)
+            if bl2.fail is None:
+                sel2, picks2, met2, w12 = bl2.direct_build()
+                if met2 == (0, 0, 0):
+                    bl, selected, metric, w1 = bl2, sel2, met2, w12
+        if metric != (0, 0, 0):
+            import os as _os
+            if _os.environ.get('LIGHTSTIM_DEBUG_JOINT'):
+                import sys as _sys
+                _B = _IntBasis()
+                for _p2 in bl.forced:
+                    _B.add(bl.isv(_p2["pauli"]))
+                for _p2 in selected:
+                    _B.add(bl.isv(_p2["pauli"]))
+                _joint = 0
+                for _v in bl.repv:
+                    _joint ^= _v
+                _res = _B.reduce(_joint)
+                _n2 = bl.n
+                _terms = []
+                for _k, _q in enumerate(bl.data):
+                    _x = (_res >> _k) & 1
+                    _z = (_res >> (_n2 + _k)) & 1
+                    if _x or _z:
+                        _terms.append(
+                            f"{'Y' if _x and _z else ('X' if _x else 'Z')}"
+                            f"@{_q}")
+                print(f"[joint] phase={phase} residual({len(_terms)}): "
+                      f"{' '.join(_terms[:14])}", file=_sys.stderr)
+            return ("fail", f"direct-scan acceptance shortfall {metric} "
+                            f"(rank deficit, weight-1 count, joint "
+                            f"missing) after {len(applied_cuts)} local "
+                            f"corner cuts (phase {phase})")
+
+
+    checks = []
+    for p in bl.forced + selected:
+        c = dict(p)
+        c["corners"] = sorted(c["pauli"])
+        checks.append(c)
+    logicals = [(nm, bl.reps[nm][0], bl.reps[nm][1]) for nm, _ in target]
+    # tracked observable: a BUS-basis representative — the memory experiment runs in the
+    # bus basis, so the tracked logical must be of that type.  The bus is the PLANNED
+    # ``bus`` when given, else the majority target basis (tie -> X).
+    if bus is None:
+        n_x = sum(1 for _, P, _ in logicals if P == "X")
+        bus = "X" if n_x >= len(logicals) - n_x else "Z"
+    x_obs = next((s for nm, P, s in logicals if P == bus), logicals[0][2])
+    return ("ok", checks, logicals, x_obs, frozenset(applied_cuts))
+
+
+def rule_based_joint_checks(placed, target, orient, data, retype, d, max_cut=4,
+                            forbidden=frozenset(), native_lock=False, bus=None,
+                            conj_names=None, extra_forced_fn=None,
+                            retire_lobes=frozenset()):
+    """Deterministic construction on the routed region (phases 0/1; corner
+    cuts are applied LOCALLY inside each attempt per the user's 2026-07-31
+    ruling — no rebuild ladder).
+    Returns ``dict(checks, data, cut, phase, logicals, x_observable, reason="")`` on
+    success, else ``dict(checks=None, reason=<why per phase>)``.  Pure function of the
+    geometry — no randomness.
+
+    ``native_lock`` (rule 0, default OFF in the abutting pipeline — in that
+    geometry the greedy's alternation is sometimes load-bearing for mixed-joint
+    distance laws; the seam-column pipeline passes True): every target patch whose interior is
+    compatible with the global checkerboard (not retyped, phase-matched) keeps its
+    TEXTBOOK standalone construction verbatim — its native boundary semicircles are
+    forced picks and non-native tiles inside the patch are expelled, so a boundary-
+    alternation tie can never relocate an observable's guard.  The facing semicircle
+    is the sole exception: when its forced-bulk extension into seam/corridor qubits
+    exists, the extension replaces it (joint-measurement rank demands this).  If the
+    lock is unsatisfiable in every phase/strategy, the ladder is retried without it
+    (noted in ``reason``).
+    """
+    reasons = []
+
+    def attempt(phase, lock=True):
+        rt = {q for q in retype if q in set(data)}
+        ef = extra_forced_fn(phase) if extra_forced_fn is not None else ()
+        res = _construct_phase(placed, target, orient, set(data), rt, phase,
+                               forbidden, native_lock=lock, bus=bus,
+                               conj_names=conj_names, extra_forced=ef,
+                               retire_lobes=retire_lobes)
+        if res[0] == "ok":
+            lcut = set(res[4]) if len(res) > 4 else set()
+            return dict(checks=res[1],
+                        data=sorted(set(data) - lcut),
+                        cut=tuple(sorted(lcut)),
+                        phase=phase, logicals=res[2], x_observable=res[3],
+                        reason="")
+        reasons.append(f"phase {phase}: {res[1]}")
+        return None
+
+    # phases 0/1 with the native lock HARD (an unsatisfiable lock is a
+    # failed build); corner cuts happen LOCALLY inside the attempt, so no
+    # cut ladder exists any more.  ``max_cut`` is kept in the signature
+    # for API compatibility only.
+    lock = bool(native_lock)
+    for phase in (0, 1):
+        out = attempt(phase, lock=lock)
+        if out is not None:
+            return out
+    return dict(checks=None, data=sorted(data), cut=(), phase=None,
+                logicals=None, x_observable=None, reason="; ".join(reasons))
+
+
+NEIGH = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+
+
+def _seam_qubits(occupied, d):
+    """The seam data qubits joining every pair of edge-adjacent occupied coarse cells
+    (seam-column grid, pitch ``2d+2``): a vertical column of ``d`` qubits between
+    horizontal neighbours, a horizontal row between vertical neighbours."""
+    P = 2 * d + 2
+    out = set()
+    for (a, b) in occupied:
+        if (a + 1, b) in occupied:
+            out |= {(P * (a + 1) - 1, P * b + 1 + 2 * j) for j in range(d)}
+        if (a, b + 1) in occupied:
+            out |= {(P * a + 1 + 2 * i, P * (b + 1) - 1) for i in range(d)}
+    return out
+
+
+def _specs_to_cells(patches, target=None, seam=False):
+    """Map the user-facing :class:`PatchSpec` list onto the internal coarse-cell model.
+
+    Returns ``(patch_at, orient, d)`` where ``patch_at[name] = (a, b)`` is the coarse cell whose
+    ``d×d`` footprint equals the patch's placed data qubits, ``orient[name]`` is the declared
+    orientation, and ``d`` is the (shared) code distance.  This is the single adapter every public
+    entry point runs first, so the whole subset API speaks ``PatchSpec`` while the routing internals
+    keep working in coarse cells.
+
+    Raises ``TypeError`` / ``ValueError`` with a concrete reason when the specs can't be placed on the
+    coarse grid — a non-``PatchSpec`` element (e.g. the old ``{name:(a,b)}`` cell dict), mixed
+    distances, duplicate names, an origin off the pitch-``2d`` grid, or a bad orientation — or when
+    ``target`` names an unknown patch, repeats one, or uses a non-``X``/``Z`` Pauli.
+    """
+    patches = list(patches)
+    if not patches:
+        raise ValueError("need at least one PatchSpec")
+    if not all(isinstance(s, PatchSpec) for s in patches):
+        raise TypeError("patches must be a list of PatchSpec(name, origin, distance, "
+                        "orientation); the old {name: (a, b)} cell-dict form is no "
+                        "longer accepted — build a PatchSpec per patch (origin_of(a, b, d) places "
+                        "one on coarse cell (a, b)).")
+    d = patches[0].distance
+    if any(s.distance != d for s in patches):
+        raise ValueError(f"all patches must share one distance, got {sorted({s.distance for s in patches})}")
+    names = [s.name for s in patches]
+    if len(set(names)) != len(names):
+        raise ValueError(f"patch names must be unique, got {names}")
+    patch_at, orient = {}, {}
+    for s in patches:
+        if s.orientation not in ("X_horizontal", "X_vertical"):
+            raise ValueError(f"patch {s.name!r}: orientation must be 'X_horizontal'|'X_vertical', "
+                             f"got {s.orientation!r}")
+        try:
+            patch_at[s.name] = cell_index(s.origin, d, seam)
+        except ValueError:
+            raise ValueError(
+                f"patch {s.name!r}: origin {s.origin} is not on the coarse routing grid (pitch "
+                f"{_pitch(d, seam)} for d={d}, seam={seam}).  Subset routing places patches on cells "
+                f"whose bus-facing corner is origin_of(a, b, d, seam={seam}).")
+        orient[s.name] = s.orientation
+    if target is not None:
+        tnames = [nm for nm, _ in target]
+        unknown = [nm for nm in tnames if nm not in patch_at]
+        if unknown:
+            raise ValueError(f"target names {unknown} are not among the patches {names}")
+        if len(set(tnames)) != len(tnames):
+            raise ValueError(f"target lists a patch more than once: {tnames}")
+        if any(P not in ("X", "Z") for _, P in target):
+            raise ValueError(f"target paulis must be 'X' or 'Z', got {[P for _, P in target]}")
+    return patch_at, orient, d
+
+
+def _cheb(ab, cd):
+    """King-move (Chebyshev) distance between two coarse cells."""
+    return max(abs(ab[0] - cd[0]), abs(ab[1] - cd[1]))
+
+
+def _legal_attach_groups(patch_at, target, orient, corridor):
+    """Per-target group of corridor cells adjacent through a PARALLEL-LAW
+    legal seam (the same rule the stitching policy applies).  Returns
+    (groups, missing) — ``missing`` lists targets with no legal cell."""
+    groups, missing = [], []
+    for nm, P in target:
+        pa = tuple(patch_at[nm])
+        cells = []
+        for da, db in NEIGH:
+            c = (pa[0] + da, pa[1] + db)
+            if c not in corridor:
+                continue
+            seam_ew = (da != 0)
+            want = 'X_horizontal' if (P == 'Z') == seam_ew else 'X_vertical'
+            if orient[nm] == want:
+                cells.append(c)
+        groups.append(cells)
+        if not cells:
+            missing.append(nm)
+    return groups, missing
+
+
+def path_to_corridor(tree_cells, placed, target, d, seam=False, patch_at=None, bus=None,
+                     conj_names=None, flip_cells=None, skip_seam_pairs=None):
+    """Convert a set of corridor **cells** into the joint code's ``(data, retype)``.
+
+    ``data`` = the target patch cells ∪ the corridor cells' footprints.
+
+    **Bus-basis rule**: the corridor's native basis is ``bus`` when given, else the
+    *majority* target basis (a tie keeps the historical X-bus).  Only the
+    non-bus-basis patches attach through mixed (XZ) domain walls — so a pure-X or
+    pure-Z joint uses NO mixed stabilizer at all (the pure-Z corridor is the exact CSS
+    dual of the pure-X one).  Passing an explicit ``bus`` forces the native basis to a
+    PLANNED choice (used to keep a shared patch's conjugation status consistent across
+    a PPM sequence); the physics is valid for either basis (conjugating the non-bus
+    patches reduces the joint to a pure-bus merge), the minority basis merely raises
+    more mixed 'M' walls.
+
+    ``conj_names``: the target patches whose LIVE construction is the colour-conjugate
+    registration.  A patch's region is retyped iff it is conjugate-registered — its
+    physical checks really are colour-flipped, and the wall the retype boundary raises
+    is what reconciles them with the corridor.  ``None`` (the historical default)
+    infers conjugation from the measured Pauli: minority-basis patches are the
+    conjugate-registered ones (first-use minority allocation), which reproduces the
+    original letter rule byte for byte.  Passing the set explicitly decouples the two:
+    a conjugate patch measuring the BUS basis (its recoloured seam still needs the
+    wall) routes without any rotation.
+
+    ``retype`` encodes this for :func:`._bent_plaquettes`: for EITHER bus letter,
+    exactly the conjugate-registered cells (plus ``flip_cells``) are flipped.  The
+    complement is an exact STATIC dual — flipping *all* of ``data`` equals flipping
+    none at the opposite checkerboard ``phase`` — but patches carry measurement
+    history, so the dual is not free to choose; the direct convention is the
+    only valid one.  Both checkerboard phases are tried downstream.
+    """
+    tnames = [nm for nm, _ in target]
+    data = set()
+    for nm in tnames:
+        data |= placed[nm]
+    for c in tree_cells:
+        data |= cell(*c, d, seam)
+    if seam:                    # seam-column design: join every adjacent occupied pair
+        if patch_at is None:
+            raise ValueError("path_to_corridor(seam=True) needs patch_at (coarse cells)")
+        occupied = set(map(tuple, tree_cells)) | {tuple(patch_at[nm]) for nm in tnames}
+        data |= _seam_qubits(occupied, d)
+        # a walled junction gets NO seam qubits (the stretched-stabilizer band
+        # lives in the gap; the wall records bridge the two segments)
+        for pair in (skip_seam_pairs or ()):
+            data -= _seam_qubits({tuple(pair[0]), tuple(pair[1])}, d)
+    xnames = [nm for nm, P in target if P == "X"]
+    znames = [nm for nm, P in target if P == "Z"]
+    if bus is None:
+        bus = "X" if len(xnames) >= len(znames) else "Z"
+    if conj_names is None:      # historical inference: conjugate ⟺ minority basis
+        conj_names = frozenset(znames if bus == "X" else xnames)
+    flip = set().union(*[placed[nm] for nm in tnames if nm in conj_names]) \
+        if conj_names else set()
+    if flip_cells:
+        # segment recolouring: these corridor cells join the flipped-gauge side,
+        # WITH the seam qubits interior to the flipped region (flipped cell to
+        # flipped cell / flipped cell to conjugate patch) — a plain stitch inside
+        # one colour region flips as a whole
+        fcs = {tuple(c) for c in flip_cells}
+        for c in fcs:
+            flip |= cell(*c, d, seam)
+        if seam:
+            fents = fcs | {tuple(patch_at[nm]) for nm in tnames
+                           if nm in conj_names}
+            flip |= _seam_qubits(fents, d) & data
+    # DIRECT convention for both bus letters (stage-A hardening): retype is
+    # exactly the flipped side - conj-registered footprints plus flip_cells.
+    # The old X-bus complement shortcut realized the colour-conjugate DUAL of
+    # the intended layout; statically equivalent, but a patch with measurement
+    # history must keep its own letters, so the dual is not free to choose.
+    retype = {q for q in data if q in flip}
+    return data, retype
+
+
+# -----------------------------------------------------------------------------
+# physics-layer reuse: a routed (data, retype) region -> a verified MultiPatchLayout
+# -----------------------------------------------------------------------------
+
+def _assemble_region(placed, target, orient, data, retype, d, seed=0, max_trials=5000, max_cut=4,
+                     forbidden=frozenset(), native_lock=False, bus=None, conj_names=None,
+                     extra_forced_fn=None, extra_connect=frozenset(),
+                     retyped_bus=frozenset(), retire_lobes=frozenset()):
+    """Hand a routed region to the **deterministic rule-based** physics layer.
+
+    The stabilizers are constructed by :func:`.deterministic_checks.rule_based_joint_checks`
+    (the documented Handbook §10.4 / Fig 33-34 rules: forced bulk, alternating-spacing
+    boundary, concave/convex corner rules with rule-driven corner cuts) — no randomized
+    search.  ``seed`` / ``max_trials`` are accepted for backward compatibility and ignored.
+    Returns a :class:`.MultiPatchLayout` (whose ``data`` may be smaller than the input when
+    the convex-corner rule cut bus-corner qubits), or ``None`` if the rules cannot host this
+    geometry.  The oracle decision itself is ``MultiPatchLayout.verify()``.
+    """
+    data = sorted(data)
+    # a walled junction leaves a data gap; its would-be seam qubits are handed
+    # in as extra_connect so the two segments count as one region
+    if not _connected(set(data) | set(extra_connect)):
+        return None
+    rb = rule_based_joint_checks(placed, target, orient, data, set(retype), d, max_cut=max_cut,
+                                 forbidden=forbidden, native_lock=native_lock, bus=bus,
+                                 conj_names=conj_names, extra_forced_fn=extra_forced_fn,
+                                 retire_lobes=retire_lobes)
+    if rb["checks"] is None:
+        return None
+    log_pairs = [(P, sup) for _, P, sup in rb["logicals"]]
+    # orientation-domain map for the hook-benign scheduler: patch cells carry
+    # their declared orientation; bus/corridor cells follow the majority
+    tally = {}
+    for nm, _ in target:
+        o = orient[nm]
+        tally[o] = tally.get(o, 0) + 1
+    bus_orient = max(sorted(tally), key=lambda o: tally[o])
+    domains = {}
+    for nm, _ in target:
+        for q in placed[nm]:
+            domains[q] = orient[nm]
+    for q in rb["data"]:
+        domains.setdefault(q, bus_orient)
+    return MultiPatchLayout(distance=d, data=rb["data"], checks=rb["checks"],
+                            logicals=rb["logicals"], x_observable=rb["x_observable"],
+                            readout_chain=_readout_chain(rb["data"], rb["checks"], log_pairs),
+                            target=list(target), domains=domains, bus=bus,
+                            retyped=frozenset(retyped_bus))
+
+
+# -----------------------------------------------------------------------------
+# the router
+# -----------------------------------------------------------------------------
+
+@dataclass
+class SubsetRoute:
+    """Result of :func:`route_and_build`.  ``status == "ok"`` iff ``layout`` is a verified joint.
+
+    On a **failure** an obstacle-free corridor may still exist but be un-hostable by the physics
+    layer — ``attempted`` / ``attempted_arms`` carry the shortest such corridor (empty only when
+    ``status == "no_path"``) so a caller can *draw the route that was found* and label it correctly
+    (a rejected corridor is **not** "no route").
+    """
+    status: str    # "ok" | "no_path" (unreachable OR only disconnected corridors) | "no_verified_route"
+    message: str = ""
+    layout: object = None                             # MultiPatchLayout when status == "ok"
+    root: str = None
+    arms: dict = field(default_factory=dict)          # z-name -> corridor-cell path (VERIFIED bus)
+    tree: set = field(default_factory=set)            # corridor cells of the VERIFIED bus
+    attempted: set = field(default_factory=set)       # corridor cells of the shortest candidate (any status)
+    attempted_arms: dict = field(default_factory=dict)  # z-name -> shortest candidate path
+    data: set = field(default_factory=set)            # data qubits of the routed region
+    placed: dict = field(default_factory=dict)        # name -> patch cells (ALL patches)
+    target: list = field(default_factory=list)
+    obstacles: list = field(default_factory=list)     # non-target patch names
+    obstacle_fp: set = field(default_factory=set)     # non-target patch data qubits
+    corridor: set = field(default_factory=set)        # all corridor-eligible cells
+    tried: int = 0
+    how: str = "standard"                             # "standard" | "corner-cut" (route_and_build)
+    cut: tuple = ()                                   # convex-corner qubits removed (corner-cut only)
+    n_walls: int = 0                                  # stretched (kf) seam walls in the layout - band
+                                                      # apparatus is real cost, chargeable like cells
+
+    @property
+    def ok(self):
+        return self.status == "ok"
+
+
+def _obstacle_ancillas(patches, tnames):
+    """The ancilla sites actually USED by the non-target (idle obstacle) patches.
+
+    Each idle patch keeps its standalone construction; its selected syndrome sites are
+    physical qubits the routed joint code may not re-use.  These are handed to the rule
+    constructor as ``forbidden`` boundary positions, so a corridor sharing an ancilla
+    line with an idle neighbour interleaves with it instead of colliding — edge-adjacent
+    placement (keepout=0) is then physically sound whenever the parity allows.
+    """
+    out = set()
+    for s in patches:
+        if s.name in tnames:
+            continue
+        for c in place_patch(s)["checks"]:
+            out.add(tuple(int(v) for v in c["syn"]))
+    return frozenset(out)
+
+
+def _table_wall_dispatch(patch_at, target, orient, tree, conj_names, bus,
+                         ns_pairs=frozenset()):
+    """Post-routing seam-table dispatch — the user's TWO-BIT table (letter,
+    colour), 2026-07-30.  TWO wall rows raise a stretched kf wall; TYPE
+    never triggers one (same-letter same-colour type-split seams are plain
+    row #1).  Step 2 never re-registers a patch: ``conj_eff`` is passed
+    through, not grown.
+
+      #4 native (letter same, colour diff): a conj-registered target
+         measuring the BUS letter — the snake family.  On a vertical seam
+         the corridor painting flips (g = 1: #4->#6 and #1->#7 wholesale).
+      #6 native (letter diff, colour same): a STANDARD-colour target
+         measuring the OTHER letter (user ruling 2026-07-30: the mixed
+         kf wall is the row's construct — the spatial-Hadamard interface
+         turns the letter at the seam).  The wall hardware is the SAME
+         local-rule family; the corridor never flips for it.  Fires only
+         under an EXPLICIT ``conj_names`` — with ``conj_names=None`` the
+         historical minority-conjugate inference keeps the legacy plain
+         path (C4 mixed cells).
+
+    Returns ``(arm_walls, conj_eff, flip_corridor)`` or ``None`` when no
+    wall is due; ``(None, conj_eff, False)`` when a due wall cannot be
+    hosted on this tree."""
+    bus_eff = bus
+    if bus_eff is None:
+        n_x = sum(1 for _, P in target if P == "X")
+        bus_eff = "X" if n_x >= len(target) - n_x else "Z"
+    conj_eff = conj_names if conj_names is not None else \
+        frozenset(nm for nm, P in target if P != bus_eff)
+    # #4-native walls: colour-diff (conj) targets measuring the bus letter
+    snake_nms = sorted(nm for nm, P in target
+                       if P == bus_eff and nm in conj_eff)
+    # #6-native walls: standard-colour targets measuring the other letter
+    direct6_nms = sorted(nm for nm, P in target
+                         if P != bus_eff and nm not in conj_eff) \
+        if conj_names is not None else []
+    wall_nms = snake_nms + direct6_nms
+    if not wall_nms:
+        return None
+    # completeness: every NON-wall target must sit on row #1 (letter same,
+    # colour same — plain stitch).  A leftover (T,T)/#7 seam in the same
+    # joint has no verified construction alongside these walls (measured:
+    # the layout passes the group oracle but the OBSERVABLE goes
+    # non-deterministic) — decline to the legacy path instead.
+    for nm, P in target:
+        if nm not in wall_nms and not (P == bus_eff and nm not in conj_eff):
+            return None
+    tset = {tuple(c) for c in tree}
+    # wall seams live on the LIVE-frame parallel-law-legal faces — the same
+    # frame _auto_stitch judges plain seams in.  A wall reconciles the
+    # CORRIDOR side of the seam (#4: the colour bit, #6: the bus letter),
+    # never the target's own seam letter: a seam that is perpendicular in
+    # the live frame is an ODD row — illegal, no wall due (measured: the
+    # registered-frame faces admitted a S-seam #4 on a rotate_90'd conj
+    # target and both construction phases refused it — 20-patch q17)
+    groups_all, _miss = _legal_attach_groups(patch_at, target, orient, tset)
+    legal_of = {nm: set(g) for (nm, _), g in zip(target, groups_all)}
+    aw, snake_vertical = [], False
+
+    def _hosts_direct6(nm, pc, wc):
+        """Tree-dependent #6 hosting law (24/24 measured matrix, 2026-08-02:
+        both orientations × all four sides × all exits, each combo built with
+        a stubbed dispatch and checked verify + p0 + graphlike distance).
+        The walled cell must be TERMINAL (degree 1 — the joint product only
+        splices through an end wall; the interior middle-wall case measured
+        (0,0,1) acceptance), and the bus may leave it straight ahead or with
+        the scan-friendly turn only: the lexicographic NW-first scan lays the
+        letter-turned continuation on ONE handedness.  With s = wc − pc and
+        e = exit − wc, decline iff cross(s, e) == −1 for an X̄-vertical
+        target and +1 for X̄-horizontal — the transpose is a REFLECTION, so
+        the bad handedness flips with the family (ptype transpose symmetry
+        makes everything else covariant, same argument as litinski ±x)."""
+        bad = -1 if orient.get(nm) == 'X_vertical' else 1
+        sx, sy = wc[0] - pc[0], wc[1] - pc[1]
+        deg = 0
+        for c in tset:
+            ex_, ey_ = c[0] - wc[0], c[1] - wc[1]
+            if abs(ex_) + abs(ey_) != 1:
+                continue
+            deg += 1
+            if deg > 1:
+                return False        # interior bus cell: splice unverified
+            if sx * ey_ - sy * ex_ == bad:
+                return False        # scan-hostile turn out of the walled cell
+        return True
+
+    for nm in wall_nms:
+        pc0 = tuple(patch_at[nm])
+        # a user-unstitched seam never hosts a wall (no_stitch wins over
+        # every table row — measured: the fig5-six PPM4 wall on q4's
+        # unstitched (2,1) seam admits, then the walled build fails and
+        # the plain fallback strands q1)
+        cells = sorted(c for c in legal_of.get(nm, ())
+                       if frozenset((pc0, tuple(c))) not in ns_pairs)
+        if nm in direct6_nms:
+            # first HOSTABLE legal cell wins (a target with two legal faces
+            # may host the wall on either; the hosting law filters per cell)
+            cells = [c for c in cells if _hosts_direct6(nm, pc0, tuple(c))]
+        if not cells:
+            return None, conj_eff, False   # this path cannot host the wall
+        wc = cells[0]
+        if nm in snake_nms and wc[0] == pc0[0]:
+            # snake wall on a HORIZONTAL (N/S) seam — the #4-native
+            # horizontal band has no verified construction (measured on
+            # the minimal std|conj pair: phase 0 acceptance (0,0,1)
+            # joint missing, phase 1 native-lock refusal).  The verified
+            # dispatch-snake family is the VERTICAL seam with the
+            # corridor flip, mirroring the gateway snake.  Decline so
+            # probe = builder.
+            return None, conj_eff, False
+        aw.append((nm, wc))
+        if nm in snake_nms and wc[0] != tuple(patch_at[nm])[0]:
+            snake_vertical = True
+    if len(direct6_nms) > 1:
+        # multiple native-#6 walls in one joint: the joint product must
+        # splice through EVERY wall and the verified splice algebra covers
+        # ONE wall (measured: two clean vertical walls, acceptance (0,0,1)
+        # joint missing).  Decline; the planner reaches the same measurement
+        # through a rotation (the conj target's #7 column is in production).
+        return None, conj_eff, False
+    if len({wc for _, wc in aw}) < len(aw):
+        # two walls on the SAME corridor cell (both seams of one cell
+        # walled) — no verified construction (the two-wall family puts
+        # each wall on its own cell); measured: the build falls through
+        # and dies on the plain path.  Decline so the probe agrees with
+        # the builder and the planner takes another convention (the
+        # all-swapped pair goes through the global-conjugate shortcut).
+        return None, conj_eff, False
+    if snake_vertical and direct6_nms:
+        # the snake flip would repaint the corridor under the native-#6
+        # walls, moving their seams to row #7 — no verified construction
+        return None, conj_eff, False
+    if snake_vertical:
+        # g = 1 (flipped painting): a STANDARD-colour non-wall target's
+        # plain seam becomes the recoloured column (#1 -> #7), verified
+        # ONLY as the snake's horizontal-seam family — decline otherwise
+        for nm, _P in target:
+            if nm in wall_nms or nm in conj_eff:
+                continue
+            pc = tuple(patch_at[nm])
+            adj = [c for c in tset
+                   if abs(c[0] - pc[0]) + abs(c[1] - pc[1]) == 1]
+            if not all(c[0] == pc[0] for c in adj):
+                return None, conj_eff, False
+    return aw, conj_eff, snake_vertical
+
+
+def route_and_build(patches, target, pad=1, per_z=6, max_std=48, cut_budget=4, max_cut=4,
+                    keepout=0, seed=0, max_trials=5000, route=None, seam=False, bus=None,
+                    conj_names=None, flip_cells=None, no_stitch=None, wall_junction=None,
+                    arm_walls=None, probe=False, geom_cache=None):
+    """Fully-automatic route **and** build: no hand-written corridor needed.
+
+    ``route`` (optional): an **explicit corridor** — a list of coarse cells ``[(a, b), …]``.
+    When given, NO automatic routing happens: the joint code is built on exactly these
+    cells by the deterministic rule constructor and gated by the full oracle.  The cells
+    must not overlap any patch; the obstacle **keep-out margin is NOT enforced** for an
+    explicit route (you are overriding the router), so check ``collision_report`` if
+    obstacles sit next to your corridor.  Omit ``route`` (default) for auto-routing.
+
+    ``conj_names`` (optional): the target patches whose LIVE construction is the
+    colour-conjugate registration (see :func:`path_to_corridor`).  ``None`` keeps the
+    historical inference (conjugate ⟺ minority basis).  Passing the true set lets a
+    conjugate patch attach in the BUS basis — its recoloured seam wall is raised by
+    the retype boundary, no rotation needed.
+
+    ``flip_cells`` + ``wall_junction`` (optional, explicit route only): a SNAKE bus.
+    ``flip_cells`` recolours those corridor cells into the conjugate gauge (they
+    plain-stitch the conjugate targets); ``wall_junction = (cell_a, cell_b)`` names
+    the adjacent corridor pair whose seam is REPLACED by a stretched-stabilizer
+    colour wall (the K&F spatial-Hadamard interface: uniform pure-letter dominoes,
+    flips the colours, keeps the letters).  No seam qubits are added there; the
+    wall's kf records are injected as forced checks, so a same-letter joint between
+    a colour-swapped and a standard patch closes with zero rotations and NO mixed
+    checks anywhere.
+
+    Propose-and-verify with retry: (1) candidate arms leave the X-anchor from **any** face (not just
+    its X-faces), so clean below-/side-attach corridors are found; (2) arm-product unions are
+    augmented with greedy **Steiner** candidates (:func:`_steiner_trees`) whose arms share a common
+    trunk; (3) a candidate whose corridor is **disconnected** (its arms meet only through a target
+    patch — two separate buses) is illegal and never tried; if *every* candidate is disconnected the
+    result is an honest ``no_path``; (4) each surviving candidate is built by the **deterministic
+    rule constructor** (:mod:`.deterministic_checks` — cut-free first, then rule-driven convex-corner
+    cuts up to ``max_cut``) and gated by the full oracle.  Candidates are tried
+    **fewest-corridor-cells first**, so the smallest *valid* bus wins — a shared straight trunk is
+    preferred over fat multi-arm unions.  ``per_z`` / ``max_std`` / ``keepout`` shape the candidate
+    pool; ``cut_budget`` / ``seed`` / ``max_trials`` are accepted for backward compatibility and
+    ignored (there is no randomized search any more).  This is the routine the demo notebook calls
+    instead of pasting cells.
+
+    Returns a :class:`SubsetRoute` with ``status == "ok"`` and ``.layout`` / ``.tree`` (route cells) /
+    ``.how`` (``"standard"`` | ``"corner-cut"``) / ``.cut`` set, or a failure ``SubsetRoute`` with
+    status ``target_obstacle_conflict`` / ``no_path`` / ``no_verified_route``.
+    """
+    if route is None:
+        raise BentLayoutError(
+            "this LightStim variant has no auto-router: pass an explicit "
+            "route (the coarse corridor cells, in order; [] for "
+            "cell-adjacent targets)")
+    patch_at, orient, d = _specs_to_cells(patches, target, seam=seam)
+    tnames = [nm for nm, _ in target]
+    # no_stitch: adjacencies that stay UNSTITCHED — the two boundaries sit next
+    # to each other without merging (no seam qubits, no seam-orientation rule;
+    # each side keeps its own free boundary).  Entries are (patch, cell) or
+    # (patch, patch); normalize to cell pairs here.
+    ns_pairs = frozenset(
+        frozenset((tuple(patch_at[a]) if isinstance(a, str) else tuple(a),
+                   tuple(patch_at[b]) if isinstance(b, str) else tuple(b)))
+        for a, b in (no_stitch or ()))
+    onames = [nm for nm in patch_at if nm not in tnames]
+
+    def _auto_stitch(tree_cells, wall_pairs=frozenset()):
+        """Parallel-law stitching policy: a target|cell (or target|target)
+        adjacency is STITCHED iff the seam runs parallel to that target's
+        measured logical; an illegal adjacency stays UNSTITCHED — the two
+        boundaries simply sit next to each other, separated by the empty
+        seam line (a corridor cell may pass BY one target to reach
+        another).  User ``no_stitch`` pairs always stay unstitched; a
+        walled junction counts as an attachment.  Returns
+        ``(skip_pairs, violation)`` — ``violation`` is set when a target
+        ends up with NO attachment at all."""
+        skip = set(ns_pairs)
+        attached = {nm: 0 for nm in tnames}
+        # two-bit TABLE legality of a PLAIN (non-wall) stitch: row #1
+        # (letter == bus, standard colours) or row #7 (letter != bus,
+        # conj-registered — the retype-boundary M-column family).  The
+        # wall rows #4/#6 cannot plain-stitch: without a dispatched wall
+        # the seam stays open.  Mirrors the rule constructor exactly, so
+        # the step-1 probe never green-lights a seam step 2 cannot build.
+        n_x_s = sum(1 for _, P in target if P == "X")
+        bus_s = bus if bus is not None else (
+            "X" if n_x_s >= len(target) - n_x_s else "Z")
+        conj_s = conj_names if conj_names is not None else \
+            frozenset(nm for nm, P in target if P != bus_s)
+
+        def _row_plain_ok(nm, P):
+            return (P != bus_s) == (nm in conj_s)
+
+        for nm, P in target:
+            pa = tuple(patch_at[nm])
+            legal_cells = []
+            for tc in map(tuple, tree_cells):
+                da, db = tc[0] - pa[0], tc[1] - pa[1]
+                if abs(da) + abs(db) != 1:
+                    continue
+                pair = frozenset((pa, tc))
+                if pair in wall_pairs:
+                    attached[nm] += 1          # the wall IS the attachment
+                    continue
+                if pair in skip:
+                    continue                   # user unstitch wins
+                seam_ew = (da != 0)
+                want = ('X_horizontal' if (P == 'Z') == seam_ew
+                        else 'X_vertical')
+                if orient[nm] != want or not _row_plain_ok(nm, P):
+                    skip.add(pair)
+                else:
+                    legal_cells.append(tc)
+            # SINGLE ATTACHMENT (user rule 2026-07-31): when the bus wraps a
+            # target on several sides, the patch attaches through EXACTLY
+            # ONE seam — any legal side works (measured: the flanked-patch
+            # double stitch is what wrecked the corner geometry), the choice
+            # is free; deterministic first-by-order here.  Extra legal
+            # adjacencies stay unstitched (the corridor passes by).
+            if attached[nm] == 0 and legal_cells:
+                keep = sorted(legal_cells)[0]
+                attached[nm] += 1
+                for tc in legal_cells:
+                    if tc != keep:
+                        skip.add(frozenset((pa, tc)))
+            else:
+                for tc in legal_cells:
+                    skip.add(frozenset((pa, tc)))
+        tl = list(target)
+        for i1, (n1, P1) in enumerate(tl):
+            c1 = tuple(patch_at[n1])
+            for n2, P2 in tl[i1 + 1:]:
+                c2 = tuple(patch_at[n2])
+                da, db = c2[0] - c1[0], c2[1] - c1[1]
+                if abs(da) + abs(db) != 1:
+                    continue
+                pair = frozenset((c1, c2))
+                if pair in wall_pairs:
+                    attached[n1] += 1
+                    attached[n2] += 1
+                    continue
+                if pair in skip:
+                    continue
+                seam_ew = (da != 0)
+                legal = all(orient[nm] == ('X_horizontal'
+                                           if (P == 'Z') == seam_ew
+                                           else 'X_vertical')
+                            and _row_plain_ok(nm, P)
+                            for nm, P in ((n1, P1), (n2, P2)))
+                if legal:
+                    attached[n1] += 1
+                    attached[n2] += 1
+                else:
+                    skip.add(pair)
+        for nm, P in target:
+            if attached[nm] == 0:
+                return skip, (
+                    f"{nm}: no parallel-law-legal attach seam to this "
+                    f"corridor — measuring {P} needs a seam PARALLEL to the "
+                    f"measured logical ({'vertical (E/W)' if (P == 'X') == (orient[nm] == 'X_vertical') else 'horizontal (N/S)'} "
+                    f"for orientation {orient[nm]!r}); every adjacency is "
+                    f"perpendicular, user-unstitched, or absent")
+        # CONNECTIVITY: per-target degree >= 1 is not enough — two adjacent
+        # targets can legally stitch to EACH OTHER while their corridor
+        # seams are all skipped, forming an island the bus never reaches
+        # (fig5 q6|q4 under all-vertical declarations).  The stitched merge
+        # graph (corridor cells + target cells; edges = corridor internal
+        # adjacency + every stitched/walled pair) must put ALL targets in
+        # the component containing the corridor.
+        cells_t = {tuple(patch_at[nm]): nm for nm in tnames}
+        nodes = set(map(tuple, tree_cells)) | set(cells_t)
+        adj = {n: set() for n in nodes}
+        tset_c = set(map(tuple, tree_cells))
+        for a in tset_c:
+            for b in tset_c:
+                if abs(a[0] - b[0]) + abs(a[1] - b[1]) == 1:
+                    adj[a].add(b)
+                    adj[b].add(a)
+        def _link(a, b):
+            pair = frozenset((a, b))
+            if pair in wall_pairs or pair not in skip:
+                adj[a].add(b)
+                adj[b].add(a)
+        for nm in tnames:
+            pa = tuple(patch_at[nm])
+            for tc in tset_c:
+                if abs(tc[0] - pa[0]) + abs(tc[1] - pa[1]) == 1:
+                    _link(pa, tc)
+            for nm2 in tnames:
+                pb = tuple(patch_at[nm2])
+                if nm2 != nm and abs(pb[0] - pa[0]) + abs(pb[1] - pa[1]) == 1:
+                    _link(pa, pb)
+        seed = next(iter(tset_c), tuple(patch_at[tnames[0]]))
+        seen_c, frontier = {seed}, [seed]
+        while frontier:
+            n = frontier.pop()
+            for m in adj[n]:
+                if m not in seen_c:
+                    seen_c.add(m)
+                    frontier.append(m)
+        stranded = [nm for nm in tnames if tuple(patch_at[nm]) not in seen_c]
+        if stranded:
+            return skip, (
+                f"{stranded}: stitched to a neighbouring target but the "
+                f"island never reaches the corridor — every corridor seam "
+                f"of the island is perpendicular, user-unstitched, or "
+                f"absent (the joint product cannot flow onto the bus)")
+        return skip, None
+
+    placed_all = {nm: cell(*ab, d, seam) for nm, ab in patch_at.items()}
+    obstacle_fp0 = set().union(*[placed_all[nm] for nm in onames]) if onames else set()
+    base0 = dict(placed=placed_all, target=list(target), obstacles=onames, obstacle_fp=obstacle_fp0,
+                 corridor=set())
+    for tn in tnames:
+        bad = [on for on in onames if _cheb(patch_at[tn], patch_at[on]) <= keepout]
+        if bad:
+            return SubsetRoute(status="target_obstacle_conflict", root=tnames[0],
+                               message=(f"target {tn} is within keepout={keepout} of obstacle(s) "
+                                        f"{bad}: their boundary ancillas would collide."), **base0)
+    # route from a bus-basis anchor; ``bus`` forces a PLANNED basis, else the majority
+    # target basis (tie keeps the historical X anchor)
+    n_x = sum(1 for _, P in target if P == "X")
+    n_z = sum(1 for _, P in target if P == "Z")
+    bus_basis = bus if bus is not None else ("X" if n_x >= n_z else "Z")
+    root0 = next((nm for nm, P in target if P == bus_basis), tnames[0])
+    if wall_junction is not None and route is None:
+        raise ValueError("wall_junction needs an explicit route")
+
+    if route is not None:                  # explicit corridor: build on EXACTLY these cells
+        tree = {tuple(c) for c in route}
+        occupied_cells = set(patch_at.values())
+        bad = sorted(tree & occupied_cells)
+        if bad:
+            raise ValueError(f"explicit route cells {bad} overlap patch cells; the corridor "
+                             f"may only use empty coarse cells")
+        # stitching decided by the parallel-law policy AFTER the wall
+        # junctions are known (a walled seam counts as an attachment)
+        # ---- corridor walls: mid-bus junctions (experimental) and ARM walls
+        # (a stretched wall ON a target's attach seam — the production device
+        # for rows #4/#6 of the seam table; the closed form is the VERIFIED
+        # patch|patch spec, the corridor cell simply takes the far-patch role)
+        # post-path seam-table dispatch (same rule as the auto branch): a
+        # GIVEN route is still a routed path — when the caller assigned no
+        # walls, classify the attach seams and assign the minority-type
+        # targets' walls here
+        if probe:
+            # STEP-1 PROBE (stage B): geometric feasibility + table
+            # classification only - route legality, parallel-law stitching
+            # and the per-seam wall count, NO construction, NO oracle.
+            wall_pairs2, aw_n = frozenset(), 0
+            if seam and TABLE_WALL_DISPATCH and not arm_walls \
+                    and wall_junction is None:
+                dp = _table_wall_dispatch(patch_at, target, orient, tree,
+                                          conj_names, bus,
+                                          ns_pairs=ns_pairs)
+                if dp is not None and dp[0] is not None:
+                    aw_n = len(dp[0])
+                    wall_pairs2 = frozenset(
+                        frozenset((tuple(patch_at[nm]), tuple(wc)))
+                        for nm, wc in dp[0])
+            if arm_walls:
+                aw_n += len(arm_walls)
+                wall_pairs2 |= frozenset(
+                    frozenset((tuple(patch_at[nm]), tuple(wc)))
+                    for nm, wc in arm_walls)
+            if seam:
+                _, viol = _auto_stitch(tree, wall_pairs=wall_pairs2)
+                if viol:
+                    return SubsetRoute(status="no_verified_route", root=root0,
+                                       tried=0, attempted=tree,
+                                       message=f"probe: {viol}", **base0)
+            return SubsetRoute(status="ok", message="probe", tree=tree,
+                               attempted=tree, tried=0,
+                               n_walls=aw_n, **base0)
+
+        if seam and TABLE_WALL_DISPATCH and not arm_walls \
+                and wall_junction is None:
+            disp = _table_wall_dispatch(patch_at, target, orient, tree,
+                                        conj_names, bus,
+                                        ns_pairs=ns_pairs)
+            if disp is not None and disp[0] is not None:
+                # the dispatched wall IS this route's construction — its
+                # outcome is FINAL (user ruling 2026-07-31: a failed step-2
+                # construction is a hard error, never a fallback; the old
+                # swallow-and-fall-to-plain masked the real error as a
+                # misleading 'no parallel-law-legal seam')
+                aw2, conj_eff2, vertical2 = disp
+                return route_and_build(
+                    patches, target, pad=pad, per_z=per_z,
+                    max_std=max_std, cut_budget=cut_budget,
+                    max_cut=max_cut, keepout=keepout, seed=seed,
+                    max_trials=max_trials, route=sorted(tree),
+                    seam=True, bus=bus, conj_names=conj_eff2,
+                    flip_cells=(sorted(tree) if vertical2
+                                else flip_cells),
+                    no_stitch=no_stitch, arm_walls=aw2)
+
+        wall_descr = []          # (c1, c2, kind, patch_name)
+        if wall_junction is not None:
+            c1, c2 = tuple(wall_junction[0]), tuple(wall_junction[1])
+            if c1 not in tree or c2 not in tree:
+                raise ValueError(f"wall_junction {(c1, c2)} must be route cells")
+            wall_descr.append((c1, c2, 'mid', None))
+        for nm, wcell in (arm_walls or ()):
+            pc, wc2 = tuple(patch_at[nm]), tuple(wcell)
+            if wc2 not in tree:
+                raise ValueError(f"arm wall cell {wc2} is not a route cell")
+            if conj_names is None:
+                raise ValueError("arm_walls needs an explicit conj_names")
+            wall_descr.append((pc, wc2, 'arm', nm))
+        walls = []
+        retire_lobes = set()
+        extra_connect = set()
+        for c1, c2, kind, wnm in wall_descr:
+            da, db = c2[0] - c1[0], c2[1] - c1[1]
+            if abs(da) + abs(db) != 1:
+                raise ValueError(f"wall cells {(c1, c2)} are not adjacent")
+            if da == 0:
+                near_c = c1 if db > 0 else c2
+                axis = 'horizontal'
+            else:
+                near_c = c1 if da > 0 else c2
+                axis = 'vertical'
+            ox, oy = origin_of(*near_c, d, seam=seam)
+            a0, n0 = (ox, oy) if axis == 'horizontal' else (oy, ox)
+            near_ln = n0 + 2 * (d - 1)
+            lo, seam_ln, hi, far_ln = (near_ln + 1, near_ln + 2, near_ln + 3,
+                                       near_ln + 4)
+            P = ((lambda a, m: (a, m)) if axis == 'horizontal'
+                 else (lambda a, m: (m, a)))
+            bus_eff2 = None
+            if kind == 'arm':
+                bus_eff2 = bus
+                if bus_eff2 is None:
+                    n_x2 = sum(1 for _, PP in target if PP == "X")
+                    bus_eff2 = "X" if n_x2 >= len(target) - n_x2 else "Z"
+                if (dict(target)[wnm] == bus_eff2
+                        and wnm not in (conj_names or frozenset())):
+                    raise BentLayoutError(
+                        f"arm wall {wnm}|{c2}: the target is same-type with "
+                        f"the corridor (rule-table row 1 = plain merge, no "
+                        f"wall is due); register it in the recolour "
+                        f"convention (conj_names) to raise a wall")
+            end_row = None
+            if kind == 'arm':
+                # the stretched end lobe goes at the end where it is NOT next
+                # to one of the attaching patch's own weight-2 lobes (the
+                # boundary alternation rule); probe the patch's REGISTERED
+                # construction for a lobe foot on the facing corner data
+                s_w = next(s for s in patches if s.name == wnm)
+                _fo = {"X_horizontal": "X_vertical",
+                       "X_vertical": "X_horizontal"}
+                reg_o = (_fo[s_w.orientation] if wnm in conj_names
+                         else s_w.orientation)
+                nat = place_patch(SimpleNamespace(
+                    origin=s_w.origin, distance=d, orientation=reg_o))["checks"]
+                pside = near_ln if tuple(patch_at[wnm]) == near_c else far_ln
+                band_lines = {lo, hi}
+                ax_i = 1 if axis == 'horizontal' else 0
+                blocked = set()
+                for c in nat:
+                    if len(c["pauli"]) != 2:
+                        continue
+                    if tuple(c["syn"])[ax_i] in band_lines:
+                        continue        # the patch's own FACING lobes — they
+                                        # are retired by the wall, not blockers
+                    for q in c["pauli"]:
+                        if q == P(a0, pside):
+                            blocked.add('low')
+                        if q == P(a0 + 2 * (d - 1), pside):
+                            blocked.add('high')
+                if 'low' not in blocked:
+                    end_row = a0
+                elif 'high' not in blocked:
+                    end_row = a0 + 2 * (d - 1)
+                else:
+                    raise BentLayoutError(
+                        f"arm wall {wnm}|{c2}: both band ends sit next to the "
+                        f"patch's own weight-2 lobes — no legal end for the "
+                        f"stretched lobe")
+            walls.append(dict(axis=axis, ox=ox, oy=oy, a0=a0,
+                              near_ln=near_ln, lo=lo, seam_ln=seam_ln, hi=hi,
+                              far_ln=far_ln, P=P, kind=kind,
+                              end_row=end_row, bus_letter=bus_eff2))
+            # the true facing-lobe sites (a tile there would couple two
+            # band feet on the same facing line) are the wall's territory
+            for a in range(a0 + 1, a0 + 2 * (d - 1), 2):
+                retire_lobes.add(P(a, lo))
+                retire_lobes.add(P(a, hi))
+            extra_connect |= _seam_qubits({c1, c2}, d)
+        wall_pairs = frozenset(frozenset((tuple(c1), tuple(c2)))
+                               for c1, c2, _, _n in wall_descr)
+        if seam:
+            stitch_skip, viol = _auto_stitch(tree, wall_pairs=wall_pairs)
+            if viol:
+                raise BentLayoutError(viol)
+        else:
+            stitch_skip = ns_pairs
+        data, retype = path_to_corridor(tree, placed_all, target, d, seam=seam,
+                                        patch_at=patch_at, bus=bus,
+                                        conj_names=conj_names,
+                                        flip_cells=flip_cells,
+                                        skip_seam_pairs=([(c1, c2)
+                                                          for c1, c2, _, _n
+                                                          in wall_descr]
+                                                         + [tuple(p) for p
+                                                            in stitch_skip])
+                                        or None)
+        wall_fn = None
+        retyped_bus = frozenset()
+        if walls:
+            from .seam_rules import _wall_checks as _wc
+            from lightstim.qec_code.surface_code.rotated.litinski_layouts import ptype as _pt
+            _retype = frozenset(retype)
+
+            def wall_fn(phase, _wc=_wc, d=d, walls=walls, _retype=_retype):
+                out = []
+                for w in walls:
+                    P = w['P']
+                    if w['kind'] == 'arm':
+                        # the user's arrangement rules (K&F Fig 4 a/b):
+                        # each stretched weight-4's side pair carries the
+                        # OPPOSITE letter of the cell stabilizer right next
+                        # to it on that side; the stretched weight-2 end
+                        # lobe carries the flip of its neighbouring stretched
+                        # record, at the end away from the patch's own lobes
+                        nl, fl = w['near_ln'], w['far_ln']
+                        nf = 1 if P(w['a0'], nl) in _retype else 0
+                        ff = 1 if P(w['a0'], fl) in _retype else 0
+
+                        def _cl(pos_a, line_m, flip):
+                            c = P(pos_a, line_m)
+                            L = _pt(c[0], c[1], phase)
+                            return _FLIP[L] if flip else L
+
+                        recs = []
+                        for k in range(d - 1):
+                            y = w['a0'] + 2 * k
+                            Ll = _FLIP[_cl(y + 1, nl - 1, nf)]
+                            Lr = _FLIP[_cl(y + 1, fl + 1, ff)]
+                            feet = {P(y, nl): Ll, P(y + 2, nl): Ll,
+                                    P(y, fl): Lr, P(y + 2, fl): Lr}
+                            A, B = ((P(y + 1, w['hi']), P(y + 1, w['lo']))
+                                    if Lr == 'Z'
+                                    else (P(y + 1, w['lo']), P(y + 1, w['hi'])))
+                            recs.append(
+                                {'syn': B, 'type': 'M', 'pauli': feet,
+                                 'corners': sorted(feet),
+                                 'kf': {'flag': A,
+                                        'shared': P(y + 1, w['seam_ln']),
+                                        'orient': ('+' if A == P(y + 1, w['hi'])
+                                                   else '-')}})
+                        e = w['end_row']
+                        adj = recs[0] if e == w['a0'] else recs[-1]
+                        Ll_e = _FLIP[adj['pauli'][P(e, nl)]]
+                        Lr_e = _FLIP[adj['pauli'][P(e, fl)]]
+                        erow = e - 1 if e == w['a0'] else e + 1
+                        feet = {P(e, nl): Ll_e, P(e, fl): Lr_e}
+                        A, B = ((P(erow, w['hi']), P(erow, w['lo']))
+                                if Lr_e == 'Z'
+                                else (P(erow, w['lo']), P(erow, w['hi'])))
+                        recs.append(
+                            {'syn': B, 'type': 'M', 'pauli': feet,
+                             'corners': sorted(feet),
+                             'kf': {'flag': A, 'shared': P(erow, w['seam_ln']),
+                                    'orient': ('+' if A == P(erow, w['hi'])
+                                               else '-')}})
+                        out.extend(recs)
+                        continue
+                    rep_near = P(w['a0'], w['near_ln'])
+                    rep_far = P(w['a0'], w['far_ln'])
+                    phi_n = phase ^ (1 if rep_near in _retype else 0)
+                    phi_f = phase ^ (1 if rep_far in _retype else 0)
+                    recs = _wc(d, phi_n, phi_f, w['ox'], w['oy'], w['axis'])
+                    part = [{'syn': tuple(B), 'type': 'M', 'pauli': dict(p),
+                             'corners': sorted(p), 'kf': dict(kf)}
+                            for B, p, kf in recs]
+                    if True:
+                        # mid-bus junction (experimental): both band ends are
+                        # free edges — mirror the closed form's end lobe
+                        ends = {w['a0'] - 1, w['a0'] - 1 + 2 * d}
+                        ax_i = 0 if w['axis'] == 'horizontal' else 1
+                        used = next(a for a in ends
+                                    if any(r['syn'][ax_i] == a for r in part))
+                        m_e = next(a for a in ends if a != used)
+                        sgn = 1 if m_e == w['a0'] - 1 else -1
+                        adj = next(r for r in part
+                                   if abs(r['syn'][ax_i] - (m_e + 2 * sgn)) <= 1)
+                        letter = _FLIP[next(iter(set(adj['pauli'].values())))]
+                        feet = {P(m_e + sgn, w['near_ln']): letter,
+                                P(m_e + sgn, w['far_ln']): letter}
+                        A, B = ((P(m_e, w['hi']), P(m_e, w['lo']))
+                                if letter == 'Z'
+                                else (P(m_e, w['lo']), P(m_e, w['hi'])))
+                        part.append({'syn': B, 'type': 'M', 'pauli': feet,
+                                     'corners': sorted(feet),
+                                     'kf': {'flag': A,
+                                            'shared': P(m_e - sgn, w['seam_ln']),
+                                            'orient': '+' if A == P(m_e, w['hi'])
+                                            else '-'}})
+                    out.extend(part)
+                return out
+        if flip_cells:
+            fq = set()
+            for c in flip_cells:
+                fq |= cell(*tuple(c), d, seam)
+            if seam:
+                fents = {tuple(c) for c in flip_cells} | \
+                    {tuple(patch_at[nm]) for nm in tnames
+                     if conj_names and nm in conj_names}
+                fq |= _seam_qubits(fents, d)
+            patchq = set().union(*[placed_all[nm] for nm in tnames])
+            retyped_bus = frozenset((fq & set(data)) - patchq)
+        # idle neighbours' USED ancilla sites — computed HERE, at the actual
+        # construction, so the step-1 probe never touches place_patch (iron
+        # rule: path finding is construction-free; this was also pure waste
+        # on every probe — the probe branch cannot reach this point)
+        forbidden = _obstacle_ancillas(patches, tnames)
+        layout = _assemble_region(placed_all, target, orient, data, retype, d, seed,
+                                  max_trials, max_cut=max_cut, forbidden=forbidden,
+                                  native_lock=True, bus=bus, conj_names=conj_names,
+                                  extra_forced_fn=wall_fn,
+                                  extra_connect=frozenset(extra_connect),
+                                  retyped_bus=retyped_bus,
+                                  retire_lobes=frozenset(retire_lobes))
+        if layout is not None and all(layout.verify().values()):
+            cutq = tuple(sorted(set(data) - set(layout.data)))
+            how = "corner-cut" if cutq else "standard"
+            msg = f"verified subset joint ({how}, rule-based, EXPLICIT route)"
+            return SubsetRoute(status="ok", message=msg,
+                               layout=layout, root=root0, tree=tree, attempted=tree,
+                               data=sorted(layout.data), tried=1, how=how, cut=cutq,
+                               n_walls=len(wall_descr),
+                               **base0)
+        return SubsetRoute(status="no_verified_route", root=root0, tried=1, attempted=tree,
+                           message=("the EXPLICIT route does not pass the rule-based "
+                                    "construction; the physics layer cannot host this "
+                                    "corridor"), **base0)
+
+
+class RotatedRoutedMultiPatchCoupler(_LCP):
+    """Routed multi-patch coupler for ROTATED patches (seam-column design)."""
+
+    EXPECTED_PATCH_COUNT = None
+    _FLIP_O = {'X_horizontal': 'X_vertical', 'X_vertical': 'X_horizontal'}
+
+    @staticmethod
+    def _key(ch):
+        return (tuple(ch['syn']),
+                frozenset((tuple(q), P) for q, P in ch['pauli'].items()))
+
+    def _build_coupler_geometry(self, coupler_patch, patches, *, specs, target,
+                                subset_route=None, seam=True, route=None,
+                                minority_names=frozenset()):
+        from types import SimpleNamespace
+        r = subset_route
+        if r is None:
+            r = route_and_build(specs, target, seam=seam, route=route)
+        if r.status != 'ok':
+            raise ValueError(f'route_and_build failed: {r.status} — {r.message}')
+        lay = r.layout
+        tnames = {nm for nm, _ in target}
+        coupler_patch.conflicting_stabilizer_coords = set()
+
+        merged_keys = {self._key(ch) for ch in lay.checks}
+        kept, native_syns, patch_cells = set(), set(), set()
+        for s in specs:
+            if s.name not in tnames:
+                continue
+            patch_cells |= {(s.origin[0] + 2 * i, s.origin[1] + 2 * j)
+                            for i in range(s.distance) for j in range(s.distance)}
+            # the construction the patch REGISTERED in the system; minority
+            # patches register the conjugate-convention construction
+            # (transposed geometry, records typeswapped)
+            reg_orient = self._FLIP_O[s.orientation] if s.name in minority_names \
+                else s.orientation
+            reg = place_patch(SimpleNamespace(origin=s.origin, distance=s.distance,
+                                              orientation=reg_orient))['checks']
+            if s.name in minority_names:
+                reg = [dict(ch, type=_FLIP[ch['type']],
+                            pauli={q: _FLIP[P] for q, P in ch['pauli'].items()})
+                       for ch in reg]
+            for ch in reg:
+                native_syns.add(tuple(ch['syn']))
+                key = self._key(ch)
+                if key not in merged_keys:
+                    coupler_patch.conflicting_stabilizer_coords.add(tuple(ch['syn']))
+                else:
+                    kept.add(key)
+
+        # new data qubits: corridor + seam columns
+        for q in sorted(set(map(tuple, lay.data)) - patch_cells):
+            coupler_patch.add_qubit(q[0], q[1], role='data')
+        # coupler-owned checks + any genuinely new ancilla positions
+        added = set()
+        for ch in lay.checks:
+            if self._key(ch) in kept:
+                continue
+            syn = tuple(ch['syn'])
+            typ = ch.get('type') or next(iter(set(ch['pauli'].values())))
+            kf = ch.get('kf')
+            if kf is not None:
+                # stretched (kf) record: B reads out in X, flag A and the
+                # shared relay S in Z (same apparatus convention as
+                # RotatedSeamWallCoupler)
+                if syn not in native_syns and syn not in added:
+                    coupler_patch.add_qubit(syn[0], syn[1], role='syndrome_x')
+                    added.add(syn)
+                for coord, role in ((tuple(kf['flag']), 'syndrome_z'),
+                                    (tuple(kf['shared']), 'syndrome_z')):
+                    if coord not in native_syns and coord not in added:
+                        coupler_patch.add_qubit(coord[0], coord[1], role=role)
+                        added.add(coord)
+                coupler_patch.stabilizers.append({
+                    'pauli': {tuple(q): P for q, P in ch['pauli'].items()},
+                    'type': 'MIXED',
+                    'syn_coord': syn,
+                    'kf': {'flag': tuple(kf['flag']),
+                           'shared': tuple(kf['shared']),
+                           'orient': kf['orient']},
+                })
+                continue
+            if syn not in native_syns and syn not in added:
+                coupler_patch.add_qubit(syn[0], syn[1],
+                                        role=('syndrome_z' if typ == 'Z'
+                                              else 'syndrome_x'))
+                added.add(syn)
+            coupler_patch.stabilizers.append({
+                'pauli': {tuple(q): P for q, P in ch['pauli'].items()},
+                'type': typ if typ in ('X', 'Z') else 'MIXED',
+                'syn_coord': syn,
+            })
+        coupler_patch.routed_layout = lay          # introspection for the protocol layer
+        coupler_patch.subset_route = r

--- a/lightstim/protocols/ppm/coupler.py
+++ b/lightstim/protocols/ppm/coupler.py
@@ -1241,6 +1241,8 @@ class SubsetRoute:
     cut: tuple = ()                                   # convex-corner qubits removed (corner-cut only)
     n_walls: int = 0                                  # stretched (kf) seam walls in the layout - band
                                                       # apparatus is real cost, chargeable like cells
+    certificate: dict = None                          # MultiPatchLayout.verify() items for the
+                                                      # accepted layout (None on failures/probes)
 
     @property
     def ok(self):
@@ -1935,14 +1937,15 @@ def route_and_build(patches, target, pad=1, per_z=6, max_std=48, cut_budget=4, m
                                   extra_connect=frozenset(extra_connect),
                                   retyped_bus=retyped_bus,
                                   retire_lobes=frozenset(retire_lobes))
-        if layout is not None and all(layout.verify().values()):
+        cert = layout.verify() if layout is not None else None
+        if cert is not None and all(cert.values()):
             cutq = tuple(sorted(set(data) - set(layout.data)))
             how = "corner-cut" if cutq else "standard"
             msg = f"verified subset joint ({how}, rule-based, EXPLICIT route)"
             return SubsetRoute(status="ok", message=msg,
                                layout=layout, root=root0, tree=tree, attempted=tree,
                                data=sorted(layout.data), tried=1, how=how, cut=cutq,
-                               n_walls=len(wall_descr),
+                               n_walls=len(wall_descr), certificate=cert,
                                **base0)
         return SubsetRoute(status="no_verified_route", root=root0, tried=1, attempted=tree,
                            message=("the EXPLICIT route does not pass the rule-based "

--- a/lightstim/protocols/ppm/lowering.py
+++ b/lightstim/protocols/ppm/lowering.py
@@ -1,0 +1,294 @@
+# protocols/ppm/lowering.py
+"""Pure PPM lowering kernel.
+
+``lower_ppm()`` turns ONE Pauli-product-measurement request into a
+:class:`LoweringPlan` — a declarative description of the construction —
+without touching the system, builder, or tracker.  ``apply_plan()``
+registers the plan's coupler with a :class:`~lightstim.ir.qec_system.QECSystem`
+in a separate step.  The experiment driver
+(:class:`~.sequential.SequentialPPMExperiment`) is one consumer of this
+kernel; a logical-level compiler is the intended other.
+
+Scope and honesty notes:
+
+- The ancilla route is EXPLICIT and required (``()`` for cell-adjacent
+  targets).  There is no auto-router; nothing here pretends otherwise.
+- Pauli letters: X and Z only.  A ``Y`` target raises
+  :class:`UnsupportedPauliError`: measuring a Y factor on a rotated
+  surface-code patch needs a twist defect or a Y-wall construction that
+  this stack does not implement (it cannot be silently rewritten as X/Z —
+  that would be a different quantum instrument).
+- Cell-adjacent two-patch requests are classified by the four-row seam
+  rule table against the LIVE system (the classification is a live probe,
+  so ``system`` is required for them).
+- ``LoweringPlan.certificate`` carries the algebraic acceptance oracle of
+  the accepted layout (commutation, the joint IS measured, no single
+  logical and no proper subset product is exposed — the "true weight-w
+  measurement, not w-1 pairwise parities" guarantee — expected rank
+  change, no weight-1 logical, plus circuit-level checks when the layout
+  hosts no stretched check).  Wall plans currently carry ``None``: the
+  wall construction is validated by its own rule-table laws and
+  end-to-end distance tests, not by this oracle — a known gap, tracked in
+  the PR's capability table.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, List, Mapping, Optional, Tuple
+
+from .spec import PatchSpec, cell_index
+from .coupler import (route_and_build, RotatedRoutedMultiPatchCoupler,
+                      SubsetRoute)
+from .seam_rules import (RotatedSeamWallCoupler, SeamRuleError, classify_seam,
+                         patch_view, wall_spec)
+
+__all__ = [
+    "PPMRequest", "LoweringPlan", "LoweringCertificate",
+    "UnsupportedPauliError", "lower_ppm", "apply_plan",
+    "is_cell_adjacent_pair",
+]
+
+_CONJ = {'X': 'Z', 'Z': 'X'}
+
+
+class UnsupportedPauliError(ValueError):
+    """A requested Pauli letter has no implemented lowering construction."""
+
+
+@dataclass(frozen=True)
+class PPMRequest:
+    """One joint Pauli-product measurement, declaratively.
+
+    Args:
+        targets: ``((patch_name, 'X'|'Z'), ...)`` — one entry per target
+            patch (each patch appears once; the single-seam attach law).
+        route: explicit corridor cells on the coarse grid; ``()`` for
+            cell-adjacent targets.  Required — there is no auto-router.
+        construction: ``'auto'`` (rule table decides) | ``'wall'`` |
+            ``'merge'`` — adjacent-pair override only.
+        schedule: per-request override of the merged-round schedule
+            (``'bent'`` | ``'diagonal'``), else the policy decides.
+    """
+    targets: Tuple[Tuple[str, str], ...]
+    route: Tuple[Tuple[int, int], ...]
+    construction: str = 'auto'
+    schedule: Optional[str] = None
+
+    def __post_init__(self):
+        if self.route is None:
+            raise ValueError(
+                "PPMRequest: route is required — pass the explicit corridor "
+                "cells, or () for cell-adjacent targets (no auto-router "
+                "exists in this stack)")
+        for name, letter in self.targets:
+            if letter == 'Y':
+                raise UnsupportedPauliError(
+                    f"target ({name!r}, 'Y'): measuring a Y factor needs a "
+                    f"twist defect or Y-wall construction that this stack "
+                    f"does not implement; it cannot be silently treated as "
+                    f"X/Z (that is a different quantum instrument). "
+                    f"Supported letters: X, Z.")
+            if letter not in ('X', 'Z'):
+                raise ValueError(
+                    f"target ({name!r}, {letter!r}): Pauli letter must be "
+                    f"'X' or 'Z'")
+
+    @property
+    def bus(self) -> str:
+        """Majority letter — the corridor's stabilizer type."""
+        n_x = sum(1 for _, P in self.targets if P == 'X')
+        return 'X' if n_x >= len(self.targets) - n_x else 'Z'
+
+
+@dataclass(frozen=True)
+class LoweringCertificate:
+    """Named algebraic/circuit acceptance items of the accepted layout."""
+    items: Mapping[str, bool]
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.items) and all(self.items.values())
+
+    @property
+    def measures_exactly_the_product(self) -> bool:
+        """The joint is measured, and neither any single logical nor any
+        proper subset product leaks — a true weight-w instrument."""
+        return (self.items.get('joint', False)
+                and self.items.get('no_single', False)
+                and self.items.get('no_subjoint', False))
+
+
+@dataclass
+class LoweringPlan:
+    """Declarative result of lowering one PPM request.
+
+    ``apply_plan(system, plan, name)`` performs the registration; the
+    driver (or compiler backend) then activates, runs the merged rounds
+    under ``schedule``, deactivates, and reads the corridor out in
+    ``corridor_readout_basis``.
+    """
+    request: PPMRequest
+    kind: str                                  # 'corridor' | 'wall'
+    schedule: str                              # 'bent' | 'diagonal'
+    specs: Tuple[PatchSpec, ...]               # live-orientation-stamped
+    conj_names: FrozenSet[str]
+    # corridor plans:
+    route_result: Optional[SubsetRoute] = None
+    # wall plans:
+    wall: Optional[dict] = None
+    # adjacent-pair rule-table row (live probe), when applicable:
+    rule: Optional[object] = None
+    certificate: Optional[LoweringCertificate] = None
+
+    @property
+    def bus(self) -> str:
+        return self.request.bus
+
+    @property
+    def corridor_init_basis(self) -> str:
+        """New corridor data qubits initialize (and read out) in the
+        conjugate of the bus letter."""
+        return _CONJ[self.bus]
+
+    corridor_readout_basis = corridor_init_basis
+
+    @property
+    def merged_checks(self) -> Tuple[dict, ...]:
+        """The merged-window check set this plan installs (corridor plans;
+        the wall coupler materializes its apparatus at registration)."""
+        if self.route_result is not None and self.route_result.layout is not None:
+            return tuple(self.route_result.layout.checks)
+        return ()
+
+    @property
+    def has_stretched_checks(self) -> bool:
+        return any(c.get('kf') for c in self.merged_checks)
+
+
+def _pick_schedule(request: PPMRequest, policy: str, *,
+                   is_wall: bool, collinear: bool) -> str:
+    """Merged-round schedule: a wall or any corridor bend forces the whole
+    merged block onto the diagonal schedule; straight corridors stay bent."""
+    if is_wall:
+        if request.schedule == 'bent' or policy == 'bent':
+            raise SeamRuleError(
+                "a wall step cannot run the bent schedule: the bent chunk "
+                "cannot express stretched (kf) checks — use 'diagonal'")
+        return 'diagonal'
+    if request.schedule is not None:
+        return request.schedule
+    if policy in ('bent', 'diagonal'):
+        return policy
+    return 'bent' if collinear else 'diagonal'
+
+
+def is_cell_adjacent_pair(specs_by_name, request) -> bool:
+    """Exactly two targets on edge-adjacent coarse cells — direct-seam
+    territory of the rule table; everything else is a routed corridor."""
+    names = [nm for nm, _ in request.targets]
+    if len(names) != 2:
+        return False
+    cells = [cell_index(specs_by_name[nm].origin,
+                        specs_by_name[nm].distance, seam=True)
+             for nm in names]
+    (a1, b1), (a2, b2) = cells
+    return abs(a1 - a2) + abs(b1 - b2) == 1
+
+
+def lower_ppm(specs: List[PatchSpec], request: PPMRequest, *,
+              system=None, conj_names: FrozenSet[str] = frozenset(),
+              schedule_policy: str = 'auto') -> LoweringPlan:
+    """Lower one PPM request to a :class:`LoweringPlan`.  Pure: no
+    system/builder/tracker mutation.
+
+    Args:
+        specs: every patch, stamped with its LIVE orientation.
+        request: the PPM request (explicit route, X/Z letters).
+        system: the live :class:`QECSystem` — required for cell-adjacent
+            pairs, whose rule-table classification probes the REAL
+            registered patches (not a reconstruction).
+        conj_names: the colour-swapped subset of the targets.
+        schedule_policy: experiment-wide policy ('auto'|'bent'|'diagonal').
+    """
+    by_name = {s.name: s for s in specs}
+    unknown = [nm for nm, _ in request.targets if nm not in by_name]
+    if unknown:
+        raise ValueError(f"lower_ppm: unknown target patch(es) {unknown}")
+
+    if is_cell_adjacent_pair(by_name, request):
+        if system is None:
+            raise ValueError(
+                "lower_ppm: a cell-adjacent pair is classified by the seam "
+                "rule table against the LIVE system (live probe) — pass "
+                "system=")
+        names = [nm for nm, _ in request.targets]
+        views = {nm: patch_view(system, nm) for nm in names}
+        tgt = dict(request.targets)
+        rule = classify_seam(views[names[0]], tgt[names[0]],
+                             views[names[1]], tgt[names[1]])
+        cons = request.construction if request.construction != 'auto' \
+            else rule.construction
+        if cons == 'wall':
+            spec = wall_spec(views[names[0]], views[names[1]], tgt)
+            return LoweringPlan(
+                request=request, kind='wall',
+                schedule=_pick_schedule(request, schedule_policy,
+                                        is_wall=True, collinear=True),
+                specs=tuple(specs), conj_names=frozenset(conj_names),
+                wall=spec, rule=rule)
+        plan = _lower_corridor(specs, request, conj_names, by_name,
+                               schedule_policy, force_collinear=True)
+        return LoweringPlan(
+            request=request, kind=plan.kind, schedule=plan.schedule,
+            specs=plan.specs, conj_names=plan.conj_names,
+            route_result=plan.route_result, certificate=plan.certificate,
+            rule=rule)
+
+    return _lower_corridor(specs, request, conj_names, by_name,
+                           schedule_policy, force_collinear=False)
+
+
+def _lower_corridor(specs, request, conj_names, by_name, schedule_policy,
+                    *, force_collinear):
+    r = route_and_build(specs, list(request.targets), seam=True,
+                        route=list(request.route),
+                        conj_names=frozenset(conj_names))
+    if r.status != 'ok':
+        raise ValueError(
+            f"lower_ppm: route_and_build failed: {r.status} — {r.message}")
+    has_kf = any(ch.get('kf')
+                 for ch in (r.layout.checks if r.layout is not None else ()))
+    if force_collinear:
+        # adjacent-pair merge rows: zero-cell corridor, collinear by
+        # construction; the emission layer re-checks kf on the layout.
+        schedule = _pick_schedule(request, schedule_policy,
+                                  is_wall=False, collinear=True)
+    else:
+        names = [nm for nm, _ in request.targets]
+        cells = [cell_index(by_name[nm].origin, by_name[nm].distance,
+                            seam=True) for nm in names] \
+            + [tuple(c) for c in (r.tree or ())]
+        collinear = (len({a for a, _ in cells}) == 1
+                     or len({b for _, b in cells}) == 1)
+        schedule = _pick_schedule(request, schedule_policy,
+                                  is_wall=has_kf, collinear=collinear)
+    cert = (LoweringCertificate(items=dict(r.certificate))
+            if r.certificate is not None else None)
+    return LoweringPlan(
+        request=request, kind='corridor', schedule=schedule,
+        specs=tuple(specs), conj_names=frozenset(conj_names),
+        route_result=r, certificate=cert)
+
+
+def apply_plan(system, plan: LoweringPlan, name: str) -> None:
+    """Register the plan's coupler with the system (the ONLY mutation of
+    this module's API; activation/rounds/split stay with the caller)."""
+    target_names = [nm for nm, _ in plan.request.targets]
+    if plan.kind == 'wall':
+        system.register_coupler(
+            RotatedSeamWallCoupler(), patch_names=target_names, name=name,
+            spec=plan.wall, occupied=frozenset(system.index_map))
+        return
+    system.register_coupler(
+        RotatedRoutedMultiPatchCoupler(),
+        patch_names=target_names, name=name, specs=list(plan.specs),
+        target=list(plan.request.targets), subset_route=plan.route_result,
+        seam=True, minority_names=plan.conj_names)

--- a/lightstim/protocols/ppm/lowering.py
+++ b/lightstim/protocols/ppm/lowering.py
@@ -34,6 +34,11 @@ Scope and honesty notes:
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Mapping, Optional, Tuple
 
+import numpy as np
+
+from lightstim.ir.tracker import UNMEASURED_STAB_RECORD
+from lightstim.utils.linear_algebra import solve_linear_decomposition
+
 from .spec import PatchSpec, cell_index
 from .coupler import (route_and_build, RotatedRoutedMultiPatchCoupler,
                       SubsetRoute)
@@ -41,9 +46,9 @@ from .seam_rules import (RotatedSeamWallCoupler, SeamRuleError, classify_seam,
                          patch_view, wall_spec)
 
 __all__ = [
-    "PPMRequest", "LoweringPlan", "LoweringCertificate",
+    "PPMRequest", "LoweringPlan", "LoweringCertificate", "PPMOutcome",
     "UnsupportedPauliError", "lower_ppm", "apply_plan",
-    "is_cell_adjacent_pair",
+    "is_cell_adjacent_pair", "joint_pauli_vector", "record_parity",
 ]
 
 _CONJ = {'X': 'Z', 'Z': 'X'}
@@ -276,6 +281,108 @@ def _lower_corridor(specs, request, conj_names, by_name, schedule_policy,
         request=request, kind='corridor', schedule=schedule,
         specs=tuple(specs), conj_names=frozenset(conj_names),
         route_result=r, certificate=cert)
+
+
+@dataclass(frozen=True)
+class PPMOutcome:
+    """PROTOCOL OUTPUT of one applied PPM: the physical measurement-record
+    parity of the requested joint product (review §3).
+
+    ``records_*`` are sorted absolute measurement indices whose XOR equals
+    the joint's pinned parity at capture time, or ``None`` when the joint
+    is a free coin there — e.g. before the merge of a request that
+    anti-commutes with the tracked state.  A ``None`` is a legitimately
+    random outcome, NOT an error.
+
+    This is deliberately distinct from an EVALUATION observable: whether
+    and how a protocol output enters a deterministic, decodable quantity
+    (an OBSERVABLE_INCLUDE, a closure detector, a feed-forward dependency)
+    is the caller's evaluation choice, made from input states, these
+    record parities, and the final measurement bases.
+    """
+    step: int
+    targets: Tuple[Tuple[str, str], ...]
+    records_pre_merge: Optional[Tuple[int, ...]]
+    records_post_split: Optional[Tuple[int, ...]]
+
+
+def joint_pauli_vector(system, targets) -> np.ndarray:
+    """[X|Z] GF(2) vector of the joint logical named by ``targets``,
+    assembled from the system's registered logical representatives."""
+    n = system.num_qubits
+    v = np.zeros(2 * n, dtype=np.uint8)
+    for nm, letter in targets:
+        for rec in (x for x in system.logical_ops
+                    if x.get('patch_name') == nm and x.get('type') == letter):
+            for q, pp in rec['pauli'].items():
+                if pp in ('X', 'Y'):
+                    v[q] ^= 1
+                if pp in ('Z', 'Y'):
+                    v[n + q] ^= 1
+    return v
+
+
+def record_parity(tracker, vec) -> Optional[List[int]]:
+    """Read-only: if ``vec`` lies in the span of the tracker's
+    record-carrying rows, return the sorted XOR of the pinning rows'
+    banked records (the operator's deterministic reconstruction); else
+    ``None`` — a free outcome, not a parity check.
+
+    Rows carrying the UNMEASURED sentinel are excluded from the basis:
+    a closure through one XORs in an unbanked, per-shot-random gauge
+    (measured 2026-08-05 on a parallel batch window), so excluding them
+    only removes WRONG reconstructions.
+    """
+    stab, logs = tracker.stabilizers, tracker.logicals
+    # deferred allocation can grow the qubit count between refreshes;
+    # symplectic rows are [X | Z] halves, so widen by re-placing each half.
+    wide = max(stab.matrix.shape[1],
+               logs.matrix.shape[1] if logs.matrix.shape[0] > 0 else 0,
+               vec.shape[0]) // 2
+
+    def _widen(M):
+        n0 = M.shape[1] // 2
+        if n0 == wide:
+            return M
+        P = np.zeros((M.shape[0], 2 * wide), dtype=M.dtype)
+        P[:, :n0] = M[:, :n0]
+        P[:, wide:wide + n0] = M[:, n0:]
+        return P
+
+    if vec.shape[0] != 2 * wide:
+        v = np.zeros(2 * wide, dtype=vec.dtype)
+        n0 = vec.shape[0] // 2
+        v[:n0] = vec[:n0]
+        v[wide:wide + n0] = vec[n0:]
+        vec = v
+    if logs.matrix.shape[0] > 0:
+        M = np.vstack([_widen(stab.matrix), _widen(logs.matrix)])
+        recs_of = stab.records + logs.records
+    else:
+        M = _widen(stab.matrix)
+        recs_of = list(stab.records)
+    n_stab = stab.matrix.shape[0]
+    rows_ok = [k for k in range(M.shape[0])
+               if k >= n_stab
+               or (recs_of[k] and UNMEASURED_STAB_RECORD not in recs_of[k])]
+    if len(rows_ok) != M.shape[0]:
+        M = M[rows_ok]
+        recs_of = [recs_of[k] for k in rows_ok]
+    if M.shape[0] == 0:
+        return None
+    out = solve_linear_decomposition(basis=M, targets=vec.reshape(1, -1),
+                                     reduce_weight=True)
+    coeffs = out[0]
+    if coeffs is None:
+        return None
+    row = np.asarray(coeffs[0], dtype=np.uint8)
+    if not np.array_equal((row.astype(int) @ M.astype(int)) % 2,
+                          vec.astype(int)):
+        return None
+    recs = set()
+    for j in np.nonzero(row)[0]:
+        recs ^= set(recs_of[j])
+    return sorted(recs)
 
 
 def apply_plan(system, plan: LoweringPlan, name: str) -> None:

--- a/lightstim/protocols/ppm/seam_rules.py
+++ b/lightstim/protocols/ppm/seam_rules.py
@@ -1,0 +1,447 @@
+# protocols/ppm/seam_rules.py
+#
+# Copied from https://github.com/John-YuehanZhang/CircLS @ 8802a5b — the
+# author's own repository (John Yuehan Zhang).  Source: circls/joint_merge.py
+# (near-verbatim; only BentLayoutError is rewired to the local spec module).
+#
+# Includes the Handbook Sec. 10.4 alternating-spacing end-cap rule in
+# ``wall_spec`` (the free-slot selection that supersedes the far-side-colour
+# proxy on transposed row-3 seams).
+
+"""The four-row merge rule table as production code (single-seam Phase 1).
+
+For a joint Pauli-product measurement between two cell-adjacent patches, the
+merge construction is chosen by (measurement kind x patch types):
+
+====  ==========  =========  =============================================
+row   measured    types      seam construction
+====  ==========  =========  =============================================
+1     same Pauli  same       plain merge (checkerboard continues; the seam
+                             line is DATA) — no stretched stabilizer
+2     same Pauli  different  stretched-stabilizer wall, uniform dominoes
+                             (FIG1 family)
+3     mixed       different  stretched-stabilizer wall, mixed dominoes
+                             (FIG6 family)
+4     mixed       same       recoloured single-cell mixed checks — no
+                             stretched stabilizer (corridor mechanism)
+====  ==========  =========  =============================================
+
+VOCABULARY (the author's, non-negotiable): **textbook/conjugate = the weight-2
+lobe POSITIONS** of a patch — colours never enter the type.  The red/blue
+**colours** (checkerboard phase) are a separate fact; ``rotate_90`` swaps
+colours and keeps positions, ``litinski`` moves positions and keeps colours.
+
+THE UNIFIED WALL LAW (machine-verified byte-identical to all four legacy
+hand specs at d = 3 and 5, both axes): the wall's dominoes, orient
+alternation, relay side and end lobe are ONE closed form of (seam axis, the
+two patches' checkerboard phases, d, origin) — see ``_wall_checks``.  A
+domino's feet on each side carry that side's outward virtual-plaquette
+colour; the flag aux A sits on the Z-foot side; ``orient = '+'`` iff A is on
+the hi side; the relay side and end-lobe end follow the far side's colour at
+the first interior column.
+
+HARD INVARIANTS: kf metadata and coord-keyed paulis are ABSOLUTE coordinates
+(``shift_coords`` / ``_translate_record`` do not translate them), so a
+``WallSpec`` is generated at the live coordinates and the coupler must be
+registered at offset (0, 0).  Multi-patch rule: the type class with FEWER
+patches carries the stretched stabilizers.
+"""
+from dataclasses import dataclass
+
+from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode
+from lightstim.qec_code.surface_code.rotated.litinski_layouts import ptype
+from .spec import BentLayoutError
+
+_FLIP = {'X': 'Z', 'Z': 'X'}
+_FLIP_O = {'X_horizontal': 'X_vertical', 'X_vertical': 'X_horizontal'}
+
+TEXTBOOK, CONJUGATE = 'textbook', 'conjugate'
+
+
+class SeamRuleError(BentLayoutError):
+    """A seam violates the rule table (wrong orientation, unreadable patch,
+    or a live geometry that contradicts the type model)."""
+
+
+# -----------------------------------------------------------------------------
+# SECTION: live probes — positions (type), colours (phase), orientation
+# -----------------------------------------------------------------------------
+
+def lobe_positions(system, name):
+    """Absolute syn coords of the patch's ACTIVE weight-2 checks (its type
+    signature; sample between merges — paused facing lobes are invisible)."""
+    return frozenset(
+        tuple(int(round(v)) for v in system.stabilizers[u]['syn_coord'])
+        for u in system.active_stabilizer_indices
+        for s in [system.stabilizers[u]]
+        if s.get('patch_name') == name and len(s['data_indices']) == 2)
+
+
+def _reference_lobes(d):
+    """Local weight-2 positions of the two types (origin-(1,1) frame):
+    textbook = a plain RotatedSurfaceCode, conjugate = its transpose."""
+    code = RotatedSurfaceCode(distance=d)
+    textbook = frozenset(
+        tuple(int(round(v)) for v in s['syn_coord'])
+        for s in code.stabilizers if len(s['pauli']) == 2)
+    return textbook, frozenset((y, x) for x, y in textbook)
+
+
+def patch_type(lobes, origin, d):
+    """TEXTBOOK or CONJUGATE from absolute weight-2 positions (colours are
+    irrelevant by definition)."""
+    ox, oy = origin
+    local = frozenset((x - ox + 1, y - oy + 1) for x, y in lobes)
+    textbook, conjugate = _reference_lobes(d)
+    if local == textbook:
+        return TEXTBOOK
+    if local == conjugate:
+        return CONJUGATE
+    raise SeamRuleError(
+        f"patch at origin {origin} has weight-2 positions {sorted(local)} "
+        f"matching neither the textbook nor the conjugate layout for d={d}")
+
+
+def detect_layout(system, name, d, origin):
+    """(lr_type, tb_type, phase) of the live patch — boundary colours and the
+    checkerboard phase, read off its records."""
+    ox, oy = origin
+    lr = tb = None
+    bulk_type = None
+    for uid in sorted(system.active_stabilizer_indices):
+        st = system.stabilizers[uid]
+        if st.get('patch_name') != name:
+            continue
+        sx, sy = (int(round(st['syn_coord'][0])),
+                  int(round(st['syn_coord'][1])))
+        if len(st['data_indices']) == 2:
+            if sx < ox or sx > ox + 2 * d - 2:
+                lr = st['type']
+            elif sy < oy or sy > oy + 2 * d - 2:
+                tb = st['type']
+        elif len(st['data_indices']) == 4 and bulk_type is None:
+            bulk_type = (sx, sy, st['type'])
+    if not (lr and tb and bulk_type):
+        raise SeamRuleError(f"could not read the live layout of {name!r}")
+    sx, sy, t = bulk_type
+    phase = 0 if t == ptype(sx, sy, 0) else 1
+    return lr, tb, phase
+
+
+@dataclass(frozen=True)
+class PatchView:
+    """Everything the rule table needs to know about one live patch.
+    ``type`` is POSITIONS (textbook/conjugate); ``phase``/``lr``/``tb`` are
+    COLOURS; ``orientation`` is the live logical orientation."""
+    name: str
+    origin: tuple
+    distance: int
+    lobes: frozenset
+    phase: int
+    lr: str
+    tb: str
+    orientation: str
+
+    @property
+    def type(self):
+        return patch_type(self.lobes, self.origin, self.distance)
+
+    @property
+    def cell(self):
+        d = self.distance
+        return (self.origin[0] // (2 * d + 2), self.origin[1] // (2 * d + 2))
+
+
+def patch_view(system, name):
+    """Build a :class:`PatchView` from the live system (origin and d derived
+    from the patch's data qubits; orientation from the X̄ logical record)."""
+    owner = system.index_to_owner_map
+    coords = [tuple(int(round(v)) for v in system.qubit_coords[q])
+              for q in system.data_indices if owner.get(q) == name]
+    if not coords:
+        raise SeamRuleError(f"patch {name!r} has no data qubits in the system")
+    xs = sorted({x for x, _ in coords})
+    ys = sorted({y for _, y in coords})
+    d = len(xs)
+    if len(ys) != d:
+        raise SeamRuleError(
+            f"patch {name!r} is not square ({len(xs)}x{len(ys)})")
+    origin = (xs[0], ys[0])
+    lr, tb, phase = detect_layout(system, name, d, origin)
+    # X̄ connects the two X boundaries: lr == 'X' means X̄ runs horizontally
+    orientation = 'X_horizontal' if lr == 'X' else 'X_vertical'
+    return PatchView(name=name, origin=origin, distance=d,
+                     lobes=lobe_positions(system, name), phase=phase,
+                     lr=lr, tb=tb, orientation=orientation)
+
+
+# -----------------------------------------------------------------------------
+# SECTION: classification (the rule table) and the multi-patch wall selector
+# -----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MergeRule:
+    row: int                  # 1..4
+    construction: str         # 'merge' | 'wall'
+    same_pauli: bool
+    same_type: bool
+    axis: str                 # 'vertical' | 'horizontal' seam line direction
+    reason: str
+
+
+def _seam_axis(a, b):
+    """The seam LINE direction between two cell-adjacent views ('vertical' =
+    patches side by side, 'horizontal' = stacked).  Raises unless adjacent,
+    aligned and equal distance."""
+    if a.distance != b.distance:
+        raise SeamRuleError(
+            f"{a.name} (d={a.distance}) and {b.name} (d={b.distance}) differ")
+    (ax, ay), (bx, by) = a.cell, b.cell
+    if abs(ax - bx) + abs(ay - by) != 1:
+        raise SeamRuleError(
+            f"{a.name} at cell {a.cell} and {b.name} at cell {b.cell} are "
+            f"not cell-adjacent — this seam API is for direct adjacency; "
+            f"distant patches go through the routed corridor")
+    return 'vertical' if ay == by else 'horizontal'
+
+
+def _check_parallel(view, pauli, axis):
+    """The measured logical must run PARALLEL to the seam line."""
+    direction = ('horizontal' if (view.orientation == 'X_horizontal')
+                 == (pauli == 'X') else 'vertical')
+    if direction != axis:
+        raise SeamRuleError(
+            f"{view.name}: the measured {pauli}̄ runs {direction} but the "
+            f"seam line is {axis} — the measured logical must run PARALLEL "
+            f"to the seam (rotate the patch or re-place it)")
+
+
+def classify_seam(a, pa, b, pb):
+    """The rule-table row for measuring ``pa ⊗ pb`` across the seam between
+    cell-adjacent patches ``a`` and ``b`` (:class:`PatchView` each)."""
+    axis = _seam_axis(a, b)
+    _check_parallel(a, pa, axis)
+    _check_parallel(b, pb, axis)
+    same_pauli = (pa == pb)
+    same_type = (a.type == b.type)
+    # self-check: different types <=> the facing lobes ALIGN on the same
+    # along-seam positions (same type <=> interleaved) — verified truth table
+    near, far = (a, b) if a.cell <= b.cell else (b, a)
+    k = 0 if axis == 'horizontal' else 1   # along-seam coordinate index
+    facing_near = {q[k] for q in near.lobes
+                   if q[1 - k] == near.origin[1 - k] + 2 * near.distance - 1}
+    facing_far = {q[k] for q in far.lobes
+                  if q[1 - k] == far.origin[1 - k] - 1}
+    aligned = facing_near == facing_far
+    if aligned == same_type:
+        raise SeamRuleError(
+            f"type model and live geometry disagree on the {a.name}-{b.name} "
+            f"seam: types {'equal' if same_type else 'differ'} but facing "
+            f"lobes {'align' if aligned else 'interleave'}")
+    row = {(True, True): 1, (True, False): 2,
+           (False, False): 3, (False, True): 4}[(same_pauli, same_type)]
+    construction = 'wall' if row in (2, 3) else 'merge'
+    reason = (f"row {row}: {'same' if same_pauli else 'mixed'} Pauli + "
+              f"{'same' if same_type else 'different'} type -> {construction}")
+    return MergeRule(row=row, construction=construction, same_pauli=same_pauli,
+                     same_type=same_type, axis=axis, reason=reason)
+
+
+def assign_walls(views, target, seams):
+    """Which patches' seams carry the stretched stabilizers: group the target
+    patches by TYPE and pick the class with FEWER patches (e.g. 1 textbook +
+    3 conjugate -> the textbook patch's seams get the walls).  Tie (2-2) ->
+    the lexicographically smaller name set.  Returns {seam: bool} — a seam
+    carries a wall iff it touches a selected patch."""
+    types = {nm: views[nm].type for nm, _ in target}
+    tb = sorted(nm for nm, t in types.items() if t == TEXTBOOK)
+    cj = sorted(nm for nm, t in types.items() if t == CONJUGATE)
+    if not tb or not cj:
+        return {seam: False for seam in seams}
+    if len(tb) != len(cj):
+        chosen = set(min((tb, cj), key=len))
+    else:
+        chosen = set(min(tb, cj))           # deterministic 2-2 tiebreak
+    return {seam: bool(set(seam) & chosen) for seam in seams}
+
+
+# -----------------------------------------------------------------------------
+# SECTION: the unified wall generator + the seam-wall coupler
+# -----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SeamFrame:
+    axis: str          # seam LINE direction: 'vertical' | 'horizontal'
+    near: int          # facing data line of the near patch (normal coord)
+    lo: int
+    seam: int
+    hi: int
+    far: int           # facing data line of the far patch
+    span: tuple        # (first, last) along-seam plaquette coordinate
+
+
+def _wall_checks(d, phi_near, phi_far, x0, y0, axis, sgn_override=None):
+    """The unified wall law.  ``(x0, y0)`` = the NEAR patch's data origin;
+    ``axis`` = 'horizontal' when the seam line runs horizontally (patches
+    stacked, dominoes vertical) — matching :func:`_seam_axis`'s naming.
+
+    Byte-identical to the four legacy hand specs (same_type_wall_spec,
+    mirror_mixed_wall_spec, test_mixed_wall.wall_spec and its horizontal
+    twin) at d = 3 and 5.  Returns the legacy record list
+    [(B, {foot: Pauli}, {'flag': A, 'shared': S, 'orient': '+'|'-'})]."""
+    # P maps (along, normal) -> (x, y); for a horizontal seam the normal is y
+    P = (lambda a, n: (a, n)) if axis == 'horizontal' else (lambda a, n: (n, a))
+    a0, n0 = (x0, y0) if axis == 'horizontal' else (y0, x0)
+    near = n0 + 2 * (d - 1)
+    lo, seam, hi, far = near + 1, near + 2, near + 3, near + 4
+    cs = [a0 - 1 + k for k in range(0, 2 * d + 1, 2)]
+    inter = cs[1:-1]
+
+    def cn(c):
+        return ptype(*P(c, lo), phi_near)
+
+    def cf(c):
+        return ptype(*P(c, hi), phi_far)
+
+    # cap end: the alternating-spacing rule (Handbook Sec. 10.4) decides —
+    # wall_spec passes it in via sgn_override.  The far-side-colour proxy
+    # below coincides with the slot rule on the four legacy families but
+    # diverges on transposed row-3 (cap crammed next to existing corner
+    # lobes, three checks fighting one corner -> 50% random detectors).
+    sgn = (sgn_override if sgn_override is not None
+           else (1 if cf(inter[0]) == 'Z' else -1))
+    out = []
+    for c in inter:
+        t, b = cf(c), cn(c)
+        A, B = (P(c, hi), P(c, lo)) if t == 'Z' else (P(c, lo), P(c, hi))
+        out.append((B, {P(c - 1, far): t, P(c + 1, far): t,
+                        P(c - 1, near): b, P(c + 1, near): b},
+                    {'flag': A, 'shared': P(c + sgn, seam),
+                     'orient': '+' if A == P(c, hi) else '-'}))
+    e = cs[0] if sgn == 1 else cs[-1]
+    ca = e + 2 * sgn
+    tl, bl = _FLIP[cf(ca)], _FLIP[cn(ca)]
+    A, B = (P(e, hi), P(e, lo)) if tl == 'Z' else (P(e, lo), P(e, hi))
+    out.append((B, {P(e + sgn, far): tl, P(e + sgn, near): bl},
+                {'flag': A, 'shared': P(e + sgn, seam),
+                 'orient': '+' if A == P(e, hi) else '-'}))
+    return out
+
+
+@dataclass(frozen=True)
+class WallSpec:
+    checks: tuple      # legacy records ((B, {foot: P}, kf), ...) — ABSOLUTE coords
+    retire: frozenset  # facing weight-2 syn coords to pause at merge
+    frame: SeamFrame = None
+
+    @staticmethod
+    def from_records(records, retire):
+        """A WallSpec from a legacy record list (frozen test specs)."""
+        return WallSpec(
+            checks=tuple((tuple(B), tuple(sorted(p.items())),
+                          tuple(sorted(kf.items())))
+                         for B, p, kf in records),
+            retire=frozenset(retire))
+
+    def as_list(self):
+        return [(B, dict(pauli), dict(kf)) for B, pauli, kf in self.checks]
+
+
+def seam_frame(a, b):
+    axis = _seam_axis(a, b)
+    near_view, far_view = (a, b) if a.cell <= b.cell else (b, a)
+    k = 0 if axis == 'horizontal' else 1   # along-seam coordinate index
+    n0 = near_view.origin[1 - k]
+    near = n0 + 2 * (near_view.distance - 1)
+    a0 = near_view.origin[k]
+    return SeamFrame(axis=axis, near=near, lo=near + 1, seam=near + 2,
+                     hi=near + 3, far=near + 4,
+                     span=(a0 - 1, a0 - 1 + 2 * near_view.distance))
+
+
+def wall_spec(a, b, target):
+    """The wall between cell-adjacent views ``a`` and ``b`` for the measured
+    Paulis ``target = {name: 'X'|'Z'}``.  Verifies the rule table sends this
+    seam to a wall (rows 2/3) and that the domino colours are consistent
+    with the measured Paulis; raises SeamRuleError otherwise."""
+    rule = classify_seam(a, target[a.name], b, target[b.name])
+    if rule.construction != 'wall':
+        raise SeamRuleError(
+            f"the {a.name}-{b.name} seam takes the row-{rule.row} merge, "
+            f"not a wall ({rule.reason})")
+    near_view, far_view = (a, b) if a.cell <= b.cell else (b, a)
+    d = near_view.distance
+    frame = seam_frame(a, b)
+    # Handbook 10.4 alternating-spacing rule ("add one, skip one gap"): the
+    # end cap may only sit at a wall end whose candidate position is at
+    # least TWO gaps from every existing boundary lobe on that end row —
+    # one gap away means the slot is taken and nothing may be added there.
+    k = 0 if rule.axis == 'horizontal' else 1
+    a0 = near_view.origin[k]
+    end_lo, end_hi = a0 - 1, a0 - 1 + 2 * d
+    all_lobes = set(near_view.lobes) | set(far_view.lobes)
+
+    def _blocked(e):
+        return any(L[k] == e and
+                   min(abs(L[1 - k] - frame.lo),
+                       abs(L[1 - k] - frame.hi)) == 2
+                   for L in all_lobes)
+
+    free = [s for s, e in ((1, end_lo), (-1, end_hi)) if not _blocked(e)]
+    if not free:
+        raise SeamRuleError(
+            f"the {a.name}-{b.name} wall has NO free end slot for its cap "
+            f"(alternating-spacing rule, Handbook Sec. 10.4): both end rows "
+            f"already carry a boundary lobe one gap away")
+    sgn_override = free[0] if len(free) == 1 else None
+    checks = _wall_checks(d, near_view.phase, far_view.phase,
+                          near_view.origin[0], near_view.origin[1],
+                          rule.axis, sgn_override=sgn_override)
+    k = 0 if rule.axis == 'horizontal' else 1
+    retire = frozenset(
+        q for v in (near_view, far_view) for q in v.lobes
+        if q[1 - k] in (frame.lo, frame.hi))
+    return WallSpec(checks=tuple((B, tuple(sorted(pauli.items())), tuple(sorted(kf.items())))
+                                 for B, pauli, kf in
+                                 ((B, p, kf) for B, p, kf in checks)),
+                    retire=retire, frame=frame)
+
+
+def _wallspec_records(spec):
+    """checks back as mutable (B, pauli_dict, kf_dict) records."""
+    return [(B, dict(pauli), dict(kf)) for B, pauli, kf in spec.checks]
+
+
+# -----------------------------------------------------------------------------
+# SECTION: the seam-wall coupler (production twin of the test harness classes)
+# -----------------------------------------------------------------------------
+
+from lightstim.ir.coupler import LogicalCouplerProtocol     # noqa: E402
+
+
+class RotatedSeamWallCoupler(LogicalCouplerProtocol):
+    """Registers a :class:`WallSpec` as an IR coupler: MIXED+kf stabilizer
+    records at ABSOLUTE coordinates (register at offset (0, 0) only), the
+    three-qubit apparatus per check (flag -> syndrome_z, shared -> syndrome_z,
+    B -> syndrome_x; coords already owned by a patch are skipped), and the
+    facing lobes in ``conflicting_stabilizer_coords`` so ``activate_coupler``
+    pauses them at merge.  Merged rounds MUST use
+    ``DiagonalSurfaceCodeExtractionBlock`` (the bent chunk raises on kf)."""
+    EXPECTED_PATCH_COUNT = 2
+
+    def _build_coupler_geometry(self, coupler_patch, patches, *, spec,
+                                occupied=frozenset()):
+        seen = set(occupied)
+        for B, pauli, kf in _wallspec_records(spec):
+            for q, role in ((B, 'syndrome_x'), (kf['flag'], 'syndrome_z'),
+                            (kf['shared'], 'syndrome_z')):
+                if q in seen:
+                    continue
+                seen.add(q)
+                coupler_patch.add_qubit(q[0], q[1], role=role)
+            coupler_patch.stabilizers.append(
+                {'pauli': dict(pauli), 'type': 'MIXED', 'syn_coord': B,
+                 'kf': dict(kf)})
+        coupler_patch.conflicting_stabilizer_coords = set(spec.retire)
+        coupler_patch.wall_spec = spec
+        coupler_patch.num_logicals = 0

--- a/lightstim/protocols/ppm/sequential.py
+++ b/lightstim/protocols/ppm/sequential.py
@@ -32,8 +32,9 @@ from lightstim.qec_code.surface_code.rotated.diagonal_se import (
     DiagonalSurfaceCodeExtractionBlock)
 
 from .spec import PPMStep, conjugate_patch_records
-from .lowering import (PPMRequest, apply_plan, is_cell_adjacent_pair,
-                       lower_ppm)
+from .lowering import (PPMOutcome, PPMRequest, apply_plan,
+                       is_cell_adjacent_pair, joint_pauli_vector, lower_ppm,
+                       record_parity)
 
 __all__ = ["SequentialPPMExperiment"]
 
@@ -227,9 +228,23 @@ class SequentialPPMExperiment:
                     tuple(self.system.qubit_coords[q]), self._orient[nm])
         return se_round_chunk(self.system, domains=domains_merged)
 
+    def _capture_outcome(self, i, step, pre):
+        """Bank PPM ``i``'s protocol output: the joint's record parity
+        before the merge (None = free coin) and after the split."""
+        post = record_parity(
+            self.tracker, joint_pauli_vector(self.system,
+                                             step.interaction_type))
+        self.ppm_outcomes[i] = PPMOutcome(
+            step=i, targets=tuple(step.interaction_type),
+            records_pre_merge=tuple(pre) if pre is not None else None,
+            records_post_split=tuple(post) if post is not None else None)
+
     def _apply_ppm_step(self, i, step):
         init_basis = self._plans[i].corridor_init_basis
         cname = f'ppm_{i}'
+        pre = record_parity(
+            self.tracker, joint_pauli_vector(self.system,
+                                             step.interaction_type))
         # idle standalone SE between PPMs (debug knob; default 0)
         if self.idle_rounds:
             self._standalone_se(self.idle_rounds)
@@ -249,6 +264,7 @@ class SequentialPPMExperiment:
         self.builder.deactivate_coupler(cname)
         self.builder.apply_data_readout(final_measurements=dict(coupler_init),
                                         resolve_absorbed=False)
+        self._capture_outcome(i, step, pre)
 
     def _apply_wall_step(self, i, step):
         """A stretched-stabilizer wall step: activate the wall coupler (its
@@ -259,11 +275,15 @@ class SequentialPPMExperiment:
         cname = f'ppm_{i}'
         if self.idle_rounds:
             self._standalone_se(self.idle_rounds)
+        pre = record_parity(
+            self.tracker, joint_pauli_vector(self.system,
+                                             step.interaction_type))
         self.builder.activate_coupler(cname)
         self.builder.apply_syndrome_extraction(
             DiagonalSurfaceCodeExtractionBlock(self.system).circuit,
             rounds=self.rounds)
         self.builder.deactivate_coupler(cname)
+        self._capture_outcome(i, step, pre)
 
     def _init_and_baseline(self, names):
         """Reset the data qubits owned by ``names`` to their initial states,
@@ -293,6 +313,9 @@ class SequentialPPMExperiment:
         self._rules = {}
         self._sched = {}
         self._plans = {}
+        # protocol outputs, one per applied PPM (review §3: distinct from
+        # the evaluation observables the final readout emits)
+        self.ppm_outcomes: Dict[int, PPMOutcome] = {}
 
         # allocate ALL patches up front (no liveness / first-use init here)
         for s in self.patches:

--- a/lightstim/protocols/ppm/sequential.py
+++ b/lightstim/protocols/ppm/sequential.py
@@ -1,0 +1,392 @@
+# protocols/ppm/sequential.py
+#
+# Copied from https://github.com/John-YuehanZhang/CircLS @ 8802a5b — the
+# author's own repository (John Yuehan Zhang).  Source: circls/
+# sequential_ppm_ls.py (``SequentialPPMExperiment``), distilled to the
+# minimal explicit-route driver.
+#
+# Intentionally NOT copied: liveness / first-use init, auto-rotation
+# planning, snake steps, Y initial states (Gidney births), joint-parity
+# record capture and program-bit observable assembly.  Every ``PPMStep``
+# must carry an explicit ``route`` (``[]`` for cell-adjacent targets);
+# ``colour_swapped`` is kept (rule-table rows 2/3 depend on patch types).
+
+"""Sequential PPM driver — run a sequence of joint Pauli-product measurements
+on rotated routed surface-code patches; between PPMs measure out ONLY the bus
+(corridor), target patches persist with state.
+
+Cell-adjacent two-patch steps are classified live by the four-row rule table
+(:mod:`.seam_rules`): rows 2/3 take the stretched-stabilizer wall coupler
+(diagonal schedule mandatory), rows 1/4 take the plain/recoloured zero-cell
+merge.  Distant targets go through the explicit-route corridor.
+"""
+from dataclasses import replace
+from typing import Dict, List
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode
+from lightstim.qec_code.surface_code.rotated.bent_joint_se import se_round_chunk
+from lightstim.qec_code.surface_code.rotated.diagonal_se import (
+    DiagonalSurfaceCodeExtractionBlock)
+
+from .spec import PPMStep, cell_index, conjugate_patch_records
+from .coupler import route_and_build, RotatedRoutedMultiPatchCoupler
+from .seam_rules import (
+    RotatedSeamWallCoupler, SeamRuleError, classify_seam, patch_view,
+    wall_spec)
+
+__all__ = ["SequentialPPMExperiment"]
+
+_CONJ = {'X': 'Z', 'Z': 'X'}
+_FLIP_O = {'X_horizontal': 'X_vertical', 'X_vertical': 'X_horizontal'}
+
+
+class SequentialPPMExperiment:
+    """Run ``ppm_sequence`` (a list of :class:`~.spec.PPMStep`) on the
+    patches declared by ``patches`` (a list of :class:`~.spec.PatchSpec`
+    on the seam-column coarse grid, pitch ``2d+2``).
+
+    All patches are allocated and initialised up front; each PPM activates
+    its pre-registered coupler, runs ``rounds`` merged SE rounds, splits, and
+    measures out the corridor only; the final data readout measures every
+    patch in its ``final_measure_states`` letter (the builder emits the
+    standing logical observables there).
+    """
+
+    def __init__(self, patches, ppm_sequence, *, initial_states,
+                 final_measure_states, rounds=3, rounds_init=1, idle_rounds=0,
+                 noise_params=None, noise_model='circuit_level',
+                 schedule: str = 'auto', colour_swapped=frozenset()):
+        self.patches = list(patches)
+        self.ppm_sequence = list(ppm_sequence)
+        self.initial_states = {k: v.upper() for k, v in initial_states.items()}
+        self.final_measure_states = {k: v.upper()
+                                     for k, v in final_measure_states.items()}
+        bad = {k: v for k, v in self.initial_states.items()
+               if v not in ('X', 'Z')}
+        if bad:
+            raise ValueError(
+                f"initial_states letters must be 'X' or 'Z'; got {bad} "
+                f"(Y initial states are not part of this minimal variant)")
+        bad = {k: v for k, v in self.final_measure_states.items()
+               if v not in ('X', 'Z')}
+        if bad:
+            raise ValueError(
+                f"final_measure_states letters must be 'X' or 'Z'; got {bad}")
+        assert rounds_init >= 1, (
+            f"rounds_init must be >= 1 (a freshly initialised patch needs at "
+            f"least one standalone SE round to establish its stabilizers "
+            f"before the merge); got {rounds_init}")
+        self.rounds = rounds
+        self.rounds_init = rounds_init
+        self.idle_rounds = idle_rounds
+        self.noise_params = noise_params
+        self.noise_model = noise_model
+        for i, step in enumerate(self.ppm_sequence):
+            if step.route is None:
+                raise ValueError(
+                    f"PPM {i}: route is required in this variant — pass the "
+                    f"explicit corridor cells, or [] for cell-adjacent targets")
+            for name, P in step.interaction_type:
+                if P not in ('X', 'Z'):
+                    raise ValueError(
+                        f"PPM Pauli must be 'X' or 'Z', got {P!r} on patch {name}")
+        patch_names = {s.name for s in self.patches}
+        missing_init = patch_names - self.initial_states.keys()
+        if missing_init:
+            raise ValueError(
+                f"patch(es) {sorted(missing_init)} missing from initial_states")
+        missing_final = patch_names - self.final_measure_states.keys()
+        if missing_final:
+            raise ValueError(
+                f"patch(es) {sorted(missing_final)} missing from "
+                f"final_measure_states")
+        # schedule policy for MERGED rounds (decide right after routing — any
+        # bend in the corridor, or a wall in the step, forces the WHOLE merged
+        # block onto the diagonal schedule; straight corridors stay bent):
+        # 'auto' (default) | 'bent' (wall steps raise) | 'diagonal'
+        if schedule not in ('auto', 'bent', 'diagonal'):
+            raise ValueError(
+                f"schedule must be 'auto', 'bent' or 'diagonal', got {schedule!r}")
+        self.schedule = schedule
+        # colour_swapped: patches whose red/blue COLOURS are swapped at
+        # allocation (conjugate_patch_records on top of the standard build).
+        # This is a COLOUR knob — weight-2 positions (textbook/conjugate)
+        # are untouched; the live logical orientation flips with the labels.
+        self.colour_swapped = frozenset(colour_swapped or ())
+        unknown_cs = self.colour_swapped - patch_names
+        if unknown_cs:
+            raise ValueError(
+                f"colour_swapped names {sorted(unknown_cs)} are not patches")
+        self._orient = {s.name: (_FLIP_O[s.orientation]
+                                 if s.name in self.colour_swapped
+                                 else s.orientation)
+                        for s in self.patches}
+
+    @staticmethod
+    def _bus_of(interaction_type):
+        n_x = sum(1 for _, P in interaction_type if P == 'X')
+        return 'X' if n_x >= len(interaction_type) - n_x else 'Z'
+
+    def _conj(self, step):
+        """The conj-registered (colour-swapped) subset of the step's targets —
+        reaches route_and_build as ``conj_names`` so the seam table is
+        classified against the REAL registrations."""
+        return frozenset(nm for nm, _ in step.interaction_type
+                         if nm in self.colour_swapped)
+
+    def _specs(self):
+        """The patch specs the router sees: every patch, stamped with its
+        live orientation (a colour-swapped patch's labels flip at allocation,
+        so its live orientation starts flipped too)."""
+        return [replace(s, orientation=self._orient[s.name])
+                for s in self.patches]
+
+    def _adjacent_pair(self, step):
+        """True iff the step's targets are exactly two patches on
+        edge-adjacent coarse cells — the direct-seam territory of the rule
+        table (rows 1-4); distant targets go through the routed corridor."""
+        names = [nm for nm, _ in step.interaction_type]
+        if len(names) != 2:
+            return False
+        cells = [cell_index(self._by_name[nm].origin,
+                            self._by_name[nm].distance, seam=True)
+                 for nm in names]
+        (a1, b1), (a2, b2) = cells
+        return abs(a1 - a2) + abs(b1 - b2) == 1
+
+    def _register_adjacent(self, i, step):
+        """Classify the direct seam by the rule table (live probe = ground
+        truth) and register the chosen construction: rows 2/3 -> the
+        stretched-stabilizer wall coupler; rows 1/4 -> the plain/recoloured
+        merge through the zero-cell corridor (route=[])."""
+        names = [nm for nm, _ in step.interaction_type]
+        views = {nm: patch_view(self.system, nm) for nm in names}
+        tgt = dict(step.interaction_type)
+        rule = classify_seam(views[names[0]], tgt[names[0]],
+                             views[names[1]], tgt[names[1]])
+        cons = step.construction if step.construction != 'auto' \
+            else rule.construction
+        if cons == 'wall':
+            spec = wall_spec(views[names[0]], views[names[1]], tgt)
+            self.system.register_coupler(
+                RotatedSeamWallCoupler(), patch_names=names, name=f'ppm_{i}',
+                spec=spec, occupied=frozenset(self.system.index_map))
+            self._walls[i] = spec
+            self._sched[i] = self._pick_schedule(step, is_wall=True,
+                                                 collinear=True)
+        else:
+            self._register_ppm(i, step)
+            self._sched[i] = self._pick_schedule(step, is_wall=False,
+                                                 collinear=True)
+        self._rules[i] = rule
+
+    def _pick_schedule(self, step, *, is_wall, collinear):
+        """The merged-round schedule, decided right after routing: a wall or
+        any corridor bend forces the whole merged block onto the diagonal
+        schedule; straight corridors stay bent."""
+        if is_wall:
+            if step.schedule == 'bent' or self.schedule == 'bent':
+                raise SeamRuleError(
+                    "a wall step cannot run the bent schedule: the bent chunk "
+                    "cannot express stretched (kf) checks — use 'diagonal'")
+            return 'diagonal'
+        if step.schedule is not None:
+            return step.schedule
+        if self.schedule in ('bent', 'diagonal'):
+            return self.schedule
+        return 'bent' if collinear else 'diagonal'
+
+    def _register_ppm(self, i, step):
+        """Route (explicit route only) and register PPM ``i``'s coupler."""
+        specs = self._specs()
+        r = route_and_build(specs, step.interaction_type, seam=True,
+                            route=step.route, conj_names=self._conj(step))
+        if r.status != 'ok':
+            raise ValueError(
+                f'route_and_build failed at PPM {i}: {r.status} — {r.message}')
+        # a dispatch-raised stretched wall in the layout makes this a WALL
+        # step: kf records demand the diagonal schedule
+        has_kf = any(ch.get('kf')
+                     for ch in (r.layout.checks if r.layout is not None else ()))
+        if i not in self._sched:
+            # schedule decision straight off the route geometry: any bend
+            # (cells not collinear) forces the diagonal schedule
+            names = [nm for nm, _ in step.interaction_type]
+            cells = [cell_index(self._by_name[nm].origin,
+                                self._by_name[nm].distance, seam=True)
+                     for nm in names] + [tuple(c) for c in (r.tree or ())]
+            collinear = (len({a for a, _ in cells}) == 1
+                         or len({b for _, b in cells}) == 1)
+            self._sched[i] = self._pick_schedule(step, is_wall=has_kf,
+                                                 collinear=collinear)
+        self.system.register_coupler(
+            RotatedRoutedMultiPatchCoupler(),
+            patch_names=[nm for nm, _ in step.interaction_type],
+            name=f'ppm_{i}', specs=specs,
+            target=step.interaction_type, subset_route=r, seam=True,
+            minority_names=self._conj(step))
+        self._routes[i] = r
+
+    def _alloc_patch(self, name):
+        """Create one patch's physical qubits in the system: the DECLARED
+        orientation, colours from ``colour_swapped``."""
+        s = self._by_name[name]
+        p = RotatedSurfaceCode(distance=s.distance)
+        if s.orientation == 'X_horizontal':
+            p.transpose_coords()
+        if name in self.colour_swapped:
+            conjugate_patch_records(p)      # colour knob: swap red/blue only
+        self.system.add_patch(p, name=name,
+                              offset=(s.origin[0] - 1, s.origin[1] - 1))
+
+    def _setup(self):
+        self.tracker = SyndromeTracker(
+            num_qubits=self.system.num_qubits,
+            expected_num_logicals=self.system.num_logicals)
+        self.builder = CircuitBuilder(tracker=self.tracker,
+                                      system_config=self.system,
+                                      if_detector=True)
+        self.system.register_tracker(self.tracker)
+        self.system.register_builder(self.builder)
+
+    def _standalone_se(self, n_rounds):
+        if n_rounds < 1:
+            return
+        owner = self.system.index_to_owner_map
+        domains = {tuple(self.system.qubit_coords[q]): self._orient[owner[q]]
+                   for q in self.system.data_indices
+                   if owner.get(q) in self._orient}
+        chunk = se_round_chunk(self.system, domains=domains)
+        self.builder.apply_syndrome_extraction(circuit_chunk=chunk,
+                                               rounds=n_rounds)
+
+    def _merged_chunk(self, i):
+        """The one-round chunk of PPM ``i``'s merged system."""
+        if self._sched.get(i, 'bent') == 'diagonal':
+            # any bend in the corridor (or a forced override) puts the whole
+            # merged block on the diagonal schedule — one stretched/bent
+            # check's tick budget is the global tick budget
+            return DiagonalSurfaceCodeExtractionBlock(self.system).circuit
+        lay = self._routes[i].layout
+        if any(c.get('kf') for c in lay.checks):
+            # a dispatch-built stretched wall in the layout: the bent
+            # chunk cannot express kf relay checks
+            return DiagonalSurfaceCodeExtractionBlock(self.system).circuit
+        domains_merged = dict(getattr(lay, 'domains', {}) or {})
+        # SPECTATOR hook-safety: the routed layout's domains cover only the
+        # step's patches + corridor.  Every OTHER live patch must still run
+        # its orientation-correct schedule — a defaulted hook direction
+        # aligned with the idle logical halves its distance to (d+1)/2
+        owner = self.system.index_to_owner_map
+        for q in self.system.data_indices:
+            nm = owner.get(q)
+            if nm in self._orient:
+                domains_merged.setdefault(
+                    tuple(self.system.qubit_coords[q]), self._orient[nm])
+        return se_round_chunk(self.system, domains=domains_merged)
+
+    def _apply_ppm_step(self, i, step):
+        bus = self._bus_of(step.interaction_type)
+        cname = f'ppm_{i}'
+        # idle standalone SE between PPMs (debug knob; default 0)
+        if self.idle_rounds:
+            self._standalone_se(self.idle_rounds)
+        # merge (coupler already registered)
+        self.builder.activate_coupler(cname)
+        coupler_patch = self.system.coupler_patches[cname]
+        l2g = self.system.local_to_global_map[cname]
+        coupler_init = {l2g[q]: _CONJ[bus] for q in coupler_patch.data_indices}
+        if coupler_init:
+            self.builder.initialize(init_dict=coupler_init,
+                                    n=self.system.num_qubits)
+        self.builder.apply_syndrome_extraction(
+            circuit_chunk=self._merged_chunk(i), rounds=self.rounds)
+        # split: the bus/corridor readout measures out the corridor ONLY; the
+        # joint patch-patch relation it created persists, so it must not
+        # resolve absorbed_ops.
+        self.builder.deactivate_coupler(cname)
+        self.builder.apply_data_readout(final_measurements=dict(coupler_init),
+                                        resolve_absorbed=False)
+
+    def _apply_wall_step(self, i, step):
+        """A stretched-stabilizer wall step: activate the wall coupler (its
+        apparatus adds no data qubits, so there is no corridor init/readout),
+        run the merged rounds on the DIAGONAL schedule (mandatory for kf
+        checks), then split by deactivating — the paused facing lobes come
+        back automatically."""
+        cname = f'ppm_{i}'
+        if self.idle_rounds:
+            self._standalone_se(self.idle_rounds)
+        self.builder.activate_coupler(cname)
+        self.builder.apply_syndrome_extraction(
+            DiagonalSurfaceCodeExtractionBlock(self.system).circuit,
+            rounds=self.rounds)
+        self.builder.deactivate_coupler(cname)
+
+    def _init_and_baseline(self, names):
+        """Reset the data qubits owned by ``names`` to their initial states,
+        then run the baseline SE (``rounds_init``) that establishes their
+        stabilizers."""
+        owner = self.system.index_to_owner_map
+        init_dict = {q: self.initial_states[owner[q]]
+                     for q in self.system.data_indices if owner.get(q) in names}
+        if init_dict:
+            self.builder.initialize(init_dict=init_dict,
+                                    n=self.system.num_qubits)
+        self._standalone_se(self.rounds_init)
+
+    def build(self):
+        # build() is re-runnable: everything below re-derives from the specs.
+        self._orient = {s.name: (_FLIP_O[s.orientation]
+                                 if s.name in self.colour_swapped
+                                 else s.orientation)
+                        for s in self.patches}
+        self.system = QECSystem()
+        self._by_name = {s.name: s for s in self.patches}
+        # direct-seam steps (two cell-adjacent targets): classified by the
+        # rule table against the LIVE system, so always registered lazily
+        self._adj_steps = {i for i, st in enumerate(self.ppm_sequence)
+                           if self._adjacent_pair(st)}
+        self._walls = {}
+        self._rules = {}
+        self._sched = {}
+
+        # allocate ALL patches up front (no liveness / first-use init here)
+        for s in self.patches:
+            self._alloc_patch(s.name)
+
+        # register the routed couplers up front (BEFORE the tracker exists);
+        # adjacent-pair steps register lazily in the loop, off the live probe
+        self._routes: List = [None] * len(self.ppm_sequence)
+        for i, step in enumerate(self.ppm_sequence):
+            if i in self._adj_steps:
+                continue
+            self._register_ppm(i, step)
+
+        self._setup()
+        self.builder.write_coordinates()
+        self._init_and_baseline({s.name for s in self.patches})
+
+        for i, step in enumerate(self.ppm_sequence):
+            if i in self._adj_steps and i not in self._walls \
+                    and self._routes[i] is None:
+                self._register_adjacent(i, step)
+            if i in self._walls:
+                self._apply_wall_step(i, step)
+                continue
+            self._apply_ppm_step(i, step)
+
+        owner = self.system.index_to_owner_map
+        meas_dict = {q: self.final_measure_states[owner[q]]
+                     for q in self.system.data_indices
+                     if owner.get(q) in self.final_measure_states}
+        if meas_dict:
+            self.builder.apply_data_readout(final_measurements=meas_dict)
+
+        if self.noise_params is not None:
+            return self.builder.build_noisy_circuit(
+                noise_params=self.noise_params, noise_model=self.noise_model)
+        return self.builder.circuit

--- a/lightstim/protocols/ppm/sequential.py
+++ b/lightstim/protocols/ppm/sequential.py
@@ -31,15 +31,12 @@ from lightstim.qec_code.surface_code.rotated.bent_joint_se import se_round_chunk
 from lightstim.qec_code.surface_code.rotated.diagonal_se import (
     DiagonalSurfaceCodeExtractionBlock)
 
-from .spec import PPMStep, cell_index, conjugate_patch_records
-from .coupler import route_and_build, RotatedRoutedMultiPatchCoupler
-from .seam_rules import (
-    RotatedSeamWallCoupler, SeamRuleError, classify_seam, patch_view,
-    wall_spec)
+from .spec import PPMStep, conjugate_patch_records
+from .lowering import (PPMRequest, apply_plan, is_cell_adjacent_pair,
+                       lower_ppm)
 
 __all__ = ["SequentialPPMExperiment"]
 
-_CONJ = {'X': 'Z', 'Z': 'X'}
 _FLIP_O = {'X_horizontal': 'X_vertical', 'X_vertical': 'X_horizontal'}
 
 
@@ -125,11 +122,6 @@ class SequentialPPMExperiment:
                                  else s.orientation)
                         for s in self.patches}
 
-    @staticmethod
-    def _bus_of(interaction_type):
-        n_x = sum(1 for _, P in interaction_type if P == 'X')
-        return 'X' if n_x >= len(interaction_type) - n_x else 'Z'
-
     def _conj(self, step):
         """The conj-registered (colour-swapped) subset of the step's targets —
         reaches route_and_build as ``conj_names`` so the seam table is
@@ -144,91 +136,38 @@ class SequentialPPMExperiment:
         return [replace(s, orientation=self._orient[s.name])
                 for s in self.patches]
 
+    def _request(self, step):
+        """Bridge a PPMStep to the kernel's declarative request."""
+        return PPMRequest(targets=tuple(step.interaction_type),
+                          route=tuple(tuple(c) for c in step.route),
+                          construction=step.construction,
+                          schedule=step.schedule)
+
     def _adjacent_pair(self, step):
-        """True iff the step's targets are exactly two patches on
-        edge-adjacent coarse cells — the direct-seam territory of the rule
-        table (rows 1-4); distant targets go through the routed corridor."""
-        names = [nm for nm, _ in step.interaction_type]
-        if len(names) != 2:
-            return False
-        cells = [cell_index(self._by_name[nm].origin,
-                            self._by_name[nm].distance, seam=True)
-                 for nm in names]
-        (a1, b1), (a2, b2) = cells
-        return abs(a1 - a2) + abs(b1 - b2) == 1
+        return is_cell_adjacent_pair(self._by_name, self._request(step))
 
-    def _register_adjacent(self, i, step):
-        """Classify the direct seam by the rule table (live probe = ground
-        truth) and register the chosen construction: rows 2/3 -> the
-        stretched-stabilizer wall coupler; rows 1/4 -> the plain/recoloured
-        merge through the zero-cell corridor (route=[])."""
-        names = [nm for nm, _ in step.interaction_type]
-        views = {nm: patch_view(self.system, nm) for nm in names}
-        tgt = dict(step.interaction_type)
-        rule = classify_seam(views[names[0]], tgt[names[0]],
-                             views[names[1]], tgt[names[1]])
-        cons = step.construction if step.construction != 'auto' \
-            else rule.construction
-        if cons == 'wall':
-            spec = wall_spec(views[names[0]], views[names[1]], tgt)
-            self.system.register_coupler(
-                RotatedSeamWallCoupler(), patch_names=names, name=f'ppm_{i}',
-                spec=spec, occupied=frozenset(self.system.index_map))
-            self._walls[i] = spec
-            self._sched[i] = self._pick_schedule(step, is_wall=True,
-                                                 collinear=True)
+    def _register_step(self, i, step):
+        """Lower PPM ``i`` through the kernel and register its plan.  All
+        construction decisions (rule row, wall vs merge, schedule, corridor
+        routing, certificate) are the kernel's; the driver only stores the
+        plan and applies it."""
+        try:
+            plan = lower_ppm(self._specs(), self._request(step),
+                             system=self.system, conj_names=self._conj(step),
+                             schedule_policy=self.schedule)
+        except ValueError as e:
+            if 'route_and_build failed' in str(e):
+                raise ValueError(f'PPM {i}: {e}') from None
+            raise
+        apply_plan(self.system, plan, f'ppm_{i}')
+        self._plans[i] = plan
+        self._sched[i] = plan.schedule
+        if plan.kind == 'wall':
+            self._walls[i] = plan.wall
         else:
-            self._register_ppm(i, step)
-            self._sched[i] = self._pick_schedule(step, is_wall=False,
-                                                 collinear=True)
-        self._rules[i] = rule
-
-    def _pick_schedule(self, step, *, is_wall, collinear):
-        """The merged-round schedule, decided right after routing: a wall or
-        any corridor bend forces the whole merged block onto the diagonal
-        schedule; straight corridors stay bent."""
-        if is_wall:
-            if step.schedule == 'bent' or self.schedule == 'bent':
-                raise SeamRuleError(
-                    "a wall step cannot run the bent schedule: the bent chunk "
-                    "cannot express stretched (kf) checks — use 'diagonal'")
-            return 'diagonal'
-        if step.schedule is not None:
-            return step.schedule
-        if self.schedule in ('bent', 'diagonal'):
-            return self.schedule
-        return 'bent' if collinear else 'diagonal'
-
-    def _register_ppm(self, i, step):
-        """Route (explicit route only) and register PPM ``i``'s coupler."""
-        specs = self._specs()
-        r = route_and_build(specs, step.interaction_type, seam=True,
-                            route=step.route, conj_names=self._conj(step))
-        if r.status != 'ok':
-            raise ValueError(
-                f'route_and_build failed at PPM {i}: {r.status} — {r.message}')
-        # a dispatch-raised stretched wall in the layout makes this a WALL
-        # step: kf records demand the diagonal schedule
-        has_kf = any(ch.get('kf')
-                     for ch in (r.layout.checks if r.layout is not None else ()))
-        if i not in self._sched:
-            # schedule decision straight off the route geometry: any bend
-            # (cells not collinear) forces the diagonal schedule
-            names = [nm for nm, _ in step.interaction_type]
-            cells = [cell_index(self._by_name[nm].origin,
-                                self._by_name[nm].distance, seam=True)
-                     for nm in names] + [tuple(c) for c in (r.tree or ())]
-            collinear = (len({a for a, _ in cells}) == 1
-                         or len({b for _, b in cells}) == 1)
-            self._sched[i] = self._pick_schedule(step, is_wall=has_kf,
-                                                 collinear=collinear)
-        self.system.register_coupler(
-            RotatedRoutedMultiPatchCoupler(),
-            patch_names=[nm for nm, _ in step.interaction_type],
-            name=f'ppm_{i}', specs=specs,
-            target=step.interaction_type, subset_route=r, seam=True,
-            minority_names=self._conj(step))
-        self._routes[i] = r
+            self._routes[i] = plan.route_result
+        if plan.rule is not None:
+            self._rules[i] = plan.rule
 
     def _alloc_patch(self, name):
         """Create one patch's physical qubits in the system: the DECLARED
@@ -289,7 +228,7 @@ class SequentialPPMExperiment:
         return se_round_chunk(self.system, domains=domains_merged)
 
     def _apply_ppm_step(self, i, step):
-        bus = self._bus_of(step.interaction_type)
+        init_basis = self._plans[i].corridor_init_basis
         cname = f'ppm_{i}'
         # idle standalone SE between PPMs (debug knob; default 0)
         if self.idle_rounds:
@@ -298,7 +237,7 @@ class SequentialPPMExperiment:
         self.builder.activate_coupler(cname)
         coupler_patch = self.system.coupler_patches[cname]
         l2g = self.system.local_to_global_map[cname]
-        coupler_init = {l2g[q]: _CONJ[bus] for q in coupler_patch.data_indices}
+        coupler_init = {l2g[q]: init_basis for q in coupler_patch.data_indices}
         if coupler_init:
             self.builder.initialize(init_dict=coupler_init,
                                     n=self.system.num_qubits)
@@ -353,6 +292,7 @@ class SequentialPPMExperiment:
         self._walls = {}
         self._rules = {}
         self._sched = {}
+        self._plans = {}
 
         # allocate ALL patches up front (no liveness / first-use init here)
         for s in self.patches:
@@ -364,7 +304,7 @@ class SequentialPPMExperiment:
         for i, step in enumerate(self.ppm_sequence):
             if i in self._adj_steps:
                 continue
-            self._register_ppm(i, step)
+            self._register_step(i, step)
 
         self._setup()
         self.builder.write_coordinates()
@@ -373,7 +313,7 @@ class SequentialPPMExperiment:
         for i, step in enumerate(self.ppm_sequence):
             if i in self._adj_steps and i not in self._walls \
                     and self._routes[i] is None:
-                self._register_adjacent(i, step)
+                self._register_step(i, step)
             if i in self._walls:
                 self._apply_wall_step(i, step)
                 continue

--- a/lightstim/protocols/ppm/spec.py
+++ b/lightstim/protocols/ppm/spec.py
@@ -1,0 +1,153 @@
+# protocols/ppm/spec.py
+#
+# Copied from https://github.com/John-YuehanZhang/CircLS @ 8802a5b — the
+# author's own repository (John Yuehan Zhang).  Sources: circls/
+# multi_patch_coupler.py (PatchSpec, place_patch, conjugate_patch_records,
+# origin_of / cell_index) and circls/sequential_ppm_ls.py (PPMStep).
+#
+# Minimal explicit-route variant, intentionally independent of CircLS:
+# LightStim's PPMStep REQUIRES an explicit ``route`` (there is no
+# auto-router in this package); liveness / first-use init / snake steps /
+# Y initial states are NOT included.
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from lightstim.qec_code.surface_code.rotated.code_patch import RotatedSurfaceCode
+
+_FLIP = {"X": "Z", "Z": "X"}
+
+
+class BentLayoutError(ValueError):
+    """Raised when the requested patch placement cannot host the joint
+    measurement (e.g. the two patches are misaligned, or their parity/seam
+    endpoints are incompatible).  The message states the concrete geometric
+    reason — it is NOT a generator hard-coding limit."""
+
+
+@dataclass(frozen=True)
+class PatchSpec:
+    """A logical patch placed on the coarse routing grid.
+
+    origin:           bus-facing corner data coord, in the library (1,1)-corner convention.
+    distance:         odd code distance.
+    orientation:      "X_horizontal" (X̄ runs along a row) | "X_vertical" (X̄ runs up a column).
+
+    Which logical each patch contributes to the joint ``M(∏ᵢ P̄ᵢ)`` is given
+    separately by the ``target`` / ``interaction_type`` list (e.g.
+    ``[("Q1", "Z"), ("Q2", "Z")]``), not by the patch itself.
+    """
+    name: str
+    origin: tuple
+    distance: int
+    orientation: str
+
+
+def place_patch(spec):
+    """Build one rotated patch placed/oriented per ``spec``; return coord-keyed dicts.
+
+    Returns dict(data=set[(col,row)], checks=list[checkdict], x_support, z_support).
+    Reuses RotatedSurfaceCode: build at the (1,1) corner, transpose for X_horizontal,
+    then shift so the corner lands at ``origin``.
+    """
+    if spec.orientation not in ("X_horizontal", "X_vertical"):
+        raise ValueError(f"orientation must be X_horizontal|X_vertical, got {spec.orientation!r}")
+    code = RotatedSurfaceCode(distance=spec.distance)
+    if spec.orientation == "X_horizontal":
+        code.transpose_coords()                       # default X̄ vertical -> horizontal
+    code.shift_coords(spec.origin[0] - 1, spec.origin[1] - 1)
+    qc = code.qubit_coords
+    data = {tuple(qc[i]) for i in code.data_indices}
+    checks = []
+    for s in code.stabilizers:
+        pauli = {tuple(qc[q]): P for q, P in s["pauli"].items()}
+        checks.append({"syn": tuple(s["syn_coord"]), "type": s["type"],
+                       "pauli": pauli, "corners": sorted(pauli)})
+    x_support = next(sorted(tuple(qc[q]) for q in lo["pauli"])
+                     for lo in code.logical_ops if lo["type"] == "X")
+    z_support = next(sorted(tuple(qc[q]) for q in lo["pauli"])
+                     for lo in code.logical_ops if lo["type"] == "Z")
+    return dict(data=data, checks=checks, x_support=x_support, z_support=z_support)
+
+
+def conjugate_patch_records(code):
+    """Typeswap a built patch IN PLACE: every stabilizer/logical record swaps
+    X<->Z (type and per-qubit Paulis) and the syndrome-role index sets swap.
+
+    The result is the CONJUGATE-CONVENTION patch: textbook-shaped on the same
+    qubits with the checkerboard colours exchanged — exactly the structure the
+    seam-column painting assigns to a minority patch.  A minority patch
+    registered this way matches the routed merged check set natively (rule-0
+    lock), so the protocol contains no transversal-H morph anywhere."""
+    for rec in code.stabilizers:
+        rec["type"] = _FLIP.get(rec["type"], rec["type"])
+        rec["pauli"] = {q: _FLIP.get(P, P) for q, P in rec["pauli"].items()}
+    for rec in code.logical_ops:
+        rec["type"] = _FLIP.get(rec["type"], rec["type"])
+        rec["pauli"] = {q: _FLIP.get(P, P) for q, P in rec["pauli"].items()}
+    xs = getattr(code, "syndrome_indices_x", None)
+    zs = getattr(code, "syndrome_indices_z", None)
+    if xs is not None and zs is not None:
+        code.syndrome_indices_x, code.syndrome_indices_z = zs, xs
+    return code
+
+
+# -----------------------------------------------------------------------------
+# The coarse routing grid (seam-column design, pitch 2d+2)
+# -----------------------------------------------------------------------------
+
+def _pitch(d, seam=False):
+    """Coarse-grid pitch: ``2d`` for the abutting design, ``2d+2`` for the SEAM-COLUMN
+    design (standard-LS style: one freshly-initialized data column/row between every
+    pair of edge-adjacent occupied cells)."""
+    return 2 * d + 2 if seam else 2 * d
+
+
+def cell(a, b, d, seam=False):
+    """The ``d×d`` data-qubit footprint of coarse cell ``(a, b)`` (rotated frame)."""
+    P = _pitch(d, seam)
+    x0, y0 = 1 + P * a, 1 + P * b
+    return {(x, y) for x in range(x0, x0 + 2 * d, 2) for y in range(y0, y0 + 2 * d, 2)}
+
+
+def origin_of(a, b, d, seam=False):
+    """The data-qubit **origin** (bus-facing ``(1,1)``-corner) of coarse cell ``(a, b)`` —
+    i.e. the :attr:`PatchSpec.origin` that places a distance-``d`` patch on that cell.
+    Inverse of :func:`cell_index`.  ``seam=True`` uses the seam-column grid (pitch ``2d+2``)."""
+    P = _pitch(d, seam)
+    return (1 + P * a, 1 + P * b)
+
+
+def cell_index(origin, d, seam=False):
+    """The coarse cell ``(a, b)`` a distance-``d`` patch placed at ``origin`` occupies.  Inverse of
+    :func:`origin_of`.  Raises ``ValueError`` if ``origin`` is off the pitch grid (patches are
+    placed only on that grid; use :func:`origin_of` to land on it)."""
+    P = _pitch(d, seam)
+    ox, oy = origin
+    if (ox - 1) % P or (oy - 1) % P:
+        raise ValueError(f"origin {origin} is not on the pitch-{P} coarse grid for d={d}")
+    return ((ox - 1) // P, (oy - 1) // P)
+
+
+# -----------------------------------------------------------------------------
+# The PPM sequence element
+# -----------------------------------------------------------------------------
+
+@dataclass
+class PPMStep:
+    """One joint PPM in a sequence.
+
+    interaction_type: [(patch_name, Pauli), ...] with Pauli in {'X', 'Z'}.
+    route:            REQUIRED explicit corridor cell list — this variant has
+                      no auto-router.  Pass the coarse-grid ``(a, b)`` cells
+                      the corridor occupies, in order; pass ``[]`` for
+                      cell-adjacent targets (zero-cell seam).
+    construction:     'auto' (rule table decides) | 'merge' | 'wall' —
+                      only meaningful for cell-adjacent targets.
+    schedule:         per-step override of the merged-round schedule
+                      ('bent' | 'diagonal'); None = the experiment's policy.
+    """
+    interaction_type: List[Tuple[str, str]]
+    route: list
+    construction: str = 'auto'
+    schedule: Optional[str] = None

--- a/lightstim/qec_code/surface_code/rotated/__init__.py
+++ b/lightstim/qec_code/surface_code/rotated/__init__.py
@@ -2,10 +2,12 @@ from .code_patch import RotatedSurfaceCode
 from .SE_block import RotatedSurfaceCodeExtractionBlock
 from .operation import RotatedSurfaceCodeLogicalOpSet
 from .two_patch_coupler import RotatedTwoPatchCoupler
+from .bent_joint_se import RotatedBentJointMeasurement
 
 __all__ = [
     "RotatedSurfaceCode",
     "RotatedSurfaceCodeExtractionBlock",
     "RotatedSurfaceCodeLogicalOpSet",
     "RotatedTwoPatchCoupler",
-]
+    "RotatedBentJointMeasurement",
+    ]

--- a/lightstim/qec_code/surface_code/rotated/bent_joint_se.py
+++ b/lightstim/qec_code/surface_code/rotated/bent_joint_se.py
@@ -1,0 +1,388 @@
+import itertools
+
+import stim
+
+
+# -----------------------------------------------------------------------------
+# Rotated bent (XZ) joint lattice-surgery measurement — circuit builder
+# -----------------------------------------------------------------------------
+#
+# The bent joint-measurement layout is transcribed from `rotated.png` as an
+# explicit list of data-qubit coordinates plus checks (pure X, pure Z, and MIXED
+# domain-wall checks carrying an explicit per-data Pauli). This module turns that
+# layout into a circuit-level syndrome-extraction circuit so the notebook does
+# NOT define the syndrome-extraction circuit inline — it lives here in
+# `lightstim/qec_code/`, next to the other surface-code extraction blocks.
+#
+# Pure X/Z checks couple their corners in a hook-benign order (see BENIGN_TABLES).
+# MIXED checks are measured with a single X-basis ancilla — X terms couple via
+# CNOT(ancilla->data) and Z terms via CZ(ancilla, data) — scheduled in the SAME
+# direction-by-tick slots the pure checks use, so the mixed checks inherit the
+# pure checks' hook-error-benign (logical-perpendicular) orientation.
+
+
+def _sgn(a):
+    return (a > 0) - (a < 0)
+
+
+# -----------------------------------------------------------------------------
+# Hook-benign scheduling
+# -----------------------------------------------------------------------------
+#
+# Each check couples its corners in a benign order so its hook error lands
+# PERPENDICULAR to the same-type logical it could shorten.  Key points:
+#
+# * one benign direction-table pair PER ORIENTATION DOMAIN (X_horizontal is the
+#   exact transpose = X/Z swap of X_vertical);
+# * when two orientation domains meet, T=5 slots with a per-check FLOATING IDLE
+#   SLOT: gate ORDER (hence hook geometry) never changes, only absolute slot
+#   positions shift so seam-band checks dodge each other.  T=4 is provably
+#   unsatisfiable for two domains; away from a seam every check keeps the
+#   default trailing idle, so a uniform layout degenerates to plain T=4;
+# * mixed (domain-wall) checks are interleaved into the SAME coupling window
+#   (X corners via CNOT, Z corners via CZ), inheriting the pure checks' hook
+#   geometry.
+
+_NE, _NW, _SE, _SW = (1, 1), (-1, 1), (1, -1), (-1, -1)
+
+#: Benign gate-order table per orientation domain: X and Z checks each couple
+#: their corners in an order whose hook (the last-coupled corner pair) lies
+#: PERPENDICULAR to the same-type logical it could shorten (X hook ⊥ X̄, Z hook
+#: ⊥ Z̄).  ``X_horizontal`` is the exact transpose (X/Z swap) of ``X_vertical``.
+#: Full circuit distance on single-patch memory in both bases; the routed
+#: pipeline (``RoutedMultiPatchLSExperiment``) reaches full joint distance with it.
+BENIGN_TABLES = {
+    'X_vertical':   {'X': (_NE, _NW, _SE, _SW), 'Z': (_NE, _SE, _NW, _SW)},
+    'X_horizontal': {'X': (_NE, _SE, _NW, _SW), 'Z': (_NE, _NW, _SE, _SW)},
+}
+
+_DEFAULT_ORIENTATION = 'X_horizontal'
+
+
+def _check_orientation(check, domains, default=_DEFAULT_ORIENTATION):
+    """Majority vote of the check's corner cells over the orientation-domain map."""
+    votes = {}
+    for q in check['pauli']:
+        o = domains.get(q, default)
+        votes[o] = votes.get(o, 0) + 1
+    return max(sorted(votes), key=lambda o: votes[o])
+
+
+def assign_hook_benign_schedule(checks, domains=None, default=_DEFAULT_ORIENTATION,
+                                max_nodes=500_000, include_mixed=False):
+    """Schedule the checks of one SE round with benign gate orders.
+
+    Returns ``(T, tickmaps)`` where ``tickmaps[k] = {corner_coord: tick}`` for
+    every scheduled check index ``k``.  By default only the pure (X/Z) checks
+    are scheduled (mixed 'M' checks then run in their own batch blocks);
+    ``include_mixed=True`` schedules the mixed checks INSIDE the same T-slot
+    coupling window (fully interleaved round): a mixed check follows its
+    domain's X table as a single corner-order permutation (per-check slot
+    injectivity by construction), its X corners couple via CNOT and Z corners
+    via CZ at their assigned slots.
+
+    ``T`` is 4 for a single orientation domain and 5 when two domains meet; in
+    the latter case each check carries one idle slot whose position is chosen
+    by a deterministic greedy sweep (with bounded backtracking) so that no
+    data qubit is touched twice in a tick and every pair of checks sharing
+    two ANTICOMMUTING corners keeps a consistent relative gate order (for
+    pure X/Z pairs this is the classic rule; it generalises to mixed-pure and
+    mixed-mixed pairs, whose shared corners carry opposite Paulis along a
+    domain wall).  The gate ORDER of each check is always exactly its
+    domain's benign table — the idle slot only shifts absolute positions, so
+    hook geometry is untouched.
+    """
+    domains = domains or {}
+    tables = BENIGN_TABLES
+    kinds = ('X', 'Z', 'M') if include_mixed else ('X', 'Z')
+    sched = [k for k, ch in enumerate(checks) if ch['type'] in kinds]
+    orients = {k: _check_orientation(checks[k], domains, default) for k in sched}
+    has_mixed = any(checks[k]['type'] == 'M' for k in sched)
+    # mixed checks reuse the X table, so wall-adjacent qubits need the floating
+    # idle slot's freedom to dodge same-slot collisions -> T=5 whenever present
+    T = 4 if len(set(orients.values())) <= 1 and not has_mixed else 5
+
+    # direction index within the table, per corner (slot base position).
+    # Corners are classified by the SIGN of their offset from the syn coord, so
+    # WIDE checks (Fig 39-style stretched supports, e.g. the mixed-wall dominoes
+    # whose feet sit rows away from the gap-centre ancilla) inherit the same
+    # corner-order tables as ordinary (±1, ±1) plaquettes.
+    def _sgn(v):
+        return (v > 0) - (v < 0)
+
+    base_pos = {}
+    for k in sched:
+        ch = checks[k]
+        # mixed checks take the domain's X table as ONE corner permutation
+        table = tables[orients[k]][ch['type'] if ch['type'] in ('X', 'Z') else 'X']
+        sx, sy = ch['syn']
+        pos_of = {d_: i for i, d_ in enumerate(table)}
+        base_pos[k] = {}
+        for q in ch['pauli']:
+            dxy = (_sgn(q[0] - sx), _sgn(q[1] - sy))
+            if dxy in pos_of:
+                base_pos[k][q] = pos_of[dxy]
+
+    # pairs sharing >=2 ANTICOMMUTING corners: relative gate order must agree
+    # (pure X vs pure Z pairs always anticommute on shared corners; mixed
+    # checks anticommute with neighbours exactly where the wall alternates)
+    by_corner = {}
+    for k in sched:
+        for q in checks[k]['pauli']:
+            by_corner.setdefault(q, []).append(k)
+    xz_pairs = {}
+    for q, ks in by_corner.items():
+        for i in range(len(ks)):
+            for j in range(i + 1, len(ks)):
+                a, b = sorted((ks[i], ks[j]))
+                if checks[a]['pauli'][q] != checks[b]['pauli'][q]:
+                    xz_pairs.setdefault((a, b), []).append(q)
+    xz_pairs = {kk: qs for kk, qs in xz_pairs.items() if len(qs) >= 2}
+    partners = {}
+    for (a, b), qs in xz_pairs.items():
+        partners.setdefault(a, []).append((b, qs))
+        partners.setdefault(b, []).append((a, qs))
+
+    def tickmap_of(k, idle):
+        slots = [t for t in range(T) if t != idle]
+        return {q: slots[base_pos[k][q]] for q in base_pos[k]}
+
+    idle_options = [None] if T == 4 else [T - 1, 3, 2, 1, 0]
+    order = sorted(sched, key=lambda k: checks[k]['syn'])
+    assign, occupied = {}, {}
+    nodes = [0]
+
+    def consistent(k, tm):
+        for q, t in tm.items():
+            if (t, q) in occupied:
+                return False
+        for other, qs in partners.get(k, ()):
+            if other in assign:
+                to = assign[other]
+                rel = None
+                for q in qs:
+                    if q in tm and q in to:
+                        r = tm[q] < to[q]
+                        if rel is None:
+                            rel = r
+                        elif rel != r:
+                            return False
+        return True
+
+    def place(i):
+        if i == len(order):
+            return True
+        nodes[0] += 1
+        if nodes[0] > max_nodes:
+            raise RuntimeError(
+                "hook-benign scheduling exceeded its search budget; "
+                "this layout's orientation-domain seams could not be resolved")
+        k = order[i]
+        for idle in idle_options:
+            tm = tickmap_of(k, idle)
+            if consistent(k, tm):
+                assign[k] = tm
+                for q, t in tm.items():
+                    occupied[(t, q)] = k
+                if place(i + 1):
+                    return True
+                for q, t in tm.items():
+                    del occupied[(t, q)]
+                del assign[k]
+        return False
+
+    if not place(0):
+        raise RuntimeError(
+            "hook-benign scheduling is unsatisfiable for this layout "
+            f"(T={T}); no idle-slot assignment resolves the seam band")
+    return T, assign
+
+
+class RotatedBentJointMeasurement:
+    """Circuit builder for the rotated bent (XZ) joint lattice-surgery measurement.
+
+    Args:
+        data:      list of data-qubit ``(col, row)`` coordinates (rotated frame).
+        checks:    list of stabilizer dicts ``{'syn', 'type', 'pauli', 'corners'}``
+                   where ``type`` is ``'X'`` / ``'Z'`` / ``'M'`` and ``pauli`` maps
+                   each corner ``(col, row)`` to ``'X'`` / ``'Z'``.
+        x_logical: data-qubit coords supporting the measured logical X̄ (read out
+                   from the final X-basis data measurement as observable 0).
+
+    The qubit index layout is: data qubits ``0 .. nq-1`` (in ``data`` order),
+    then one ancilla per check ``nq + k`` (in ``checks`` order ``k``).
+    """
+
+    def __init__(self, data, checks, x_logical, domains=None):
+        self.data = list(data)
+        self.checks = list(checks)
+        self.x_logical = list(x_logical)
+        self.domains = dict(domains) if domains else {}
+        self.nq = len(self.data)
+        self.nst = len(self.checks)
+        self.di = {q: i for i, q in enumerate(self.data)}
+        self.aid = {k: self.nq + k for k in range(self.nst)}
+        self.Xk = [k for k, c in enumerate(self.checks) if c['type'] == 'X']
+        self.Zk = [k for k, c in enumerate(self.checks) if c['type'] == 'Z']
+        self.Mk = [k for k, c in enumerate(self.checks) if c['type'] == 'M']
+        self._hb_plan = None    # cached (T, tickmaps) schedule
+
+    def _hb_schedule(self):
+        if self._hb_plan is None:
+            self._hb_plan = assign_hook_benign_schedule(
+                self.checks, self.domains, include_mixed=True)
+        return self._hb_plan
+
+    def _se_round_hook_benign(self, c, p):
+        """One FULLY INTERLEAVED SE round under the hook-benign schedule: every
+        check — pure X, pure Z and mixed — couples inside the SAME T-slot
+        window (mixed X corners via CNOT, Z corners via CZ; CNOT and CZ share a
+        tick on disjoint qubits).  Round depth: R + H + T + H + M."""
+        di, AID, CHECKS = self.di, self.aid, self.checks
+        T, tickmaps = self._hb_schedule()
+        anc = [AID[k] for k in range(self.nst)]
+        c.append("R", anc)
+        if p > 0:
+            c.append("X_ERROR", anc, p)
+        c.append("TICK")                                            # phase: reset ancillas
+
+        xanc = [AID[k] for k in self.Xk] + [AID[k] for k in self.Mk]
+        c.append("H", sorted(xanc))
+        if p > 0:
+            c.append("DEPOLARIZE1", sorted(xanc), p)
+        c.append("TICK")                                            # phase: prep X/mixed ancillas
+
+        for t in range(T):                                          # ONE coupling window
+            cn, cz = [], []
+            for k in self.Xk:
+                for q, tk in tickmaps[k].items():
+                    if tk == t:
+                        cn += [AID[k], di[q]]
+            for k in self.Zk:
+                for q, tk in tickmaps[k].items():
+                    if tk == t:
+                        cn += [di[q], AID[k]]
+            for k in self.Mk:
+                ch = CHECKS[k]
+                for q, tk in tickmaps[k].items():
+                    if tk == t:
+                        if ch['pauli'][q] == 'X':
+                            cn += [AID[k], di[q]]                   # CNOT(anc -> data)
+                        else:
+                            cz += [di[q], AID[k]]                   # CZ(data, anc)
+            if cn:
+                c.append("CNOT", cn)
+                if p > 0:
+                    c.append("DEPOLARIZE2", cn, p)
+            if cz:                                                  # disjoint qubits: same tick
+                c.append("CZ", cz)
+                if p > 0:
+                    c.append("DEPOLARIZE2", cz, p)
+            c.append("TICK")
+
+        c.append("H", sorted(xanc))
+        if p > 0:
+            c.append("DEPOLARIZE1", sorted(xanc), p)
+        c.append("TICK")                                            # phase: unprep X/mixed ancillas
+
+        c.append("M", anc, p if p > 0 else 0)                       # all ancillas, fixed order
+        c.append("TICK")
+
+    def circuit(self, rounds=3, p=0.0, basis="X"):
+        """Build the full bent joint-measurement circuit: ``basis``-basis init, ``rounds`` of
+        syndrome extraction, ``basis``-basis data readout, detectors and the tracked observable.
+
+        ``basis="X"`` (default) is the X-memory experiment (X-init/readout, X-type checks close, the
+        observable is the X̄ logical).  ``basis="Z"`` is the Z-memory experiment, used when the tracked
+        logical is Z (e.g. a pure-Z joint ``M(Z̄₁Z̄₂)``).  Returns a ``stim.Circuit``.
+
+        Syndrome extraction uses the hook-benign schedule (orientation-aware benign
+        tables + T=5 floating idle slot at orientation seams; see
+        :func:`assign_hook_benign_schedule`).
+
+        WARNING: this is a STANDALONE builder whose observable is a SINGLE logical
+        (``x_logical``), NOT the ``SyndromeTracker`` joint m.  It is correct for
+        single-patch memory and for checking a round's determinism / collision-
+        freedom, but on a MULTI-PATCH joint its graphlike distance is NOT the real
+        joint distance -- use :class:`RoutedMultiPatchLSExperiment` to measure joint
+        distance / LER."""
+        se_round = lambda cc, pp: self._se_round_hook_benign(cc, pp)
+        di, AID, CHECKS = self.di, self.aid, self.checks
+        nq, NST = self.nq, self.nst
+        reset, meas, err, want = (("RX", "MX", "Z_ERROR", "X") if basis == "X"
+                                  else ("RZ", "MZ", "X_ERROR", "Z"))
+        close_k = self.Xk if basis == "X" else self.Zk             # same-type checks close at readout
+        c = stim.Circuit()
+        for i, q in enumerate(self.data):
+            c.append("QUBIT_COORDS", [i], [float(q[0]), float(q[1])])
+        for k in range(NST):
+            c.append("QUBIT_COORDS", [AID[k]], [float(CHECKS[k]['syn'][0]), float(CHECKS[k]['syn'][1])])
+        c.append(reset, range(nq))
+        if p > 0:
+            c.append(err, range(nq), p)
+        is_det0 = lambda ch: all(P == want for P in ch['pauli'].values())   # deterministic on the init state
+        for r in range(rounds):
+            if p > 0:
+                c.append("DEPOLARIZE1", range(nq), p)               # data idle
+            se_round(c, p)
+            for k in range(NST):
+                tr = -(NST - k); co = [float(CHECKS[k]['syn'][0]), float(CHECKS[k]['syn'][1]), r]
+                if r == 0:
+                    if is_det0(CHECKS[k]):
+                        c.append("DETECTOR", [stim.target_rec(tr)], co)
+                else:
+                    c.append("DETECTOR", [stim.target_rec(tr), stim.target_rec(tr - NST)], co)
+        c.append(meas, range(nq), p if p > 0 else 0)                # basis-basis data readout
+        drec = {q: -(nq - di[q]) for q in self.data}
+        for k in close_k:                                          # closing detectors: last SE ancilla vs data
+            ch = CHECKS[k]; tr_anc = -(nq + (NST - k))
+            c.append("DETECTOR", [stim.target_rec(tr_anc)] + [stim.target_rec(drec[d]) for d in ch['pauli']],
+                     [float(ch['syn'][0]), float(ch['syn'][1]), rounds])
+        c.append("OBSERVABLE_INCLUDE", [stim.target_rec(drec[q]) for q in self.x_logical], 0)   # tracked logical
+        return c
+
+
+
+
+
+
+
+
+def se_round_chunk(system, domains=None):
+    """ONE syndrome-extraction round over ``system``'s ACTIVE stabilizers as a
+    stim circuit chunk for :meth:`CircuitBuilder.apply_syndrome_extraction`.
+
+    Emits gates on GLOBAL qubit indices; the last instruction is the single
+    ancilla measurement (builder contract).  Reuses the rotated bent-joint
+    hook-benign engine, so merged rounds with mixed domain-wall checks inherit
+    the verified hook geometry.
+    """
+    checks, aid = [], {}
+    for k, uid in enumerate(sorted(system.active_stabilizer_indices)):
+        rec = system.stabilizers[uid]
+        if rec.get('kf') is not None:
+            raise ValueError(
+                f"se_round_chunk: stabilizer at {tuple(rec['syn_coord'])} carries "
+                f"K&F relay metadata ('kf'); the bent hook-benign schedule cannot "
+                f"express a stretched check and would silently emit long-range "
+                f"gates. Merged rounds containing a seam wall must use "
+                f"DiagonalSurfaceCodeExtractionBlock(system).circuit.")
+        pauli = {tuple(system.qubit_coords[i]): P for i, P in rec['pauli'].items()}
+        typ = rec.get('type', 'Z')
+        checks.append({'syn': tuple(rec['syn_coord']),
+                       'pauli': pauli,
+                       'type': typ if typ in ('X', 'Z') else 'M',
+                       'corners': sorted(pauli)})
+        aid[k] = rec['syn_idx'] if rec.get('syn_idx') is not None \
+            else system.index_map[tuple(rec['syn_coord'])]
+    data_coords = sorted({q for ch in checks for q in ch['pauli']})
+    rb = RotatedBentJointMeasurement(data_coords, checks,
+                                     x_logical=[data_coords[0]],
+                                     domains=domains or {})
+    rb.di = {q: system.index_map[q] for q in data_coords}
+    rb.aid = aid
+    c = stim.Circuit()
+    rb._se_round_hook_benign(c, 0.0)
+    while len(c) and c[-1].name == 'TICK':      # builder contract: chunk ends on M
+        c = c[:-1]
+    return c

--- a/lightstim/qec_code/surface_code/rotated/diagonal_se.py
+++ b/lightstim/qec_code/surface_code/rotated/diagonal_se.py
@@ -1,0 +1,423 @@
+"""Diagonal syndrome-extraction schedule (Kishony & Fowler, *Surface code
+off-the-hook: diagonal syndrome-extraction scheduling*).
+
+One globally uniform gate ORDER for every patch shape and orientation —
+Z-plaquette corners coupled NW→SE→NE→SW, X-plaquette SW→NE→SE→NW (y-up frame) —
+so every ancilla hook lands on a DIAGONAL data pair and never aligns with a
+horizontal or vertical logical path.  This is what keeps boundary-deformation
+steps (grow / move-corners / shrink) fault-tolerant: their logical
+representatives bend, and an exhaustive sweep showed every N/Z zigzag variant
+caps the Z-memory distance of the grow step at 2, while this schedule reaches
+full distance d for both bases at d = 3 and 5 (``tests/test_grow_patch.py``).
+
+Slot assignment: the FIXED compact-7 table of K&F Fig 4 — no dynamic search.
+
+* Plain plaquettes (and boundary lobes, restricted to present corners) read
+  ``FIXED_SLOTS`` at their corner deltas: Z at slots 1-4, X at slots 4-7 over
+  the 7-slot coupling window.  Round depth: R | H | 7 | H | M = 11 ticks.
+* Single-cell mixed checks (corridor/recoloured-column stabilizers; not in
+  the paper) read TWO fixed variant tables (``_M_SLOTS``) keyed by the
+  (west,south)-most foot's Pauli — the single-cell twin of the wall's
+  '+'/'-' alternation, derived offline by constraint solving and selected
+  by the distance ladder (see the table's comment).
+* K&F relay (stretched) checks use the Fig 4(c) program verbatim via
+  ``_kf_events``; adjacent dominoes alternate between the two Fig 4 variants
+  (offset 0 / +2, i.e. the paper's slot-1 and slot-3 anchored circuits).
+
+The K&F Sec. II constraint (two checks sharing two anticommuting corners keep
+a consistent relative gate order) and (slot, qubit) collision-freedom are now
+VALIDATED, not searched for: ``_validate_fixed`` raises with the offending
+coordinates if a layout violates the table, instead of packing around it.
+"""
+import stim
+
+
+_NE, _NW, _SE, _SW = (1, 1), (-1, 1), (1, -1), (-1, -1)
+
+#: K&F diagonal gate orders (y-up corner deltas, data − syndrome)
+DIAGONAL_ORDERS = {'Z': (_NW, _SE, _NE, _SW), 'X': (_SW, _NE, _SE, _NW)}
+
+#: K&F Fig 4 fixed slots (1-indexed over the 7-slot window): Z gates at 1-4,
+#: X gates at 4-7.  These ARE the numbers printed on the paper's plaquettes;
+#: ``_slot_maps`` subtracts 1 to get 0-indexed circuit slots.
+FIXED_SLOTS = {
+    'Z': {_NW: 1, _NE: 3, _SW: 4, _SE: 2},
+    'X': {_NW: 7, _NE: 5, _SW: 4, _SE: 6},
+}
+
+
+#: K&F relay-template program (Fig 39 / interface plaquette): per-check slot
+#: offsets for the two-aux + shared-relay realization of a wide mixed check.
+#: A = flag aux (RX -> MZ, couples the Z feet via CZ), B = syndrome aux
+#: (RZ -> MX, couples the X feet via CX), S = shared relay (RZ -> MZ).
+#: p0 CX(A,S); p1 CZ(A,fz1)+CX(S,B); p2 CZ(A,fz2)+CX(B,fx1);
+#: p3 CX(S,A)+CX(B,fx2); p4 CX(B,S).  This IS the Fig 4(c) circuit: offset 0
+#: reproduces the paper's slot-1 anchored variant (feet at slots 2-4,
+#: 1-indexed) and offset +2 the slot-3 anchored one (feet at 4-6) — the two
+#: stretched-stabilizer schedules that alternate along the interface in
+#: Fig 4(a,b).  Adjacent dominoes share two anticommuting feet, so a uniform
+#: offset would violate the K&F Sec. II consistency constraint; the builders
+#: therefore alternate '+'/'-' along the wall.
+_KF_OFFSET = {'+': 0, '-': 2}
+
+#: Single-cell mixed (corridor/recoloured-column) checks: TWO fixed variant
+#: tables keyed by the Pauli of the check's (west-most, then south-most)
+#: foot — the single-cell twin of the wall's '+'/'-' alternation.  A
+#: recoloured column's checks alternate their foot Paulis row by row and
+#: adjacent checks share two anticommuting feet with each other AND with
+#: the neighbouring bulk plaquettes; one per-own-Pauli table cannot order
+#: all those pairs consistently (K&F Sec. II).  These tables were derived
+#: OFFLINE by constraint solving over five verified corridor layouts
+#: (straight/stacked row-4, an obstacle-detour bent corridor, an L
+#: corridor) and selected by the distance ladder: all scenarios reach
+#: p=0-clean full graphlike distance under the diagonal schedule.
+#: (Entries never exercised by a real check pattern carry the solver's
+#: canonical values.)  Keys: (corner, foot Pauli) -> 1-indexed slot.
+_M_SLOTS = (
+    # variant 0: the check's (west,south)-most foot is X-support
+    {(_NW, 'X'): 4, (_NW, 'Z'): 1, (_NE, 'X'): 1, (_NE, 'Z'): 5,
+     (_SW, 'X'): 3, (_SW, 'Z'): 1, (_SE, 'X'): 4, (_SE, 'Z'): 2},
+    # variant 1: it is Z-support
+    {(_NW, 'X'): 7, (_NW, 'Z'): 4, (_NE, 'X'): 3, (_NE, 'Z'): 1,
+     (_SW, 'X'): 1, (_SW, 'Z'): 5, (_SE, 'X'): 6, (_SE, 'Z'): 4},
+)
+
+
+def _kf_events(ch):
+    """The (slot, gate, pair) events of one K&F relay check.  ``ch`` needs
+    'offset', flag/shared/syn coords 'A'/'S'/'B', and per-side feet lists
+    'fa' (A's side) / 'fb' (B's side), each a list of (subslot, coord, gate)
+    with subslot in {0, 1} (the foot's POSITIONAL slot within the side's
+    pair — like the paper's boundary lobes, a weight-1 side keeps the slot
+    its corner position dictates, it does not slide to the first one) and
+    gate 'CX' (X-support foot, aux is control) or 'CZ' (Z-support).
+    The aux split is GEOMETRIC (each aux couples the feet on its own row),
+    not Pauli-based: back-propagation gives MX(B) = the full check and keeps
+    MZ(A)/MZ(S) deterministic for ANY foot-Pauli pattern, so the same
+    template serves mixed dominoes (2+2 split) and uniform same-type
+    dominoes (all-X or all-Z)."""
+    o = ch['offset']
+    A, S, B = ch['A'], ch['S'], ch['B']
+
+    def foot(aux, coord, gate):
+        return (gate, (aux, coord) if gate == 'CX' else (coord, aux))
+
+    ev = [(o + 0, 'CX', (A, S)), (o + 1, 'CX', (S, B))]
+    for sub, coord, gate in ch['fa']:
+        ev.append((o + 1 + sub,) + foot(A, coord, gate))
+    for sub, coord, gate in ch['fb']:
+        ev.append((o + 2 + sub,) + foot(B, coord, gate))
+    ev.extend([(o + 3, 'CX', (S, A)), (o + 4, 'CX', (B, S))])
+    return ev
+
+
+def _validate_fixed(placements):
+    """Assert the fixed table produced a legal schedule — raise, don't search.
+
+    ``placements``: list of ``(label, pauli_at, {coord: slot})`` covering every
+    check's data couplings AND the K&F relay apparatus gates.  Checks the two
+    invariants the old backtracking packer used to guarantee:
+
+    * no (slot, qubit) cell is used twice;
+    * K&F Sec. II — two checks sharing >= 2 anticommuting corners keep a
+      consistent relative gate order on them (apparatus cells carry no Pauli
+      and are exempt: ``pauli_at`` simply has no entry for them).
+    """
+    occupied = {}
+    for label, _, cm in placements:
+        for q, t in cm.items():
+            if not 0 <= t < 7:
+                raise RuntimeError(
+                    f"fixed compact-7 schedule: {label} places qubit {q} at "
+                    f"slot {t + 1}, outside the 7-slot window")
+            other = occupied.setdefault((t, q), label)
+            if other != label:
+                raise RuntimeError(
+                    f"fixed compact-7 schedule: slot {t + 1} on qubit {q} is "
+                    f"used by both {other} and {label} — this layout violates "
+                    f"the K&F Fig 4 table (fix the wall spec, do not repack)")
+    by_corner = {}
+    for k, (_, pauli_at, cm) in enumerate(placements):
+        for q in cm:
+            if q in pauli_at:
+                by_corner.setdefault(q, []).append(k)
+    pairs = {}
+    for q, ks in by_corner.items():
+        for i in range(len(ks)):
+            for j in range(i + 1, len(ks)):
+                a, b = ks[i], ks[j]
+                if placements[a][1][q] != placements[b][1][q]:
+                    pairs.setdefault((a, b), []).append(q)
+    for (a, b), qs in pairs.items():
+        if len(qs) < 2:
+            continue
+        la, _, ca = placements[a]
+        lb, _, cb = placements[b]
+        rels = {ca[q] < cb[q] for q in qs}
+        if len(rels) > 1:
+            raise RuntimeError(
+                f"fixed compact-7 schedule: K&F Sec. II consistency violated "
+                f"between {la} and {lb} on shared anticommuting corners {qs}")
+
+
+class DiagonalSurfaceCodeExtractionBlock:
+    """Drop-in alternative to :class:`RotatedSurfaceCodeExtractionBlock` using the
+    diagonal schedule.  Same contract: ``self.circuit`` is one noiseless SE round,
+    last instruction is the syndrome measurement."""
+
+    def __init__(self, system):
+        self.system = system
+        self.circuit = stim.Circuit()
+        self.coupling_slots = None    # set by _build_circuit: always 7 (K&F Fig 4)
+        self._build_circuit()
+
+    def _gather(self):
+        """Gather ALL active checks — pure X/Z plaquettes AND single-cell mixed
+        checks (type 'MIXED'/'M', e.g. corridor stabilizers).  Corners are
+        classified by the SIGN of their offset from the syn coord and then read
+        the fixed table: a plain check its own type's table, a mixed check each
+        FOOT's own Pauli's table (gates stay per-foot: CX for X-support / CZ
+        for Z-support).  A check whose feet do not sit on four distinct
+        diagonal corners cannot be expressed in the table — raise, don't guess."""
+        system = self.system
+
+        def sgn(v):
+            return (v > 0) - (v < 0)
+
+        checks, kf_checks = [], []
+        for uid in sorted(system.active_stabilizer_indices):
+            st = system.stabilizers[uid]
+            if st.get('kf') is not None:
+                kf_checks.append(self._gather_kf(st))
+                continue
+            t = st.get('type')
+            typ = t if t in ('X', 'Z') else 'M'
+            sc = st['syn_coord']
+            deltas = {}
+            pauli_of = {}
+            for di in st['data_indices']:
+                dc = system.qubit_coords[di]
+                dxy = (sgn(dc[0] - sc[0]), sgn(dc[1] - sc[1]))
+                if dxy in deltas:
+                    raise RuntimeError(
+                        f"fixed compact-7 schedule: check at {tuple(sc)} has "
+                        f"two data qubits ({tuple(system.qubit_coords[deltas[dxy]])} "
+                        f"and {tuple(dc)}) on the same {dxy} corner direction — "
+                        f"a wide check must carry 'kf' relay metadata, the "
+                        f"plain table cannot express it")
+                deltas[dxy] = di
+                pauli_of[di] = (st['pauli'][di] if typ == 'M' else typ)
+            pauli_at = {tuple(system.qubit_coords[di]): p
+                        for di, p in pauli_of.items()}
+            checks.append({'type': typ, 'syn': tuple(sc), 'syn_idx': st['syn_idx'],
+                           'deltas': deltas, 'pauli_of': pauli_of,
+                           'pauli_at': pauli_at})
+        return checks, kf_checks
+
+    def _gather_kf(self, st):
+        """One K&F relay check: resolve the apparatus coords (flag A, shared S,
+        syn B = ``syn_coord``) and split the feet GEOMETRICALLY — each foot
+        belongs to the aux one diagonal step away (its own gap side).  Both
+        Fig 4 orientations are supported and told apart by the apparatus
+        axis: A and B in the same COLUMN = vertical domino (feet above and
+        below the aux band), same ROW = horizontal domino (feet left and
+        right).  Each foot gets the POSITIONAL subslot of the Fig 4 table —
+        vertical: Z side east first, X side west first (Fig 4b); horizontal:
+        both sides north first on the '-' variant, south first on '+'
+        (Fig 4a/c) — and carries its own gate: CX for X support, CZ for Z
+        support."""
+        system = self.system
+
+        def sgn(v):
+            return (v > 0) - (v < 0)
+
+        kf = st['kf']
+        B = tuple(st['syn_coord'])
+        A = tuple(kf['flag'])
+        S = tuple(kf['shared'])
+        if A[0] == B[0] and A[1] != B[1]:
+            horizontal = False
+        elif A[1] == B[1] and A[0] != B[0]:
+            horizontal = True
+        else:
+            raise RuntimeError(
+                f"K&F relay check at {B}: apparatus A={A} and B={B} share "
+                f"neither a row nor a column — malformed wall spec")
+        axis = 0 if horizontal else 1     # feet split along this coordinate
+        feet = {A: {}, B: {}}      # aux -> {delta-from-aux: (coord, pauli)}
+        for di in st['data_indices']:
+            dc = tuple(system.qubit_coords[di])
+            p = st['pauli'][di]
+            ax = A if abs(dc[axis] - A[axis]) == 1 else B
+            if dc in (A, S, B) or abs(dc[0] - ax[0]) != 1 or abs(dc[1] - ax[1]) != 1:
+                raise RuntimeError(
+                    f"K&F relay check at {B}: foot {dc} is not one diagonal "
+                    f"step from its aux {ax} (apparatus A={A}, S={S}, B={B}) — "
+                    f"malformed wall spec")
+            dxy = (sgn(dc[0] - ax[0]), sgn(dc[1] - ax[1]))
+            if dxy in feet[ax]:
+                raise RuntimeError(
+                    f"K&F relay check at {B}: feet {feet[ax][dxy][0]} and {dc} "
+                    f"occupy the same {dxy} corner of aux {ax} — malformed "
+                    f"wall spec")
+            feet[ax][dxy] = (dc, p)
+
+        offset = _KF_OFFSET[kf['orient']]
+
+        def side(ax):
+            # K&F Fig 4 foot subslots for the stretched stabilizers.  The
+            # subslot is POSITIONAL (which end of the side's short edge), so
+            # a weight-1 side keeps the slot its corner dictates — exactly
+            # like the paper's boundary lobes.
+            # * vertical dominoes (Fig 4b): an X-support side couples its
+            #   WEST foot first (time runs west -> east on the red halves),
+            #   a Z-support side its EAST foot first.  Sides are
+            #   Pauli-uniform in every wall family we build; a hypothetical
+            #   mixed side gets the X rule.
+            # * horizontal dominoes (Fig 4a/c): the order is keyed by the
+            #   VARIANT, not the Pauli — the slot-3-anchored '-' circuit
+            #   couples both sides north first (Fig 4c: tl=4,bl=5 / tr=5,
+            #   br=6), the slot-1-anchored '+' couples both south first.
+            out = []
+            for coord, p in feet[ax].values():
+                if horizontal:
+                    north = coord[1] > ax[1]
+                    north_first = (offset == 2)
+                    sub = (0 if north else 1) if north_first else (1 if north else 0)
+                else:
+                    paulis = {q for _, q in feet[ax].values()}
+                    east_first = (paulis == {'Z'})
+                    east = coord[0] > ax[0]
+                    sub = (0 if east else 1) if east_first else (1 if east else 0)
+                out.append((sub, coord, 'CX' if p == 'X' else 'CZ'))
+            return sorted(out)
+
+        return {'A': A, 'S': S, 'B': B, 'fa': side(A), 'fb': side(B),
+                'offset': offset,
+                'syn_idx': st['syn_idx'],
+                'flag_idx': system.index_map[A],
+                'shared_idx': system.index_map[S],
+                'pauli_at': {tuple(system.qubit_coords[di]): st['pauli'][di]
+                             for di in st['data_indices']}}
+
+    def _slot_maps(self, checks, kf_checks=()):
+        """Fixed compact-7 assignment (K&F Fig 4) — a table lookup, no search.
+
+        Plain X/Z checks (any corner subset) read ``FIXED_SLOTS[type]``;
+        single-cell mixed checks read each foot's OWN Pauli's table at that
+        foot's corner; K&F relay checks are already fully determined by
+        ``_kf_events``.  Everything is then validated once.
+        """
+        system = self.system
+        slot_maps = []
+        for ch in checks:
+            tm = {}
+            # single-cell mixed checks read the _M_SLOTS variant table keyed
+            # by the (west,south)-most foot's Pauli (see the table's comment)
+            if ch['type'] == 'M':
+                feet_coords = {tuple(system.qubit_coords[di]): di
+                               for di in ch['deltas'].values()}
+                first = feet_coords[min(feet_coords)]
+                m_tab = _M_SLOTS[0 if ch['pauli_of'][first] == 'X' else 1]
+            for dxy, di in ch['deltas'].items():
+                pauli = ch['pauli_of'][di] if ch['type'] == 'M' else ch['type']
+                if pauli not in FIXED_SLOTS:
+                    raise RuntimeError(
+                        f"fixed compact-7 schedule: check at {ch['syn']} has "
+                        f"{pauli!r} support on qubit "
+                        f"{tuple(system.qubit_coords[di])} — the K&F table "
+                        f"only covers X and Z")
+                if dxy not in FIXED_SLOTS[pauli]:
+                    raise RuntimeError(
+                        f"fixed compact-7 schedule: check at {ch['syn']} has a "
+                        f"non-diagonal corner delta {dxy} (qubit "
+                        f"{tuple(system.qubit_coords[di])}) — the K&F table "
+                        f"only covers diagonal corners")
+                if ch['type'] == 'M':
+                    tm[di] = m_tab[(dxy, pauli)] - 1
+                else:
+                    tm[di] = FIXED_SLOTS[pauli][dxy] - 1
+            slot_maps.append(tm)
+
+        placements = []
+        for ch, tm in zip(checks, slot_maps):
+            placements.append(
+                (f"{ch['type']}-check@{ch['syn']}", ch['pauli_at'],
+                 {tuple(system.qubit_coords[di]): t for di, t in tm.items()}))
+            # the check's own ancilla is busy at every one of its coupling
+            # slots: register those cells too, so a collision against a K&F
+            # apparatus qubit (or anything else) on the ancilla coord raises
+            for t in tm.values():
+                placements.append(
+                    (f"{ch['type']}-check@{ch['syn']}:anc", {}, {ch['syn']: t}))
+        for ch in kf_checks:
+            feet_cm = {}
+            for slot, gate, (u, v) in _kf_events(ch):
+                for q in (u, v):
+                    if q in (ch['A'], ch['S'], ch['B']):
+                        # apparatus qubits recur across slots: one placement
+                        # per event, carrying no Pauli (collision check only)
+                        placements.append(
+                            (f"kf-apparatus@{ch['B']}:t{slot}", {}, {q: slot}))
+                    else:
+                        feet_cm[q] = slot
+            placements.append(
+                (f"kf-check@{ch['B']}", ch['pauli_at'], feet_cm))
+        _validate_fixed(placements)
+
+        return 7, slot_maps
+
+    def _build_circuit(self):
+        system = self.system
+        checks, kf_checks = self._gather()
+        T, slot_maps = self._slot_maps(checks, kf_checks)
+        self.coupling_slots = T
+
+        idx = system.index_map
+        # K&F relay apparatus: A = flag (RX -> MZ: H after reset only),
+        # B = syndrome (RZ -> MX: H before measure only), S = relay (RZ -> MZ:
+        # no H).  Plain X/M checks keep the H sandwich on both sides.
+        kf_gates = {}                 # slot -> list of ('CX'|'CZ', u_idx, v_idx)
+        for ch in kf_checks:
+            for slot, gate, (u, v) in _kf_events(ch):
+                kf_gates.setdefault(slot, []).append((gate, idx[u], idx[v]))
+
+        plain_h = [ch['syn_idx'] for ch in checks if ch['type'] in ('X', 'M')]
+        h_pre = sorted(plain_h + [ch['flag_idx'] for ch in kf_checks])
+        h_post = sorted(plain_h + [ch['syn_idx'] for ch in kf_checks])
+        syn = sorted(
+            [ch['syn_idx'] for ch in checks]
+            + [i for ch in kf_checks
+               for i in (ch['syn_idx'], ch['flag_idx'], ch['shared_idx'])])
+
+        self.circuit.append("R", syn)
+        self.circuit.append("TICK", tag="SE_start")
+        if h_pre:
+            self.circuit.append("H", h_pre)
+        self.circuit.append("TICK")
+        for t in range(T):
+            cx, cz = [], []
+            for gate, u, v in kf_gates.get(t, ()):
+                (cx if gate == 'CX' else cz).extend([u, v])
+            for ch, smap in zip(checks, slot_maps):
+                si = ch['syn_idx']
+                for di, slot in smap.items():
+                    if slot != t:
+                        continue
+                    if ch['type'] == 'X':
+                        cx.extend([si, di])       # X plaquette: CNOT(anc -> data)
+                    elif ch['type'] == 'Z':
+                        cx.extend([di, si])       # Z plaquette: CNOT(data -> anc)
+                    elif ch['pauli_of'][di] == 'X':
+                        cx.extend([si, di])       # mixed, X-support: CNOT(anc -> data)
+                    else:
+                        cz.extend([di, si])       # mixed, Z-support: CZ(data, anc)
+            if cx:
+                self.circuit.append("CNOT", cx)
+            if cz:
+                self.circuit.append("CZ", cz)
+            self.circuit.append("TICK")
+        if h_post:
+            self.circuit.append("H", h_post)
+        self.circuit.append("TICK")
+        self.circuit.append("M", syn)

--- a/lightstim/qec_code/surface_code/rotated/litinski_layouts.py
+++ b/lightstim/qec_code/surface_code/rotated/litinski_layouts.py
@@ -1,0 +1,121 @@
+"""Closed-form stage layouts of the Litinski patch rotation (Fig 45 steps 4→9).
+
+Every stage boundary comes from ONE rule, ``rect_boundary``: on each edge of a
+rectangular footprint, weight-2 lobes sit exactly where the outward virtual
+plaquette's checkerboard type equals that edge's boundary type.  Verified
+check-by-check against 800/1600-dpi crops of arXiv:1808.02892 Fig 45
+(tests/test_grow_patch.py, test_move_corners.py, test_shrink_patch.py,
+test_litinski_rotation.py), and cross-validated for rule generality against
+Kishony-Fowler's diagonal-scheduling paper Fig 5 (their 2d+1 frame).
+
+Stage map (bar-local y-up coords; the bar is (2d-1) rows × d cols, the original
+patch occupies the TOP d rows and the rotation slides it to the BOTTOM and back):
+
+* start (panels 1/4)   = ``rect_boundary(d, d, 'X', 'Z')``  — X̄ horizontal;
+* grown (panel 5)      = builder completion of ``grown_forced`` (mixed
+  convention: kept start checks + the far-end corner-pair structure);
+* moved (panel 6)      = grown with the left long edge flipped to Z;
+* shrunk (panel 7)     = ``rect_boundary(d, d, 'Z', 'X')``  — ROTATED, at the
+  bar's bottom d×d;
+* bar-2 (panel 8)      = ``rect_boundary(d, 2d-1, 'Z', 'X')`` — the rotated
+  convention extended upward (convention-preserving, no corner pair);
+* final (panel 9)      = ``rect_boundary(d, d, 'Z', 'X')`` again, at the TOP
+  tile — identical local layout to panel 7, translated back home.
+"""
+from lightstim.qec_code.surface_code.rotated.rule_based_patch import RuleBasedRectPatch
+
+
+def ptype(cx, cy, phase=0):
+    return 'X' if (((cx + cy) // 2) + phase) % 2 else 'Z'
+
+
+def rect_boundary(d_z, d_x, lr, tb, phase=0):
+    """Closed-form boundary of a ``d_z``-col × ``d_x``-row rectangular patch whose
+    left/right edges carry type ``lr`` and top/bottom edges type ``tb``: lobes sit
+    exactly where the outward virtual plaquette's checkerboard type matches."""
+    w2 = {}
+    for cy in range(2, 2 * d_x, 2):
+        for cx, sx in ((0, 1), (2 * d_z, 2 * d_z - 1)):
+            if ptype(cx, cy, phase) == lr:
+                w2[(cx, cy)] = (lr, [(sx, cy - 1), (sx, cy + 1)])
+    for cx in range(2, 2 * d_z, 2):
+        for cy, sy in ((0, 1), (2 * d_x, 2 * d_x - 1)):
+            if ptype(cx, cy, phase) == tb:
+                w2[(cx, cy)] = (tb, [(cx - 1, sy), (cx + 1, sy)])
+    return w2
+
+
+def start_w2(d, phase=0):
+    """Paper-q2 orientation d×d start boundary (Fig 45 panels 1/4)."""
+    return rect_boundary(d, d, 'X', 'Z', phase)
+
+
+def grown_forced(d, phase=0):
+    """Anchors for the grown bar (panel 5): the start's non-growth-edge checks
+    shifted to the top of the bar frame; the rule sweep completes the rest."""
+    dy = 2 * (d - 1)
+    out = {}
+    for sc, (t, sup) in start_w2(d, phase).items():
+        if sc[1] == 0:                       # growth-edge (bottom) lobes drop
+            continue
+        out[(sc[0], sc[1] + dy)] = (t, sorted((x, y + dy) for x, y in sup))
+    return out
+
+
+def grown_patch(d, phase=0):
+    """The grown (2d-1)×d reference geometry (== Fig 45 panel 5)."""
+    return RuleBasedRectPatch(distance_x=2 * d - 1, distance_z=d,
+                              forced=grown_forced(d, phase), phase=phase)
+
+
+def _w2_of(patch):
+    out = {}
+    for s in patch.stabilizers:
+        if len(s['data_indices']) == 2:
+            sc = tuple(int(round(v)) for v in s['syn_coord'])
+            out[sc] = (s['type'], sorted(tuple(int(round(v)) for v in patch.qubit_coords[i])
+                                         for i in s['data_indices']))
+    return out
+
+
+def moved_w2(d, phase=0):
+    """Panel-6 boundary: the grown bar's w2 with the left long edge flipped to Z."""
+    out = {sc: v for sc, v in _w2_of(grown_patch(d, phase)).items() if sc[0] != 0}
+    for cy in range(2, 2 * (2 * d - 1), 2):
+        if ptype(0, cy, phase) == 'Z':
+            out[(0, cy)] = ('Z', [(1, cy - 1), (1, cy + 1)])
+    return out
+
+
+def shrunk_w2(d, phase=0):
+    """Panel-7 (and panel-9) boundary: the ROTATED d×d convention."""
+    return rect_boundary(d, d, 'Z', 'X', phase)
+
+
+def bar2_w2(d, phase=0):
+    """Panel-8 boundary: the rotated convention on the full (2d-1)×d bar."""
+    return rect_boundary(d, 2 * d - 1, 'Z', 'X', phase)
+
+
+def grown_w2_full(d, phase=0):
+    """The COMPLETE grown-bar boundary (panel 5), as the rules complete it."""
+    return _w2_of(grown_patch(d, phase))
+
+
+def transpose_w2(w2):
+    """Transpose a boundary dict (x <-> y).  ``ptype`` is symmetric under
+    transposition, so the checkerboard phase is unchanged, and Pauli letters
+    are untouched (coordinate relabeling).  Identity used by the ±x growth
+    variants: transpose_w2(rect_boundary(a, b, lr, tb, ph))
+    == rect_boundary(b, a, tb, lr, ph)."""
+    return {(cy, cx): (t, sorted((y, x) for x, y in sup))
+            for (cx, cy), (t, sup) in w2.items()}
+
+
+def flip_w2(w2, Y):
+    """Mirror a boundary dict vertically (y → Y − y).  Used to build the stage
+    geometries for a +y growth direction (e.g. stim-rendering frames, which draw
+    y downward): the completed layouts are flipped and passed fully-forced, because
+    the rule sweep's lexicographic order is not mirror-symmetric."""
+    return {(cx, Y - cy): (t, sorted((x, Y - y) for x, y in sup))
+            for (cx, cy), (t, sup) in w2.items()}

--- a/lightstim/qec_code/surface_code/rotated/operation.py
+++ b/lightstim/qec_code/surface_code/rotated/operation.py
@@ -382,6 +382,10 @@ class RotatedSurfaceCodeLogicalOpSet(CSSLogicalOpSet):
             circuit_chunk=dynamical_round,
             rounds=1,
             noiseless=noiseless,
+            # The mid-cycle fold layer needs the measurement-block engine's
+            # retained-data semantics; opt in explicitly (the legacy engine
+            # is the default for calls without measurement_blocks).
+            measurement_blocks=(dynamical_round,),
         )
 
     def fold_transversal_s(

--- a/lightstim/qec_code/surface_code/rotated/rule_based_patch.py
+++ b/lightstim/qec_code/surface_code/rotated/rule_based_patch.py
@@ -1,0 +1,213 @@
+"""Rule-based rectangular rotated-surface-code patch.
+
+Builds a ``d_z × d_x`` patch by APPLYING THE CONSTRUCTION RULES rather than emitting a
+hardcoded stabilizer layout, so the boundary pattern comes out the way Litinski draws it
+(*A Game of Surface Codes*, Fig 45 step 5) rather than the way the plain
+:class:`RotatedSurfaceCode` builder happens to lay it out.
+
+The rules are the documented ones (Handbook §10.4 / Fig 33-34, mirrored from
+``multi_patch_coupler``'s deterministic construction):
+
+1. **Bulk forced** — every complete weight-4 plaquette of the footprint is taken.
+2. **Corners first** — exposed corner data qubits (≤2 orthogonal neighbours) are covered
+   first, in lexicographic order, each by the first incident boundary tile that passes the
+   vetoes.  *This is what anchors the alternating pattern of every boundary chain*, and it
+   is the step the plain builder skips — it is why the rule-based patch has two same-type
+   boundary lobes meeting at a corner (they share one data qubit, and sharing exactly one
+   qubit commutes precisely when the two are the same type).
+3. **Alternating-spacing sweep** — the remaining weight-2 candidates are swept in
+   lexicographic order and taken unless a veto applies: one lattice spacing from an
+   already-selected stabilizer *along the same edge*; anticommutes with something already
+   selected; or linearly dependent on the current selection.
+
+**Corner anchoring is for UNCOVERED corners only.**  A corner data qubit already inside
+some selected check (bulk, a forced boundary check, or an earlier corner pass) needs no
+anchor of its own; eagerly giving every corner its own tile is what mis-placed the
+same-type corner pair against Litinski Fig 45 step 5 (it landed on the mirror corner)
+and smuggled a redundant lobe next to a forced corner check against Kishony-Fowler
+Fig 5b.  With the coverage check in place, the boundary pattern of BOTH papers' grown
+patches — Litinski Fig 45 step 5 (d=3, grow down, 2d-1) and Kishony-Fowler Fig 5b
+(d=5, grow right, 2d+1, conjugate orientation) — emerges from bulk + ``forced`` + the
+plain lexicographic sweep alone, including the same-type corner pair at the far corner
+of the growth.
+
+**Destination anchoring.**  The grown bar's far side carries a mid-edge topological
+corner (a boundary-type change along one edge), and its position is a protocol input,
+not a geometric consequence: both papers pin it to the boundary of the DESTINATION
+sub-patch the later shrink step will leave behind (visible at d=5, where the free edge
+has slack; at d=3 the vetoes fix it).  The caller expresses it through ``forced``: add
+the destination patch's far-side boundary checks alongside the kept live-patch checks.
+"""
+from typing import Dict, List, Tuple
+
+from lightstim.qec_code.surface_code.rotated.code_patch import RotatedSurfaceCode
+
+
+def _sym_commute(a: Dict[Tuple[int, int], str], b: Dict[Tuple[int, int], str]) -> bool:
+    """Do two coordinate-keyed Pauli operators commute?  (X/Z-only supports.)"""
+    anti = sum(1 for q, p in a.items() if q in b and b[q] != p)
+    return anti % 2 == 0
+
+
+def _independent(sel: List[Dict], cand: Dict, coords: List[Tuple[int, int]]) -> bool:
+    """Is ``cand`` outside the GF(2) span of ``sel``?"""
+    n = len(coords)
+    idx = {q: i for i, q in enumerate(coords)}
+
+    def pack(op):
+        v = 0
+        for q, p in op.items():
+            v |= 1 << (idx[q] + (0 if p == 'X' else n))
+        return v
+
+    rows: List[int] = []
+    for op in sel:
+        v = pack(op)
+        for r in rows:
+            v = min(v, v ^ r)
+        if v:
+            rows.append(v)
+            rows.sort(reverse=True)
+    v = pack(cand)
+    for r in rows:
+        v = min(v, v ^ r)
+    return v != 0
+
+
+class RuleBasedRectPatch(RotatedSurfaceCode):
+    """A ``distance_x`` × ``distance_z`` patch whose boundary is chosen by the rules above.
+
+    Same interface as :class:`RotatedSurfaceCode` (``distance_x``/``distance_z``/``shift``),
+    so it drops straight into :meth:`QECSystem.grow_patch`.
+    """
+
+    def build(self):
+        d_x, d_z = self.distance_x, self.distance_z
+        data = [(2 * c + 1, 2 * r + 1) for c in range(d_z) for r in range(d_x)]
+        dset = set(data)
+        # ``forced``: checks that MUST be kept, given as {(syn_coord): (type, [supports])}.
+        # When growing a live patch these are the existing patch's checks, so the grown
+        # code contains them verbatim and their detector history survives the growth.
+        forced = dict(self.params.get('forced') or {})
+
+        # --- plaquette candidates: every centre with >= 2 data corners ------------
+        cxs = range(0, 2 * d_z + 1, 2)
+        cys = range(0, 2 * d_x + 1, 2)
+        phase = self.params.get('phase', 0)
+
+        def corners(cx, cy):
+            return sorted(q for q in ((cx - 1, cy - 1), (cx - 1, cy + 1),
+                                      (cx + 1, cy - 1), (cx + 1, cy + 1)) if q in dset)
+
+        def ptype(cx, cy):
+            return 'X' if (((cx + cy) // 2) + phase) % 2 else 'Z'
+
+        bulk, cands = [], []
+        for cx in cxs:
+            for cy in cys:
+                sup = corners(cx, cy)
+                if len(sup) == 4:
+                    bulk.append(((cx, cy), ptype(cx, cy), sup))
+                elif len(sup) == 2:
+                    cands.append(((cx, cy), ptype(cx, cy), sup))
+        cands.sort()
+
+        selected = list(bulk)                       # rule 1: bulk is forced
+        # rule 1b: the caller's pre-existing checks are forced too (anchoring), unless the
+        # enlarged bulk already contains them at that centre.
+        have = {c for c, _, _ in selected}
+        for sc, (t, sup) in sorted(forced.items()):
+            sup = sorted(tuple(q) for q in sup)
+            if sc not in have and all(q in dset for q in sup):
+                selected.append((tuple(sc), t, sup))
+                have.add(tuple(sc))
+
+        def op_of(entry):
+            _, t, sup = entry
+            return {q: t for q in sup}
+
+        def passes(entry):
+            (cx, cy), t, sup = entry
+            op = op_of(entry)
+            for other in selected:
+                if not _sym_commute(op, op_of(other)):
+                    return False
+                # spacing rule: one lattice spacing away ALONG THE SAME EDGE
+                (ox, oy), _, osup = other
+                if len(osup) == 2 and len(set(osup) & set(sup)) == 1 \
+                        and (ox == cx or oy == cy):
+                    return False
+            return _independent([op_of(s) for s in selected], op, data)
+
+        # --- rule 2: corners first ------------------------------------------------
+        def n_orth(q):
+            return sum(1 for dx, dy in ((2, 0), (-2, 0), (0, 2), (0, -2))
+                       if (q[0] + dx, q[1] + dy) in dset)
+
+        for cq in sorted(q for q in data if n_orth(q) <= 2):
+            # anchor only UNCOVERED corners (see module docstring): a corner already
+            # inside a selected check — bulk, forced, or an earlier corner pass — gets
+            # no eager tile of its own.  Eager per-corner selection is what mis-placed
+            # the same-type corner pair against Litinski Fig 45 step 5 and smuggled a
+            # redundant lobe next to a forced corner check against Kishony-Fowler
+            # Fig 5b; with this check, the sweep below reproduces both papers.
+            if any(cq in sup for _, _, sup in selected):
+                continue
+            for entry in cands:
+                if entry in selected or cq not in entry[2]:
+                    continue
+                if passes(entry):
+                    selected.append(entry)
+                    break
+
+        # --- rule 3: alternating-spacing sweep ------------------------------------
+        for entry in cands:
+            if entry not in selected and passes(entry):
+                selected.append(entry)
+
+        # --- register qubits ------------------------------------------------------
+        for q in data:
+            self.add_qubit(*q, role='data')
+        for (cx, cy), t, _ in selected:
+            self.add_qubit(cx, cy, role='syndrome_x' if t == 'X' else 'syndrome_z')
+
+        # --- stabilizers ----------------------------------------------------------
+        for (cx, cy), t, sup in selected:
+            self.create_stim_stabilizer({q: t for q in sup}, (cx, cy), t)
+
+        # --- logical operators: the shortest surviving X / Z chains ---------------
+        ops = [op_of(s) for s in selected]
+
+        def logical(kind, chains, partner=None):
+            """A chain that commutes with every check, is not a stabilizer, and — when a
+            ``partner`` logical is given — ANTICOMMUTES with it (the two must cross, else
+            they would not be a conjugate pair)."""
+            for sup in chains:
+                op = {q: kind for q in sup}
+                if not all(_sym_commute(op, o) for o in ops):
+                    continue
+                if not _independent(ops, op, data):
+                    continue
+                if partner is not None and _sym_commute(op, partner):
+                    continue
+                return op
+            return None
+
+        cols = [[(2 * c + 1, 2 * r + 1) for r in range(d_x)] for c in range(d_z)]
+        rows = [[(2 * c + 1, 2 * r + 1) for c in range(d_z)] for r in range(d_x)]
+        # shortest chains first, so the stored representatives are minimum-weight ones
+        chains = sorted(cols + rows, key=len)
+        x_op = logical('X', chains)
+        if x_op is None:
+            raise ValueError(f"RuleBasedRectPatch({d_x}x{d_z}): no surviving X logical chain")
+        z_op = logical('Z', chains, partner=x_op)
+        if z_op is None:
+            raise ValueError(
+                f"RuleBasedRectPatch({d_x}x{d_z}): no Z logical chain anticommuting with X̄ — "
+                f"the rule-selected boundary over-constrains this footprint")
+        self.create_stim_logical(x_op, 'X')
+        self.create_stim_logical(z_op, 'Z')
+
+        self.num_logicals = 1
+        if self.shift != (0, 0):
+            self.shift_coords(*self.shift)

--- a/notebooks/LogicalOps/ppm_lowering.ipynb
+++ b/notebooks/LogicalOps/ppm_lowering.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PPM lowering: a two-step sequence, with and without the driver\n",
+    "\n",
+    "One PPM sequence on THREE patches in a row \u2014 `M(Z\u0304A Z\u0304B)` through\n",
+    "the corridor between A and B, then `M(Z\u0304B Z\u0304C)` through the corridor\n",
+    "between B and C \u2014 built two ways: through the kernel API alone\n",
+    "(`lower_ppm` / `apply_plan` + builder primitives), then through\n",
+    "`SequentialPPMExperiment`.  Each shows the full-circuit\n",
+    "`detslice-with-ops-svg` (every tick).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = Path(\"../..\").resolve()\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "\n",
+    "import contextlib\n",
+    "import io\n",
+    "\n",
+    "import stim\n",
+    "\n",
+    "import lightstim\n",
+    "from lightstim.ir.builder import CircuitBuilder\n",
+    "from lightstim.ir.qec_system import QECSystem\n",
+    "from lightstim.ir.tracker import SyndromeTracker\n",
+    "from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode\n",
+    "from lightstim.qec_code.surface_code.rotated.bent_joint_se import (\n",
+    "    se_round_chunk)\n",
+    "from lightstim.protocols.ppm import (PatchSpec, PPMStep, PPMRequest,\n",
+    "                                     SequentialPPMExperiment, apply_plan,\n",
+    "                                     lower_ppm, origin_of)\n",
+    "\n",
+    "# the environment may alias bare lightstim imports elsewhere via a .pth -\n",
+    "# always verify which tree this notebook runs against\n",
+    "print(\"lightstim from:\", lightstim.__file__)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "D = 3          # code distance (rounds = D in every merged window)\n",
+    "\n",
+    "px = [PatchSpec('A', origin_of(0, 0, D, seam=True), D, 'X_horizontal'),\n",
+    "      PatchSpec('B', origin_of(2, 0, D, seam=True), D, 'X_horizontal'),\n",
+    "      PatchSpec('C', origin_of(4, 0, D, seam=True), D, 'X_horizontal')]\n",
+    "STATES = {'A': 'Z', 'B': 'Z', 'C': 'Z'}\n",
+    "# two DIFFERENT products through two different corridors\n",
+    "requests = [PPMRequest(targets=(('A', 'Z'), ('B', 'Z')), route=((1, 0),)),\n",
+    "            PPMRequest(targets=(('B', 'Z'), ('C', 'Z')), route=((3, 0),))]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Without `SequentialPPMExperiment`: the kernel API end to end\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "system = QECSystem()\n",
+    "for s in px:\n",
+    "    p = RotatedSurfaceCode(distance=s.distance)\n",
+    "    if s.orientation == 'X_horizontal':\n",
+    "        p.transpose_coords()\n",
+    "    system.add_patch(p, name=s.name,\n",
+    "                     offset=(s.origin[0] - 1, s.origin[1] - 1))\n",
+    "\n",
+    "plans = [lower_ppm(px, r, system=system) for r in requests]\n",
+    "for i, plan in enumerate(plans):\n",
+    "    apply_plan(system, plan, f'ppm_{i}')\n",
+    "\n",
+    "tracker = SyndromeTracker(num_qubits=system.num_qubits,\n",
+    "                          expected_num_logicals=system.num_logicals)\n",
+    "builder = CircuitBuilder(tracker=tracker, system_config=system,\n",
+    "                         if_detector=True)\n",
+    "system.register_tracker(tracker)\n",
+    "system.register_builder(builder)\n",
+    "builder.write_coordinates()\n",
+    "owner = system.index_to_owner_map\n",
+    "builder.initialize(\n",
+    "    init_dict={q: STATES[owner[q]] for q in system.data_indices\n",
+    "               if owner.get(q) in STATES},\n",
+    "    n=system.num_qubits)\n",
+    "orient = {s.name: s.orientation for s in px}\n",
+    "domains = {tuple(system.qubit_coords[q]): orient[owner[q]]\n",
+    "           for q in system.data_indices if owner.get(q) in orient}\n",
+    "builder.apply_syndrome_extraction(\n",
+    "    circuit_chunk=se_round_chunk(system, domains=domains), rounds=1)\n",
+    "\n",
+    "for i, plan in enumerate(plans):\n",
+    "    cname = f'ppm_{i}'\n",
+    "    builder.activate_coupler(cname)\n",
+    "    cp = system.coupler_patches[cname]\n",
+    "    l2g = system.local_to_global_map[cname]\n",
+    "    corridor_init = {l2g[q]: plan.corridor_init_basis\n",
+    "                     for q in cp.data_indices}\n",
+    "    builder.initialize(init_dict=corridor_init, n=system.num_qubits)\n",
+    "    merged = dict(plan.route_result.layout.domains or {})\n",
+    "    for q in system.data_indices:\n",
+    "        nm = owner.get(q)\n",
+    "        if nm in orient:\n",
+    "            merged.setdefault(tuple(system.qubit_coords[q]), orient[nm])\n",
+    "    builder.apply_syndrome_extraction(\n",
+    "        circuit_chunk=se_round_chunk(system, domains=merged), rounds=D)\n",
+    "    builder.deactivate_coupler(cname)\n",
+    "    builder.apply_data_readout(final_measurements=dict(corridor_init),\n",
+    "                               resolve_absorbed=False)\n",
+    "\n",
+    "builder.apply_data_readout(\n",
+    "    final_measurements={q: STATES[owner[q]] for q in system.data_indices\n",
+    "                        if owner.get(q) in STATES})\n",
+    "c_free = builder.circuit\n",
+    "print('qubits:', c_free.num_qubits, '| ticks:', c_free.num_ticks,\n",
+    "      '| detectors:', c_free.num_detectors,\n",
+    "      '| observables:', c_free.num_observables)\n",
+    "det, obs = c_free.compile_detector_sampler(seed=0).sample(\n",
+    "    1024, separate_observables=True)\n",
+    "print('p=0 silent:', not det.any() and not obs.any())\n",
+    "c_free.diagram('detslice-with-ops-svg', tick=range(1, c_free.num_ticks + 1))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. With `SequentialPPMExperiment`: the same sequence\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "exp = SequentialPPMExperiment(\n",
+    "    px,\n",
+    "    [PPMStep([('A', 'Z'), ('B', 'Z')], route=[(1, 0)]),\n",
+    "     PPMStep([('B', 'Z'), ('C', 'Z')], route=[(3, 0)])],\n",
+    "    initial_states=STATES, final_measure_states=STATES,\n",
+    "    rounds=D, rounds_init=1)\n",
+    "with contextlib.redirect_stdout(io.StringIO()):\n",
+    "    circuit = exp.build()\n",
+    "print('qubits:', circuit.num_qubits, '| ticks:', circuit.num_ticks,\n",
+    "      '| detectors:', circuit.num_detectors,\n",
+    "      '| observables:', circuit.num_observables)\n",
+    "det, obs = circuit.compile_detector_sampler(seed=0).sample(\n",
+    "    1024, separate_observables=True)\n",
+    "print('p=0 silent:', not det.any() and not obs.any())\n",
+    "circuit.diagram('detslice-with-ops-svg', tick=range(1, circuit.num_ticks + 1))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -47,6 +47,7 @@ notebooks/
 | `state_injection.ipynb` | `protocols/state_injection.py` | Non-FT magic-state injection (rotated SC) |
 | `two_patch_LS.ipynb` | `protocols/two_patch_ls.py` | Two-patch ZZ lattice surgery coupler |
 | `multi_patch_LS.ipynb` | *(in-progress)* | Multi-patch lattice surgery; unrotated SC N-patch coupler |
+| `ppm_lowering.ipynb` | `protocols/ppm/` | Two-step PPM sequence, built via the lowering kernel API and via the sequential driver; full-circuit detector slices |
 
 ### Memory/
 

--- a/tests/color_code/test_color_code.py
+++ b/tests/color_code/test_color_code.py
@@ -650,7 +650,9 @@ class TestColorCodeMemory:
             include_measurement_bases=True,
         )
 
-        builder.apply_syndrome_extraction(block.circuit, rounds=1)
+        builder.apply_syndrome_extraction(
+            block.circuit, rounds=1,
+            measurement_blocks=block.measurement_blocks)
 
         p9_rows = [
             i
@@ -670,9 +672,11 @@ class TestColorCodeMemory:
             {q: "X" for q in system.data_indices},
             n=code.num_qubits,
         )
+        block = ColorCodeBellMultiplexingBlock(system)
         builder.apply_syndrome_extraction(
-            ColorCodeBellMultiplexingBlock(system).circuit,
+            block.circuit,
             rounds=2,
+            measurement_blocks=block.measurement_blocks,
         )
 
         detectors = [
@@ -699,10 +703,14 @@ class TestColorCodeMemory:
             )
             block = ColorCodeBellMultiplexingBlock(system)
             if combined_rounds:
-                builder.apply_syndrome_extraction(block.circuit, rounds=3)
+                builder.apply_syndrome_extraction(
+                    block.circuit, rounds=3,
+                    measurement_blocks=block.measurement_blocks)
             else:
                 for _ in range(3):
-                    builder.apply_syndrome_extraction(block.circuit, rounds=1)
+                    builder.apply_syndrome_extraction(
+                        block.circuit, rounds=1,
+                        measurement_blocks=block.measurement_blocks)
             return builder.circuit
 
         repeated = build(combined_rounds=True)

--- a/tests/test_absorbed_census.py
+++ b/tests/test_absorbed_census.py
@@ -21,31 +21,51 @@ def _z_row(n, qubits):
     return row
 
 
-def test_census_counts_up_to_logical_equivalence():
+def test_census_dedups_representatives_at_insertion():
     # Reviewer-mandated regression: two representatives differing by a
-    # stabilizer are ONE logical relation, not two.
+    # stabilizer are ONE logical relation, not two.  The dedup happens at
+    # insertion: the second representative reduces to zero against the
+    # bank + ledger and is skipped.
     n = 4
     tracker = SyndromeTracker(n, 0)
     tracker.stabilizers.matrix = _z_row(n, [0, 1]).reshape(1, -1)
     tracker.stabilizers.records = [[0]]
     rep_a = _z_row(n, [2, 3])
     rep_b = (_z_row(n, [2, 3]) + _z_row(n, [0, 1])) % 2  # rep_a * stabilizer
-    tracker.absorbed_ops.matrix = np.vstack([rep_a, rep_b]).astype(np.uint8)
-    tracker.absorbed_ops.records = [[], []]
 
+    assert tracker.record_absorbed_op(rep_a) is True
+    assert tracker.record_absorbed_op(rep_b) is False
+    assert tracker.absorbed_ops.count == 1
     assert tracker.num_absorbed_dof() == 1
 
 
-def test_group_member_relation_holds_no_dof():
-    # A relation that has itself become a stabilizer holds no logical DOF.
+def test_group_member_relation_is_not_banked():
+    # An operator already expressed by the current stabilizer rows holds
+    # no NEW logical DOF at insertion time and must not enter the ledger.
     n = 4
     tracker = SyndromeTracker(n, 0)
     tracker.stabilizers.matrix = _z_row(n, [0, 1]).reshape(1, -1)
     tracker.stabilizers.records = [[0]]
-    tracker.absorbed_ops.matrix = _z_row(n, [0, 1]).reshape(1, -1)
-    tracker.absorbed_ops.records = [[]]
 
+    assert tracker.record_absorbed_op(_z_row(n, [0, 1])) is False
     assert tracker.num_absorbed_dof() == 0
+
+
+def test_banked_relation_survives_its_own_closure_row():
+    # After a merge, the joint's CLOSURE row (same relation, carrying the
+    # merge records) legitimately enters the stabilizer bank.  The banked
+    # DOF must keep counting — the census is the ledger's own rank, never
+    # quotiented by the bank (regression for the measurement-block round
+    # over post-PPM state, where the quotient version tripped the alarm).
+    n = 4
+    tracker = SyndromeTracker(n, 1)
+    assert tracker.record_absorbed_op(_z_row(n, [0, 1])) is True
+    # the closure row appears in the bank AFTER the relation was banked
+    tracker.stabilizers.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.stabilizers.records = [[3]]
+
+    assert tracker.num_absorbed_dof() == 1
+    tracker.validate_logical_count(context="closure row coexists")
 
 
 def test_alarm_fires_when_a_relation_is_lost():

--- a/tests/test_absorbed_census.py
+++ b/tests/test_absorbed_census.py
@@ -1,0 +1,98 @@
+"""Absorbed-DOF census: one ledger, derived count, logical equivalence.
+
+absorbed_ops is the single census ledger — every path that absorbs a
+logical DOF records the OPERATOR; the count is always derived as
+rank([stabilizers; absorbed]) - rank(stabilizers).  There is deliberately
+no separately maintained integer (the old `_absorbed_logical_dofs` counter
+demanded perfect increment/decrement pairing from every path and drifted
+silently when one forgot).  Geometry-independent, like
+test_tracker_closure_contract.
+"""
+import numpy as np
+import pytest
+
+from lightstim.ir.tracker import SyndromeTracker
+
+
+def _z_row(n, qubits):
+    row = np.zeros(2 * n, dtype=np.uint8)
+    for q in qubits:
+        row[n + q] = 1
+    return row
+
+
+def test_census_counts_up_to_logical_equivalence():
+    # Reviewer-mandated regression: two representatives differing by a
+    # stabilizer are ONE logical relation, not two.
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    tracker.stabilizers.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.stabilizers.records = [[0]]
+    rep_a = _z_row(n, [2, 3])
+    rep_b = (_z_row(n, [2, 3]) + _z_row(n, [0, 1])) % 2  # rep_a * stabilizer
+    tracker.absorbed_ops.matrix = np.vstack([rep_a, rep_b]).astype(np.uint8)
+    tracker.absorbed_ops.records = [[], []]
+
+    assert tracker.num_absorbed_dof() == 1
+
+
+def test_group_member_relation_holds_no_dof():
+    # A relation that has itself become a stabilizer holds no logical DOF.
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    tracker.stabilizers.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.stabilizers.records = [[0]]
+    tracker.absorbed_ops.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.absorbed_ops.records = [[]]
+
+    assert tracker.num_absorbed_dof() == 0
+
+
+def test_alarm_fires_when_a_relation_is_lost():
+    n = 4
+    tracker = SyndromeTracker(n, 1)  # budget: one logical DOF somewhere
+    tracker.absorbed_ops.matrix = _z_row(n, [2, 3]).reshape(1, -1)
+    tracker.absorbed_ops.records = [[]]
+    tracker.validate_logical_count(context="healthy state")  # no raise
+
+    # A path that loses the relation without accounting for it must trip
+    # the alarm at the next validation — the ledger IS the count, so the
+    # two can no longer drift apart silently.
+    tracker.absorbed_ops.matrix = np.zeros((0, 2 * n), dtype=np.uint8)
+    tracker.absorbed_ops.records = []
+    with pytest.raises(RuntimeError, match="absorbed logical DOFs"):
+        tracker.validate_logical_count(context="after losing the relation")
+
+
+def test_block_absorb_records_the_operator():
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    consumed = _z_row(n, [1, 2])
+    tracker._gauge_logical_vectors = [np.array([1], dtype=np.uint8)]
+
+    tracker._record_measurement_logical_effects(
+        set(), old_logicals_current_frame=consumed.reshape(1, -1))
+
+    assert tracker.absorbed_ops.count == 1
+    assert (tracker.absorbed_ops.matrix[0] == consumed).all()
+    assert tracker.num_absorbed_dof() == 1
+
+
+def test_block_absorb_skips_surviving_logicals():
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    tracker._gauge_logical_vectors = [np.array([1], dtype=np.uint8)]
+
+    tracker._record_measurement_logical_effects(
+        {0}, old_logicals_current_frame=_z_row(n, [1, 2]).reshape(1, -1))
+
+    assert tracker.absorbed_ops.count == 0
+    assert tracker.num_absorbed_dof() == 0
+
+
+def test_block_absorb_requires_the_frame():
+    tracker = SyndromeTracker(4, 0)
+    tracker._gauge_logical_vectors = [np.array([1], dtype=np.uint8)]
+
+    with pytest.raises(ValueError, match="cannot be recorded"):
+        tracker._record_measurement_logical_effects(set())

--- a/tests/test_absorbed_census.py
+++ b/tests/test_absorbed_census.py
@@ -96,3 +96,36 @@ def test_block_absorb_requires_the_frame():
 
     with pytest.raises(ValueError, match="cannot be recorded"):
         tracker._record_measurement_logical_effects(set())
+
+
+def test_reset_folds_relation_off_reset_qubits_mod_group():
+    # A relation is only defined mod the stabilizer group: when qubit 0 is
+    # re-initialized, Z0Z1 survives as Z1Z2 via the group element Z0Z2.
+    n = 4
+    tracker = SyndromeTracker(n, 1)
+    tracker.stabilizers.matrix = _z_row(n, [0, 2]).reshape(1, -1)
+    tracker.stabilizers.records = [[0]]
+    tracker.absorbed_ops.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.absorbed_ops.records = [[]]
+
+    tracker.reset_records_for_qubits([0])
+
+    assert tracker.absorbed_ops.count == 1
+    assert (tracker.absorbed_ops.matrix[0] == _z_row(n, [1, 2])).all()
+    assert tracker.num_absorbed_dof() == 1
+    tracker.validate_logical_count(context="after fold")  # still accounted
+
+
+def test_reset_annihilates_unfoldable_relation_and_alarm_fires():
+    # No group element can move Z0Z1 off qubit 0: the re-init destroys the
+    # relation.  The row is dropped and the census alarm reports the loss.
+    n = 4
+    tracker = SyndromeTracker(n, 1)
+    tracker.absorbed_ops.matrix = _z_row(n, [0, 1]).reshape(1, -1)
+    tracker.absorbed_ops.records = [[]]
+
+    tracker.reset_records_for_qubits([0])
+
+    assert tracker.absorbed_ops.count == 0
+    with pytest.raises(RuntimeError, match="absorbed logical DOFs"):
+        tracker.validate_logical_count(context="after destructive reset")

--- a/tests/test_declare_logical.py
+++ b/tests/test_declare_logical.py
@@ -1,0 +1,85 @@
+"""tracker.declare_logical — record-seeded logical birth (Gidney Y-init, C1).
+
+A protocol (e.g. the in-place Y-basis initialization, arXiv:2302.07395) can
+leave a would-be logical operator DETERMINED by the tracked stabilizer rows:
+its sign is the XOR of the pinning rows' measurement records. LightStim's
+implicit promotion only births records-less rows; declare_logical is the
+explicit path: move the operator into self.logicals carrying the pinning
+records, drop one pinning stabilizer row (rank preserved), budget += 1.
+"""
+import numpy as np
+import pytest
+
+from lightstim.ir.tracker import SyndromeTracker
+
+
+def _tracker(n, rows, records):
+    t = SyndromeTracker(num_qubits=n, expected_num_logicals=0)
+    t.stabilizers.add_stabilizers(np.array(rows, dtype=np.uint8),
+                                  [list(r) for r in records])
+    return t
+
+
+def _z(n, *qs):
+    v = np.zeros(2 * n, dtype=np.uint8)
+    for q in qs:
+        v[n + q] = 1
+    return v
+
+
+def _x(n, *qs):
+    v = np.zeros(2 * n, dtype=np.uint8)
+    for q in qs:
+        v[q] = 1
+    return v
+
+
+def test_moves_row_records_and_budget():
+    # stabilizers: Z0 (pinned by record 3), Z1 (reset row, no records)
+    n = 2
+    t = _tracker(n, [_z(n, 0), _z(n, 1)], [[3], []])
+    recs = t.declare_logical(_z(n, 0, 1))
+    assert sorted(recs) == [3]
+    assert t.logicals.count == 1
+    assert sorted(t.logicals.records[0]) == [3]
+    assert np.array_equal(t.logicals.matrix[0], _z(n, 0, 1))
+    assert t.stabilizers.count == 1          # one pinning row removed
+    assert t.expected_num_logicals == 1      # budget bumped at declare time
+    # the operator is no longer derivable from stabilizers alone
+    with pytest.raises(ValueError):
+        t.declare_logical(_z(n, 0, 1))
+
+
+def test_record_xor_cancels_duplicates():
+    # Y_L-style: pinned by two rows sharing a record -> XOR cancels it
+    n = 3
+    t = _tracker(n, [_z(n, 0), _z(n, 1), _z(n, 2)], [[5, 9], [9], []])
+    recs = t.declare_logical(_z(n, 0, 1, 2))
+    assert sorted(recs) == [5]
+
+
+def test_rejects_undetermined_operator():
+    n = 2
+    t = _tracker(n, [_z(n, 0), _z(n, 1)], [[], []])
+    with pytest.raises(ValueError, match="not determined|span"):
+        t.declare_logical(_x(n, 0))
+    # tracker unchanged after the failed declare
+    assert t.stabilizers.count == 2 and t.logicals.count == 0
+    assert t.expected_num_logicals == 0
+
+
+def test_explicit_records_override():
+    n = 2
+    t = _tracker(n, [_z(n, 0), _z(n, 1)], [[3], []])
+    recs = t.declare_logical(_z(n, 0, 1), records=[7, 8])
+    assert sorted(recs) == [7, 8]
+    assert sorted(t.logicals.records[0]) == [7, 8]
+
+
+def test_census_guardrail_consistent_after_declare():
+    # (absorbed + logicals.count) == expected must hold right after declare
+    n = 2
+    t = _tracker(n, [_z(n, 0), _z(n, 1)], [[3], []])
+    t.declare_logical(_z(n, 0, 1))
+    absorbed = getattr(t, 'absorbed_logical_rank', 0) or 0
+    assert absorbed + t.logicals.count == t.expected_num_logicals

--- a/tests/test_dormant_qubit_reuse.py
+++ b/tests/test_dormant_qubit_reuse.py
@@ -1,0 +1,75 @@
+"""add_patch on dormant (retired) qubit indices must clear retirement state.
+
+The retire bookkeeping (retired-qubit masking, Fix C absorbed-relation
+resolution) treats every index in tracker.retired_qubits as measured-out.
+When add_patch re-births a patch on those indices, the qubits are live
+again: leaving them marked retired makes later retirements resolve
+absorbed relations against a live qubit.  The coupler-activation path
+already discards reused indices; this pins the ordinary add_patch path.
+"""
+import numpy as np
+import pytest
+
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode
+from lightstim.qec_code.surface_code.rotated.SE_block import (
+    RotatedSurfaceCodeExtractionBlock,
+)
+
+D = 3
+
+
+def _retired_system():
+    """P born, stabilized, read out, retired; every P qubit dormant."""
+    system = QECSystem()
+    system.add_patch(RotatedSurfaceCode(distance=D), name="P", offset=(0, 0))
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system,
+                             if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.initialize(init_dict={q: 'Z' for q in system.data_indices},
+                       n=system.num_qubits)
+    builder.apply_syndrome_extraction(
+        circuit_chunk=RotatedSurfaceCodeExtractionBlock(system).circuit,
+        rounds=1)
+    p_data = sorted(system.data_indices)
+    builder.apply_data_readout(
+        final_measurements={q: 'Z' for q in p_data})
+    system.retire_measured_patch("P")
+    # retire_measured_patch leaves syndrome ancillas active; park them too so
+    # a same-footprint rebirth exercises pure dormant reuse.
+    system.active_qubit_indices.difference_update(system.syndrome_indices)
+    return system, tracker, set(p_data)
+
+
+def test_add_patch_reuse_clears_retired_qubits():
+    system, tracker, p_data = _retired_system()
+    assert p_data <= tracker.retired_qubits  # retirement really happened
+
+    system.add_patch(RotatedSurfaceCode(distance=D), name="Q", offset=(0, 0))
+
+    reused = set(system.local_to_global_map["Q"].values())
+    assert reused & p_data, "rebirth did not reuse the dormant indices"
+    assert tracker.retired_qubits.isdisjoint(reused), (
+        "reused qubits are still marked retired")
+
+
+def test_add_patch_reuse_rejects_stale_tracker_support():
+    system, tracker, p_data = _retired_system()
+    q0 = min(p_data)
+    # Corrupt: a stabilizer row still referencing the retired qubit.  The
+    # retirement contract eliminated these columns; rebirth on top of a
+    # stale tableau must fail loud, not silently build.
+    n = tracker.num_qubits
+    row = np.zeros(2 * n, dtype=np.uint8)
+    row[n + q0] = 1
+    tracker.stabilizers.matrix = row.reshape(1, -1)
+    tracker.stabilizers.records = [[0]]
+
+    with pytest.raises(RuntimeError, match="stale retirement state"):
+        system.add_patch(RotatedSurfaceCode(distance=D), name="Q",
+                         offset=(0, 0))

--- a/tests/test_grow_patch.py
+++ b/tests/test_grow_patch.py
@@ -1,0 +1,140 @@
+"""Circuit-level grow_patch verification with the rule-based (paper) geometry.
+
+Litinski Fig 45 step 4->5: the paper-q2-orientation d×d patch grows DOWN through its
+Z boundary onto the (2d-1)×d bar (new data qubits initialised |+>), geometry from
+``RuleBasedRectPatch(..., pair_type='X')`` — the layout verified check-by-check against
+panel 5 in ``test_rule_based_patch.py``.
+
+Gates (spec §5): p=0 detectors quiet + observable deterministic (both memory bases,
+i.e. both logicals' eigenvalues are carried through the growth); anchoring — 7/8 (d=3)
+resp. 22/24 (d=5) old checks keep their uid across the grow; noisy graphlike
+distance == d.
+
+Scheduling note: boundary-deformation steps NEED the K&F diagonal schedule.  The
+grown bar's Z̄ representative bends (vertical left leg + horizontal bottom leg), and
+an exhaustive sweep of every (phase-1, phase-2) combination of the N/Z variants
+('perpendicular'/'swapped'/'parallel') caps the Z-memory graphlike distance at 2 —
+hook pairs around the handoff seam are unavoidable for any single N/Z orientation.
+The diagonal schedule (hooks never align with any logical direction) reaches full
+distance for both bases at d = 3 and 5.  For PLAIN memory on the mirrored (paper-q2)
+patch, the N/Z block still works if and only if ``scheduling='swapped'`` — kept as a
+regression witness below.
+"""
+import pytest
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.qec_code.surface_code.rotated.SE_block import (
+    RotatedSurfaceCodeExtractionBlock)
+from lightstim.qec_code.surface_code.rotated.diagonal_se import (
+    DiagonalSurfaceCodeExtractionBlock)
+from lightstim.qec_code.surface_code.rotated.rule_based_patch import RuleBasedRectPatch
+from lightstim.noise.config import NoiseConfig
+
+pytestmark = pytest.mark.smoke
+
+NP = NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3, p_reset=1e-3, p_idle=1e-3)
+
+
+# closed-form stage layouts live in the library now (litinski_layouts); the names are
+# re-exported here because the demo notebook and sibling test modules import them
+from lightstim.qec_code.surface_code.rotated.litinski_layouts import (   # noqa: F401
+    ptype, start_w2 as paper_start_w2, grown_forced)
+
+
+def build_grow_memory(d, basis):
+    """Init memory in ``basis`` -> d SE rounds -> grow -> d SE rounds -> readout."""
+    dy = 2 * (d - 1)
+    start = RuleBasedRectPatch(distance_x=d, distance_z=d,
+                               forced=paper_start_w2(d), phase=0)
+    system = QECSystem()
+    system.add_patch(start, offset=(0, dy), name="q2")
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.write_coordinates()
+    builder.initialize({q: basis for q in sorted(system.data_indices)},
+                       n=system.num_qubits)
+    se = DiagonalSurfaceCodeExtractionBlock(system)
+    builder.apply_syndrome_extraction(se.circuit, rounds=d)
+
+    grown_geom = RuleBasedRectPatch(distance_x=2 * d - 1, distance_z=d,
+                                    forced=grown_forced(d), phase=0)
+    old_active = set(system.active_stabilizer_indices)
+    new_data, _ = system.grow_patch("q2", grown_geom, offset=(0, 0))
+    kept = len(old_active & set(system.active_stabilizer_indices))
+
+    # growth through the Z boundary extends Z̄, so the new region is initialised in
+    # the Z basis — |0⟩, NOT the spec's original |+⟩ (Fig 40d transposed: "wider
+    # patch" = X̄-extension = X-basis init; confirmed by the K&F reference
+    # implementation, patch_rotation_manual.py, z=1 block reset="z").  Every new
+    # Z check is then first-round deterministic (Fig 41 trivial outcome) — the
+    # retiring lobes' successors continue their banked values and every
+    # handoff-window error is detector-spanned.
+    builder.initialize({q: 'Z' for q in new_data}, n=system.num_qubits)
+    se2 = DiagonalSurfaceCodeExtractionBlock(system)
+    builder.apply_syndrome_extraction(se2.circuit, rounds=d)
+    builder.apply_data_readout({q: basis for q in sorted(system.data_indices)})
+    return builder, kept, new_data
+
+
+def _check(d, basis, kept_expect):
+    builder, kept, new_data = build_grow_memory(d, basis)
+    assert len(new_data) == (d - 1) * d
+    assert kept == kept_expect
+    det, obs = builder.circuit.compile_detector_sampler(seed=0).sample(
+        512, separate_observables=True)
+    assert not det.any(), f"d={d} {basis}: detector fired at p=0"
+    assert not obs.any(), f"d={d} {basis}: observable not deterministic at p=0"
+    noisy = builder.build_noisy_circuit(noise_params=NP, noise_model='circuit_level')
+    noisy.detector_error_model(decompose_errors=True)
+    assert len(noisy.shortest_graphlike_error()) == d
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_grow_d3(basis):
+    _check(3, basis, kept_expect=7)
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_grow_d5(basis):
+    _check(5, basis, kept_expect=22)
+
+
+def test_diagonal_fixed_table_is_seven_slots():
+    """The schedule is the FIXED compact-7 table of K&F Fig 4 (Z at slots 1-4,
+    X at 4-7) — a lookup, not a packing search, so T is always exactly 7."""
+    d = 3
+    dy = 2 * (d - 1)
+    system = QECSystem()
+    system.add_patch(RuleBasedRectPatch(distance_x=d, distance_z=d,
+                                        forced=paper_start_w2(d), phase=0),
+                     offset=(0, dy), name="q2")
+    assert DiagonalSurfaceCodeExtractionBlock(system).coupling_slots == 7
+
+
+def test_mirror_patch_needs_swapped_scheduling():
+    """Regression witness for the scheduling discovery: with the default
+    'perpendicular' zigzag the mirrored start patch's memory distance halves."""
+    d = 3
+    start = RuleBasedRectPatch(distance_x=d, distance_z=d,
+                               forced=paper_start_w2(d), phase=0)
+    system = QECSystem()
+    system.add_patch(start, offset=(0, 0), name="q")
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.write_coordinates()
+    builder.initialize({q: 'X' for q in sorted(system.data_indices)},
+                       n=system.num_qubits)
+    se = RotatedSurfaceCodeExtractionBlock(system, scheduling='perpendicular')
+    builder.apply_syndrome_extraction(se.circuit, rounds=d)
+    builder.apply_data_readout({q: 'X' for q in sorted(system.data_indices)})
+    noisy = builder.build_noisy_circuit(noise_params=NP, noise_model='circuit_level')
+    noisy.detector_error_model(decompose_errors=True)
+    assert len(noisy.shortest_graphlike_error()) == 2

--- a/tests/test_move_corners.py
+++ b/tests/test_move_corners.py
@@ -1,0 +1,125 @@
+"""Circuit-level verification of move_corners (Litinski Fig 45 step 5→6).
+
+Ground truth read check-by-check off 800/1600-dpi crops of Fig 45 panel 6
+(d=3 grown bar after the corner movement):
+
+* ALL 8 bulk checks unchanged (Fig 40b: only boundary stabilizers change);
+* top Z(2,10), right-upper X(6,8), bottom X(2,0), right-lower Z(6,2) kept verbatim;
+* the LEFT long edge flips X→Z: X(0,6), X(0,2) retire; Z(0,8), Z(0,4) appear.
+
+Topological effect: the same-type corner wrap moves from the bottom-left (X pair
+of panel 5) to the top-left (Z pair: Z(0,8)+Z(2,10) share (1,9)) — matching the
+transposed structure of Kishony-Fowler Fig 5 b→c (they flip the long bottom edge
+of their horizontal bar).  No data qubits are added or removed.
+
+Sequence under test: start (d rounds) → grow (|0⟩ region, d rounds) →
+move_corners (d rounds, no init) → readout.  Gates: p=0 determinism, uid
+anchoring across BOTH deformations, graphlike distance == d for both bases.
+"""
+import pytest
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.qec_code.surface_code.rotated.diagonal_se import (
+    DiagonalSurfaceCodeExtractionBlock)
+from lightstim.qec_code.surface_code.rotated.rule_based_patch import RuleBasedRectPatch
+from lightstim.noise.config import NoiseConfig
+
+from tests.test_grow_patch import paper_start_w2, grown_forced
+
+pytestmark = pytest.mark.smoke
+
+NP = NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3, p_reset=1e-3, p_idle=1e-3)
+
+
+# the layout generators live in the library now; re-exported for the notebook
+from lightstim.qec_code.surface_code.rotated.litinski_layouts import (   # noqa: F401
+    grown_patch, moved_w2)
+
+
+PANEL6_W2 = {   # Fig 45 panel 6, hand-read ground truth (d=3)
+    (2, 10): ('Z', [(1, 9), (3, 9)]),
+    (6, 8):  ('X', [(5, 7), (5, 9)]),
+    (0, 8):  ('Z', [(1, 7), (1, 9)]),
+    (0, 4):  ('Z', [(1, 3), (1, 5)]),
+    (2, 0):  ('X', [(1, 1), (3, 1)]),
+    (6, 2):  ('Z', [(5, 1), (5, 3)]),
+}
+
+
+def test_moved_boundary_matches_panel6():
+    assert moved_w2(3) == {sc: (t, sorted(map(tuple, sup)))
+                           for sc, (t, sup) in PANEL6_W2.items()}
+
+
+def test_moved_geometry_is_valid_code():
+    d = 5
+    patch = RuleBasedRectPatch(distance_x=2 * d - 1, distance_z=d,
+                               forced=moved_w2(d), phase=0)
+    n = len(patch.data_indices)
+    assert len(patch.stabilizers) == n - 1
+    # bulk identical to the grown bar's
+    grown_bulk = {tuple(map(int, s['syn_coord'])): s['type']
+                  for s in grown_patch(d).stabilizers if len(s['data_indices']) == 4}
+    moved_bulk = {tuple(map(int, s['syn_coord'])): s['type']
+                  for s in patch.stabilizers if len(s['data_indices']) == 4}
+    assert moved_bulk == grown_bulk
+
+
+def build_rotation_prefix(d, basis):
+    """start → grow → move_corners, d diagonal rounds each, then readout."""
+    dy = 2 * (d - 1)
+    system = QECSystem()
+    system.add_patch(RuleBasedRectPatch(distance_x=d, distance_z=d,
+                                        forced=paper_start_w2(d), phase=0),
+                     offset=(0, dy), name="q2")
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.write_coordinates()
+    builder.initialize({q: basis for q in sorted(system.data_indices)},
+                       n=system.num_qubits)
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    new_data, _ = system.grow_patch("q2", grown_patch(d), offset=(0, 0))
+    builder.initialize({q: 'Z' for q in new_data}, n=system.num_qubits)
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+    kept_grow = len(system.active_stabilizer_indices)
+
+    moved_geom = RuleBasedRectPatch(distance_x=2 * d - 1, distance_z=d,
+                                    forced=moved_w2(d), phase=0)
+    old_active = set(system.active_stabilizer_indices)
+    md, _ = system.move_corners("q2", moved_geom, offset=(0, 0))
+    kept_move = len(old_active & set(system.active_stabilizer_indices))
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    builder.apply_data_readout({q: basis for q in sorted(system.data_indices)})
+    return builder, kept_move
+
+
+def _check(d, basis, kept_expect):
+    builder, kept_move = build_rotation_prefix(d, basis)
+    assert kept_move == kept_expect     # bulk + unchanged boundary keep their uid
+    det, obs = builder.circuit.compile_detector_sampler(seed=0).sample(
+        512, separate_observables=True)
+    assert not det.any(), f"d={d} {basis}: detector fired at p=0"
+    assert not obs.any(), f"d={d} {basis}: observable not deterministic at p=0"
+    noisy = builder.build_noisy_circuit(noise_params=NP, noise_model='circuit_level')
+    noisy.detector_error_model(decompose_errors=True)
+    assert len(noisy.shortest_graphlike_error()) == d
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_move_corners_d3(basis):
+    _check(3, basis, kept_expect=12)    # 14 checks, 2 left-edge lobes retire
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_move_corners_d5(basis):
+    _check(5, basis, kept_expect=40)    # 44 checks, 4 left-edge lobes retire

--- a/tests/test_ppm_lowering.py
+++ b/tests/test_ppm_lowering.py
@@ -1,0 +1,116 @@
+"""The pure PPM lowering kernel: request in, plan + certificate out.
+
+lower_ppm() must not mutate the system; apply_plan() is the single
+registration step; the certificate carries the named algebraic oracle —
+including the true-weight-w guarantee (no single logical, no proper
+subset product leaks).  Y letters and missing routes are rejected
+explicitly, never silently rewritten.
+"""
+import contextlib
+import io
+
+import pytest
+
+from lightstim.protocols.ppm.spec import PatchSpec, PPMStep, origin_of
+from lightstim.protocols.ppm.lowering import (
+    PPMRequest, UnsupportedPauliError, lower_ppm)
+from lightstim.protocols.ppm.coupler import route_and_build
+from lightstim.protocols.ppm.seam_rules import SeamRuleError
+from lightstim.protocols.ppm.sequential import SequentialPPMExperiment
+
+D = 3
+
+
+def _spec(nm, a, b, o):
+    return PatchSpec(nm, origin_of(a, b, D, seam=True), D, o)
+
+
+def _built_zz_experiment():
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 0, "X_horizontal")]
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0)])],
+        initial_states={"A": "Z", "B": "Z"},
+        final_measure_states={"A": "Z", "B": "Z"},
+        rounds=D, rounds_init=1)
+    with contextlib.redirect_stdout(io.StringIO()):
+        exp.build()
+    return exp
+
+
+def test_lower_zz_pair_plan_fields():
+    exp = _built_zz_experiment()
+    plan = exp._plans[0]
+    assert plan.kind == 'corridor'
+    assert plan.bus == 'Z'
+    assert plan.corridor_init_basis == 'X'
+    assert plan.schedule == 'bent'
+    assert plan.merged_checks, "plan must expose the merged check set"
+    assert not plan.has_stretched_checks
+
+
+def test_certificate_names_the_instrument_guarantees():
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 0, "X_horizontal")]
+    r = route_and_build(px, [("A", "Z"), ("B", "Z")], seam=True,
+                        route=[(1, 0)])
+    assert r.ok and r.certificate is not None
+    for item in ("commute", "joint", "no_single", "no_subjoint",
+                 "logical_count"):
+        assert r.certificate[item] is True, item
+    exp = _built_zz_experiment()
+    cert = exp._plans[0].certificate
+    assert cert is not None and cert.ok
+    # the true weight-w guarantee: the joint is measured and NO pairwise /
+    # single logical information leaks (a different quantum instrument).
+    assert cert.measures_exactly_the_product
+
+
+def test_y_letter_rejected_explicitly():
+    with pytest.raises(UnsupportedPauliError, match="different quantum"):
+        PPMRequest(targets=(("A", "Y"), ("B", "Z")), route=())
+
+
+def test_route_is_required_no_autorouter():
+    with pytest.raises(ValueError, match="no auto-router"):
+        PPMRequest(targets=(("A", "Z"), ("B", "Z")), route=None)
+
+
+def test_adjacent_pair_requires_live_system():
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 1, 0, "X_horizontal")]
+    req = PPMRequest(targets=(("A", "Z"), ("B", "Z")), route=())
+    with pytest.raises(ValueError, match="live probe"):
+        lower_ppm(px, req, system=None)
+
+
+def test_lower_ppm_is_pure_apply_is_the_mutation():
+    exp = _built_zz_experiment()
+    n_couplers = len(exp.system.coupler_patches)
+    req = PPMRequest(targets=(("A", "Z"), ("B", "Z")), route=((1, 0),))
+    plan = lower_ppm(exp._specs(), req, system=exp.system)
+    assert len(exp.system.coupler_patches) == n_couplers, \
+        "lower_ppm mutated the system"
+    assert plan.route_result.ok
+
+
+def test_wall_plan_and_bent_conflict():
+    # Rule row 2 (same letter, different patch types; the
+    # test_row2_same_pauli_diff_type_wall configuration): stretched-wall
+    # construction, diagonal schedule mandatory.
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 0, 1, "X_vertical")]
+    seq = [PPMStep([("A", "X"), ("B", "X")], route=[])]
+    states = {"A": "X", "B": "X"}
+    exp = SequentialPPMExperiment(
+        px, seq, initial_states=states, final_measure_states=states,
+        rounds=D, rounds_init=1, colour_swapped={"B"})
+    with contextlib.redirect_stdout(io.StringIO()):
+        exp.build()
+    plan = exp._plans[0]
+    assert plan.kind == 'wall'
+    assert plan.schedule == 'diagonal'
+    assert plan.wall is not None
+
+    bad = SequentialPPMExperiment(
+        px, seq, initial_states=states, final_measure_states=states,
+        rounds=D, rounds_init=1, schedule='bent', colour_swapped={"B"})
+    with pytest.raises(SeamRuleError, match="bent"):
+        with contextlib.redirect_stdout(io.StringIO()):
+            bad.build()

--- a/tests/test_ppm_matrix.py
+++ b/tests/test_ppm_matrix.py
@@ -1,0 +1,149 @@
+"""Verification-matrix additions (review item 5).
+
+- a larger-weight joint (weight 4) with the exactly-the-product
+  certificate;
+- a d=5 representative (slow-marked);
+- composition with the measurement-block engine on post-PPM tracker
+  state, driven through the compiler-facing kernel API (lower_ppm /
+  apply_plan + builder primitives, no experiment driver).
+"""
+import contextlib
+import io
+
+import numpy as np
+import pytest
+
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode
+from lightstim.qec_code.surface_code.rotated.SE_block import (
+    RotatedSurfaceCodeExtractionBlock,
+)
+from lightstim.qec_code.surface_code.rotated.bent_joint_se import (
+    se_round_chunk,
+)
+from lightstim.protocols.ppm.spec import PatchSpec, PPMStep, origin_of
+from lightstim.protocols.ppm.lowering import (PPMRequest, apply_plan,
+                                              lower_ppm)
+from lightstim.protocols.ppm.sequential import SequentialPPMExperiment
+
+D = 3
+
+
+def _spec(nm, a, b, o, d=D):
+    return PatchSpec(nm, origin_of(a, b, d, seam=True), d, o)
+
+
+def _build(exp):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return exp.build()
+
+
+def test_weight4_straight_chain_is_an_explicit_gap():
+    """KNOWN GAP fixture (review: leave a reproducible test, not a prose
+    TODO): a weight-4 joint on a straight chain needs the snake / kf-wall
+    attach machinery that this minimal explicit-route variant deliberately
+    does not carry — alternating seam parity strands the far targets.  The
+    physics layer rejects it loudly with the exact reason; nothing
+    silently degrades.  Supported target weights today: 2 and 3 (T
+    corridor); see the capability table."""
+    from lightstim.protocols.ppm.spec import BentLayoutError
+    px = [_spec("q1", 0, 0, "X_horizontal"), _spec("q2", 2, 0, "X_horizontal"),
+          _spec("q3", 4, 0, "X_horizontal"), _spec("q4", 6, 0, "X_horizontal")]
+    st = {q: "Z" for q in ("q1", "q2", "q3", "q4")}
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("q1", "Z"), ("q2", "Z"), ("q3", "Z"), ("q4", "Z")],
+                     route=[(1, 0), (3, 0), (5, 0)])],
+        initial_states=st, final_measure_states=st, rounds=D, rounds_init=1)
+    with pytest.raises(BentLayoutError, match="never reaches the corridor"):
+        _build(exp)
+
+
+@pytest.mark.slow
+def test_zz_pair_full_distance_d5():
+    d = 5
+    px = [_spec("A", 0, 0, "X_horizontal", d), _spec("B", 2, 0,
+                                                     "X_horizontal", d)]
+    st = {"A": "Z", "B": "Z"}
+    from lightstim.noise.config import NoiseConfig
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0)])],
+        initial_states=st, final_measure_states=st, rounds=d, rounds_init=1,
+        noise_params=NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3,
+                                 p_reset=1e-3, p_idle=1e-3))
+    c = _build(exp)
+    c.detector_error_model(decompose_errors=True)
+    assert len(c.shortest_graphlike_error()) == d
+
+
+def test_kernel_api_composes_with_measurement_block_engine():
+    """Compiler-consumer path: lower_ppm/apply_plan + builder primitives,
+    no experiment driver — then ONE measurement-block engine round on the
+    post-PPM tracker state (absorbed joint present), then readout.  The
+    block path and the PPM tracker semantics must share one census."""
+    specs = [_spec("A", 0, 0, "X_horizontal"),
+             _spec("B", 2, 0, "X_horizontal")]
+    system = QECSystem()
+    for s in specs:
+        p = RotatedSurfaceCode(distance=s.distance)
+        if s.orientation == 'X_horizontal':
+            p.transpose_coords()
+        system.add_patch(p, name=s.name,
+                         offset=(s.origin[0] - 1, s.origin[1] - 1))
+
+    plan = lower_ppm(specs,
+                     PPMRequest(targets=(("A", "Z"), ("B", "Z")),
+                                route=((1, 0),)),
+                     system=system)
+    apply_plan(system, plan, "ppm_0")
+
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system,
+                             if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.write_coordinates()
+    builder.initialize(init_dict={q: 'Z' for q in system.data_indices},
+                       n=system.num_qubits)
+    orient = {s.name: s.orientation for s in specs}
+    owner = system.index_to_owner_map
+    domains = {tuple(system.qubit_coords[q]): orient[owner[q]]
+               for q in system.data_indices if owner.get(q) in orient}
+    builder.apply_syndrome_extraction(
+        circuit_chunk=se_round_chunk(system, domains=domains), rounds=1)
+
+    builder.activate_coupler("ppm_0")
+    coupler_patch = system.coupler_patches["ppm_0"]
+    l2g = system.local_to_global_map["ppm_0"]
+    corridor_init = {l2g[q]: plan.corridor_init_basis
+                     for q in coupler_patch.data_indices}
+    builder.initialize(init_dict=corridor_init, n=system.num_qubits)
+    merged = dict(plan.route_result.layout.domains or {})
+    for q in system.data_indices:
+        nm = owner.get(q)
+        if nm in orient:
+            merged.setdefault(tuple(system.qubit_coords[q]), orient[nm])
+    builder.apply_syndrome_extraction(
+        circuit_chunk=se_round_chunk(system, domains=merged), rounds=D)
+    builder.deactivate_coupler("ppm_0")
+    builder.apply_data_readout(final_measurements=dict(corridor_init),
+                               resolve_absorbed=False)
+
+    # one measurement-block engine round on the post-PPM state
+    block_chunk = se_round_chunk(system, domains=domains)
+    builder.apply_syndrome_extraction(circuit_chunk=block_chunk, rounds=1,
+                                      measurement_blocks=(block_chunk,))
+    tracker.validate_logical_count(
+        context="block round on post-PPM state")
+
+    builder.apply_data_readout(
+        final_measurements={q: 'Z' for q in system.data_indices})
+    c = builder.circuit
+    # same as the driver's ZZ flow: two logical DOFs, one consumed by the
+    # joint (its value is the protocol output), one standing observable
+    assert c.num_observables == 1
+    det, obs = c.compile_detector_sampler(seed=0).sample(
+        1024, separate_observables=True)
+    assert not det.any() and not obs.any()

--- a/tests/test_ppm_matrix.py
+++ b/tests/test_ppm_matrix.py
@@ -60,6 +60,59 @@ def test_weight4_straight_chain_is_an_explicit_gap():
         _build(exp)
 
 
+def test_longer_straight_route_full_distance():
+    # a 3-cell corridor between distant targets stays on the bent schedule
+    from lightstim.noise.config import NoiseConfig
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 4, 0, "X_horizontal")]
+    st = {"A": "Z", "B": "Z"}
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0), (2, 0), (3, 0)])],
+        initial_states=st, final_measure_states=st, rounds=D, rounds_init=1,
+        noise_params=NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3,
+                                 p_reset=1e-3, p_idle=1e-3))
+    c = _build(exp)
+    assert exp._sched[0] == 'bent'
+    assert exp._plans[0].certificate.measures_exactly_the_product
+    c.detector_error_model(decompose_errors=True)
+    assert len(c.shortest_graphlike_error()) == D
+
+
+def test_bent_route_forces_diagonal_and_full_distance():
+    # any bend in the corridor puts the whole merged block on the diagonal
+    # schedule; the certificate still pins the exact-product guarantee
+    from lightstim.noise.config import NoiseConfig
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 1, "X_vertical")]
+    st = {"A": "Z", "B": "Z"}
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0), (2, 0)])],
+        initial_states=st, final_measure_states=st, rounds=D, rounds_init=1,
+        noise_params=NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3,
+                                 p_reset=1e-3, p_idle=1e-3))
+    c = _build(exp)
+    assert exp._sched[0] == 'diagonal'
+    assert exp._plans[0].certificate.measures_exactly_the_product
+    c.detector_error_model(decompose_errors=True)
+    assert len(c.shortest_graphlike_error()) == D
+
+
+def test_three_target_certificate_pins_true_multibody_instrument():
+    # the multi-body matrix item: the weight-3 T-corridor joint measures
+    # the triple product and NOTHING finer (no pairwise parity leaks)
+    px = [_spec("q1", 0, 0, "X_horizontal"), _spec("q2", 4, 0, "X_horizontal"),
+          _spec("q3", 2, 1, "X_vertical")]
+    st = {"q1": "Z", "q2": "Z", "q3": "Z"}
+    exp = SequentialPPMExperiment(
+        px, [PPMStep([("q1", "Z"), ("q2", "Z"), ("q3", "Z")],
+                     route=[(1, 0), (2, 0), (3, 0)])],
+        initial_states=st, final_measure_states=st, rounds=D, rounds_init=1)
+    _build(exp)
+    cert = exp._plans[0].certificate
+    assert cert.ok
+    assert cert.items['no_subjoint'] is True
+    assert cert.items['no_single'] is True
+    assert cert.measures_exactly_the_product
+
+
 @pytest.mark.slow
 def test_zz_pair_full_distance_d5():
     d = 5

--- a/tests/test_ppm_outcomes.py
+++ b/tests/test_ppm_outcomes.py
@@ -1,0 +1,89 @@
+"""Protocol output vs evaluation observable (review §3).
+
+Every applied PPM exposes its physical measurement-record parity as a
+PPMOutcome; whether that parity is deterministic is a property of the
+request's relation to the tracked state, not a correctness question.
+An anti-commuting outcome is a legitimate free coin (protocol output);
+the deterministic quantities the circuit DOES certify (closure
+detectors, standing observables) are the evaluation layer's choice.
+"""
+import contextlib
+import io
+
+import numpy as np
+
+from lightstim.protocols.ppm.spec import PatchSpec, PPMStep, origin_of
+from lightstim.protocols.ppm.sequential import SequentialPPMExperiment
+
+D = 3
+
+
+def _spec(nm, a, b, o):
+    return PatchSpec(nm, origin_of(a, b, D, seam=True), D, o)
+
+
+def _build(exp):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return exp.build()
+
+
+def _bits(circuit, records, shots=400, seed=5):
+    m = circuit.compile_sampler(seed=seed).sample(shots)
+    out = np.zeros(shots, dtype=bool)
+    for r in records:
+        out ^= m[:, r]
+    return out
+
+
+def test_commuting_repeat_outcome_is_reproducible():
+    # M(ZZ) twice: the second joint is pinned BEFORE its merge (pre-merge
+    # records exist), and the two protocol outputs agree shot by shot — a
+    # deterministic correlation between two protocol outputs.
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 0, "X_horizontal")]
+    seq = [PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0)]),
+           PPMStep([("A", "Z"), ("B", "Z")], route=[(1, 0)])]
+    st = {"A": "Z", "B": "Z"}
+    exp = SequentialPPMExperiment(px, seq, initial_states=st,
+                                  final_measure_states=st, rounds=D,
+                                  rounds_init=1)
+    c = _build(exp)
+    o0, o1 = exp.ppm_outcomes[0], exp.ppm_outcomes[1]
+    assert o0.records_post_split is not None
+    assert o1.records_pre_merge is not None, \
+        "a commuting repeat is pinned before its own merge"
+    assert o1.records_post_split is not None
+    b0 = _bits(c, o0.records_post_split)
+    b1 = _bits(c, o1.records_post_split)
+    assert (b0 == b1).all(), "repeated commuting PPM outcomes must agree"
+
+
+def test_anticommuting_outcome_is_a_free_coin():
+    # A sits on a corner: M(X̄A X̄B) through the E/W seam, then M(Z̄A Z̄C)
+    # through the N/S seam — the joints anti-commute at A (X̄A vs Z̄A), and
+    # each step is individually parallel-law-legal on its own seam (no
+    # rotation needed).  The second outcome is a legitimately random
+    # protocol output: no pre-merge parity, per-shot coin after the split
+    # — while every correlation the circuit certifies (closures,
+    # observables) stays silent at p=0.
+    px = [_spec("A", 0, 0, "X_vertical"), _spec("B", 1, 0, "X_vertical"),
+          _spec("C", 0, 1, "X_vertical")]
+    seq = [PPMStep([("A", "X"), ("B", "X")], route=[]),
+           PPMStep([("A", "Z"), ("C", "Z")], route=[])]
+    exp = SequentialPPMExperiment(
+        px, seq, initial_states={"A": "X", "B": "X", "C": "Z"},
+        final_measure_states={"A": "Z", "B": "X", "C": "Z"},
+        rounds=D, rounds_init=1)
+    c = _build(exp)
+    o_0, o_1 = exp.ppm_outcomes[0], exp.ppm_outcomes[1]
+    assert o_0.records_post_split is not None
+    assert o_1.records_pre_merge is None, \
+        "an anti-commuting joint must NOT be pinned before its merge"
+    assert o_1.records_post_split is not None
+
+    coin = _bits(c, o_1.records_post_split)
+    assert coin.any() and not coin.all(), \
+        "the anti-commuting outcome must be a per-shot coin"
+
+    det = c.compile_detector_sampler(seed=0).sample(1024)
+    assert not det.any(), \
+        "every certified (evaluation-layer) correlation must stay silent"

--- a/tests/test_ppm_outcomes.py
+++ b/tests/test_ppm_outcomes.py
@@ -87,3 +87,23 @@ def test_anticommuting_outcome_is_a_free_coin():
     det = c.compile_detector_sampler(seed=0).sample(1024)
     assert not det.any(), \
         "every certified (evaluation-layer) correlation must stay silent"
+
+
+def test_record_parity_excludes_sentinel_rows():
+    """A reconstruction through an UNMEASURED-sentinel row would XOR in an
+    unbanked, per-shot-random gauge — record_parity must refuse it and
+    report the operator as not record-deterministic (None), not fabricate
+    a wrong record set."""
+    import numpy as np
+    from lightstim.ir.tracker import (SyndromeTracker,
+                                      UNMEASURED_STAB_RECORD)
+    from lightstim.protocols.ppm.lowering import record_parity
+
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    row = np.zeros(2 * n, dtype=np.uint8)
+    row[[n + 0, n + 1]] = 1
+    tracker.stabilizers.matrix = row.reshape(1, -1)
+    tracker.stabilizers.records = [[UNMEASURED_STAB_RECORD]]
+
+    assert record_parity(tracker, row.copy()) is None

--- a/tests/test_relay_chunk.py
+++ b/tests/test_relay_chunk.py
@@ -116,6 +116,49 @@ def test_two_relay_rounds_full_detector_complement():
     assert _noiseless_clean(builder.circuit)
 
 
+def test_relay_and_readout_observable_ids_do_not_collide():
+    """Centralized observable allocation (review blocker: relay allocated
+    from circuit.num_observables without advancing tracker.total_observables,
+    so a later data readout reused the same ID and XORed two independent
+    logical results into one observable — silently: the XOR of two
+    deterministic bits is still deterministic, so p=0 sampling stays clean).
+
+    Scenario: patch P is measured out by a relay chunk (one observable),
+    then patch Q is read out terminally (a second observable).  The two
+    OBSERVABLE_INCLUDEs must carry distinct IDs and both counters agree."""
+    system = QECSystem()
+    system.add_patch(RotatedSurfaceCode(distance=D), name="P", offset=(0, 0))
+    system.add_patch(RotatedSurfaceCode(distance=D), name="Q", offset=(20, 0))
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system,
+                             if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    _init_z(system, builder)
+    builder.apply_syndrome_extraction(
+        circuit_chunk=RotatedSurfaceCodeExtractionBlock(system).circuit,
+        rounds=1)
+
+    p_qubits = system.patches["P"][0].num_qubits
+    relay = stim.Circuit()
+    for q in sorted(q for q in system.data_indices if q < p_qubits):
+        relay.append("M", [q])
+    builder.apply_relay_chunk(relay)
+    assert tracker.total_observables == builder.circuit.num_observables == 1
+
+    builder.apply_data_readout(
+        final_measurements={q: 'Z' for q in system.data_indices
+                            if q >= p_qubits})
+    c = builder.circuit
+    obs_ids = sorted(int(i.gate_args_copy()[0]) for i in c.flattened()
+                     if i.name == 'OBSERVABLE_INCLUDE')
+    assert obs_ids == [0, 1], f"independent observables share an ID: {obs_ids}"
+    assert c.num_observables == 2
+    assert tracker.total_observables == 2
+    assert _noiseless_clean(c)
+
+
 def test_readout_after_relay_round_emits_observable():
     system, tracker, builder = _fresh()
     _init_z(system, builder)

--- a/tests/test_relay_chunk.py
+++ b/tests/test_relay_chunk.py
@@ -1,0 +1,131 @@
+"""builder.apply_relay_chunk — flow-solved round processing (route ②).
+
+Rounds where stabilizers are relayed between ancillas mid-round (e.g. the
+Y-basis transition round of arXiv:2302.07395) violate the standard SE path's
+per-measurement contract (builder.py syn-block zeroing: sound iff each
+measurement, back-propagated, touches other ancillas only in their reset
+basis). apply_relay_chunk instead solves the round's stabilizer flows with
+stim (Circuit.flow_generators) and merges them with the tracker's
+record-augmented rows: closed flows -> DETECTORs, open flows -> new tracked
+rows, logical rows transported exactly.
+
+Spec anchor: on a STANDARD SE round the relay path must be observationally
+identical to apply_syndrome_extraction (same detector record-sets, same
+tracker knowledge), and must compose with the standard path afterwards.
+"""
+import numpy as np
+import pytest
+import stim
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode
+from lightstim.qec_code.surface_code.rotated.SE_block import (
+    RotatedSurfaceCodeExtractionBlock,
+)
+
+D = 3
+
+
+def _fresh(d=D):
+    system = QECSystem()
+    system.add_patch(RotatedSurfaceCode(distance=d), name="P", offset=(0, 0))
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system,
+                             if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    return system, tracker, builder
+
+
+def _init_z(system, builder):
+    builder.initialize(
+        init_dict={q: 'Z' for q in system.data_indices},
+        n=system.num_qubits)
+
+
+_MEAS = {'M', 'MX', 'MY', 'MR', 'MRX', 'MRY'}
+
+
+def _detector_recsets(circuit):
+    """Each DETECTOR as a frozenset of ABSOLUTE measurement indices."""
+    out = []
+    m = 0
+    for inst in circuit.flattened():
+        if inst.name in _MEAS:
+            m += len(inst.targets_copy())
+        elif inst.name == 'DETECTOR':
+            out.append(frozenset(m + t.value for t in inst.targets_copy()))
+    return out
+
+
+def _noiseless_clean(circuit, shots=256):
+    s = circuit.compile_detector_sampler(seed=11).sample(
+        shots=shots, append_observables=True)
+    return not s.any()
+
+
+def test_standard_round_matches_se_path():
+    # Path A: the existing SE machinery
+    sysA, trA, bA = _fresh()
+    _init_z(sysA, bA)
+    chunkA = RotatedSurfaceCodeExtractionBlock(sysA).circuit
+    bA.apply_syndrome_extraction(circuit_chunk=chunkA, rounds=1)
+
+    # Path B: relay path on the identical chunk
+    sysB, trB, bB = _fresh()
+    _init_z(sysB, bB)
+    chunkB = RotatedSurfaceCodeExtractionBlock(sysB).circuit
+    bB.apply_relay_chunk(chunkB)
+
+    assert bB.circuit.num_measurements == bA.circuit.num_measurements
+    assert sorted(sorted(r) for r in _detector_recsets(bB.circuit)) == \
+        sorted(sorted(r) for r in _detector_recsets(bA.circuit))
+    assert _noiseless_clean(bB.circuit)
+    assert trB.total_measurements == trA.total_measurements
+    # same knowledge: every registered stabilizer decomposes identically
+    assert trB.stabilizers.count > 0
+
+
+def test_relay_round_then_standard_round_composes():
+    system, tracker, builder = _fresh()
+    _init_z(system, builder)
+    chunk = RotatedSurfaceCodeExtractionBlock(system).circuit
+    builder.apply_relay_chunk(chunk)
+    n_det_before = builder.circuit.num_detectors
+
+    # the ordinary path must be able to continue on relay-installed rows
+    builder.apply_syndrome_extraction(circuit_chunk=chunk, rounds=1)
+    round2 = builder.circuit.num_detectors - n_det_before
+    assert round2 == 8            # full complement at d=3
+    assert _noiseless_clean(builder.circuit)
+
+
+def test_two_relay_rounds_full_detector_complement():
+    system, tracker, builder = _fresh()
+    _init_z(system, builder)
+    chunk = RotatedSurfaceCodeExtractionBlock(system).circuit
+    builder.apply_relay_chunk(chunk)
+    n1 = builder.circuit.num_detectors
+    builder.apply_relay_chunk(chunk)
+    n2 = builder.circuit.num_detectors - n1
+    assert n1 == 4                # Z-init: only Z-checks deterministic
+    assert n2 == 8
+    assert _noiseless_clean(builder.circuit)
+
+
+def test_readout_after_relay_round_emits_observable():
+    system, tracker, builder = _fresh()
+    _init_z(system, builder)
+    chunk = RotatedSurfaceCodeExtractionBlock(system).circuit
+    builder.apply_relay_chunk(chunk)
+    builder.apply_syndrome_extraction(circuit_chunk=chunk, rounds=1)
+    builder.apply_data_readout(
+        final_measurements={q: 'Z' for q in system.data_indices})
+    c = builder.circuit
+    assert c.num_observables == 1
+    assert _noiseless_clean(c)
+    dem = c.detector_error_model(decompose_errors=True)
+    assert dem.num_observables == 1

--- a/tests/test_rule_based_patch.py
+++ b/tests/test_rule_based_patch.py
@@ -1,0 +1,197 @@
+"""Rule-based patch builder vs the two published grown-patch layouts.
+
+Litinski (arXiv:1808.02892) Fig 45 step 5, read check-by-check off 800/1600-dpi
+crops: the grown 3×5 bar keeps q2's three non-growth-edge boundary checks verbatim
+and carries the same-type corner pair on the bottom-left (X) corner — X@(0,2) and
+X@(2,0) sharing corner data qubit (1,1) — with a single Z@(6,2) bottom-right.
+
+Kishony-Fowler (diagonal-scheduling paper) Fig 5b, extracted from the PDF's vector
+graphics: d=5, conjugate orientation (X̄ vertical), grows RIGHT through the Z
+boundary to 5×11 (2d+1), corner pair at the far bottom-right (X) corner, and the
+mid-top-edge topological corner pinned to the destination sub-patch's boundary.
+
+Both layouts must emerge from bulk + ``forced`` (kept live checks, plus destination
+boundary anchors where the free edge has slack) + the corner/sweep rules — with no
+per-paper hints.  The eager per-corner tile selection this file once guarded with a
+``pair_type`` parameter is gone: corners already covered by a selected check are not
+anchored, which is what makes both papers come out of the same rules.
+"""
+import numpy as np
+import pytest
+
+from lightstim.qec_code.surface_code.rotated.rule_based_patch import RuleBasedRectPatch
+
+pytestmark = pytest.mark.smoke
+
+D = 3
+DY = 2 * (D - 1)
+
+# Paper q2 starting boundary, 3×3 local coords, y up (verified against Fig 45 panel 1)
+PAPER_Q2_W2 = {
+    (0, 2): ('X', [(1, 1), (1, 3)]),   # left, lower half
+    (4, 0): ('Z', [(3, 1), (5, 1)]),   # bottom, right half (growth edge -> dropped)
+    (6, 4): ('X', [(5, 3), (5, 5)]),   # right, upper half
+    (2, 6): ('Z', [(1, 5), (3, 5)]),   # top, left half
+}
+PAPER_Q2_BULK = {
+    (2, 4): ('X', [(1, 3), (3, 3), (1, 5), (3, 5)]),
+    (4, 4): ('Z', [(3, 3), (5, 3), (3, 5), (5, 5)]),
+    (2, 2): ('Z', [(1, 1), (3, 1), (1, 3), (3, 3)]),
+    (4, 2): ('X', [(3, 1), (5, 1), (3, 3), (5, 3)]),
+}
+
+# Fig 45 panel 5 ground truth: all 14 checks of the grown bar
+PANEL5_BULK = {
+    (2, 8): 'X', (4, 8): 'Z', (2, 6): 'Z', (4, 6): 'X',
+    (2, 4): 'X', (4, 4): 'Z', (2, 2): 'Z', (4, 2): 'X',
+}
+PANEL5_W2 = {
+    (2, 10): ('Z', [(1, 9), (3, 9)]),
+    (6, 8):  ('X', [(5, 7), (5, 9)]),
+    (0, 6):  ('X', [(1, 5), (1, 7)]),
+    (0, 2):  ('X', [(1, 1), (1, 3)]),   # corner pair member
+    (2, 0):  ('X', [(1, 1), (3, 1)]),   # corner pair member
+    (6, 2):  ('Z', [(5, 1), (5, 3)]),
+}
+
+
+def _forced():
+    out = {}
+    for sc, (t, sup) in PAPER_Q2_W2.items():
+        if sc == (4, 0):
+            continue
+        out[(sc[0], sc[1] + DY)] = (t, sorted((x, y + DY) for x, y in sup))
+    return out
+
+
+def _layout(patch):
+    out = {}
+    for s in patch.stabilizers:
+        sc = tuple(int(round(v)) for v in s['syn_coord'])
+        sup = sorted(tuple(int(round(v)) for v in patch.qubit_coords[i])
+                     for i in s['data_indices'])
+        out[sc] = (s['type'], sup)
+    return out
+
+
+def _grown():
+    return RuleBasedRectPatch(distance_x=2 * D - 1, distance_z=D,
+                              forced=_forced(), phase=0)
+
+
+def _gf2_rank(M):
+    M = M.copy() % 2
+    r = 0
+    for c in range(M.shape[1]):
+        piv = next((i for i in range(r, M.shape[0]) if M[i, c]), None)
+        if piv is None:
+            continue
+        M[[r, piv]] = M[[piv, r]]
+        M[[i for i in range(M.shape[0]) if i != r and M[i, c]]] ^= M[r]
+        r += 1
+    return r
+
+
+def test_step5_layout_matches_paper():
+    lay = _layout(_grown())
+    expect = {}
+    for (cx, cy), t in PANEL5_BULK.items():
+        expect[(cx, cy)] = (t, sorted((cx + dx, cy + dy)
+                                      for dx in (-1, 1) for dy in (-1, 1)))
+    for sc, (t, sup) in PANEL5_W2.items():
+        expect[sc] = (t, sorted(sup))
+    assert lay == expect
+
+
+# ---- Kishony-Fowler Fig 5b (d=5, conjugate orientation, grow right to 2d+1) ----
+
+KF_A_KEPT_W2 = {
+    (0, 2):  ('Z', [(1, 1), (1, 3)]),
+    (0, 6):  ('Z', [(1, 5), (1, 7)]),
+    (2, 10): ('X', [(1, 9), (3, 9)]),
+    (6, 10): ('X', [(5, 9), (7, 9)]),
+    (4, 0):  ('X', [(3, 1), (5, 1)]),
+    (8, 0):  ('X', [(7, 1), (9, 1)]),
+}
+KF_DEST_TOP_Z = {
+    (16, 10): ('Z', [(15, 9), (17, 9)]),
+    (20, 10): ('Z', [(19, 9), (21, 9)]),
+}
+KF_B_W2 = {
+    (0, 2): ('Z', [(1, 1), (1, 3)]), (0, 6): ('Z', [(1, 5), (1, 7)]),
+    (2, 10): ('X', [(1, 9), (3, 9)]), (6, 10): ('X', [(5, 9), (7, 9)]),
+    (10, 10): ('X', [(9, 9), (11, 9)]),
+    (16, 10): ('Z', [(15, 9), (17, 9)]), (20, 10): ('Z', [(19, 9), (21, 9)]),
+    (4, 0): ('X', [(3, 1), (5, 1)]), (8, 0): ('X', [(7, 1), (9, 1)]),
+    (12, 0): ('X', [(11, 1), (13, 1)]), (16, 0): ('X', [(15, 1), (17, 1)]),
+    (20, 0): ('X', [(19, 1), (21, 1)]),
+    (22, 2): ('X', [(21, 1), (21, 3)]), (22, 6): ('X', [(21, 5), (21, 7)]),
+}
+
+
+def test_kf_fig5b_layout_matches_paper():
+    patch = RuleBasedRectPatch(distance_x=5, distance_z=11,
+                               forced={**KF_A_KEPT_W2, **KF_DEST_TOP_Z}, phase=1)
+    lay = _layout(patch)
+    expect = {}
+    for cx in range(2, 22, 2):
+        for cy in range(2, 10, 2):
+            t = 'X' if (((cx + cy) // 2) + 1) % 2 else 'Z'
+            expect[(cx, cy)] = (t, sorted((cx + dx, cy + dy)
+                                          for dx in (-1, 1) for dy in (-1, 1)))
+    for sc, (t, sup) in KF_B_W2.items():
+        expect[sc] = (t, sorted(sup))
+    assert lay == expect
+
+
+def test_step5_algebra_and_exhaustive_distance():
+    patch = _grown()
+    lay = _layout(patch)
+    coords = sorted({tuple(int(round(v)) for v in patch.qubit_coords[i])
+                     for i in patch.data_indices})
+    n = len(coords)
+    idx = {q: i for i, q in enumerate(coords)}
+
+    def vec(t, sup):
+        v = np.zeros(2 * n, dtype=np.uint8)
+        for q in sup:
+            v[idx[q] + (0 if t == 'X' else n)] = 1
+        return v
+
+    S = np.array([vec(t, sup) for t, sup in lay.values()], dtype=np.uint8)
+
+    def commute(u, v):
+        return (int(u[:n] @ v[n:]) + int(u[n:] @ v[:n])) % 2 == 0
+
+    assert all(commute(S[i], S[j])
+               for i in range(len(S)) for j in range(i + 1, len(S)))
+    assert _gf2_rank(S) == n - 1          # k = 1
+
+    # anchoring: exactly 7 of the 8 original q2 checks survive verbatim
+    old = {}
+    for sc, (t, sup) in {**PAPER_Q2_W2, **PAPER_Q2_BULK}.items():
+        old[(sc[0], sc[1] + DY)] = (t, sorted((x, y + DY) for x, y in sup))
+    kept = sum(1 for sc, rec in old.items() if lay.get(sc) == rec)
+    assert kept == 7
+
+    # TRUE distance by full GF(2) exhaustion per CSS sector (d = min(dx, dz))
+    Hx = np.array([vec(t, sup)[:n] for t, sup in lay.values() if t == 'X'],
+                  dtype=np.uint8)
+    Hz = np.array([vec(t, sup)[n:] for t, sup in lay.values() if t == 'Z'],
+                  dtype=np.uint8)
+
+    def sector_distance(H_other, G_same):
+        rk = _gf2_rank(G_same)
+        best = None
+        for bits in range(1, 1 << n):
+            e = np.array([(bits >> i) & 1 for i in range(n)], dtype=np.uint8)
+            if best is not None and int(e.sum()) >= best:
+                continue
+            if ((H_other @ e) % 2).any():
+                continue
+            if _gf2_rank(np.vstack([G_same, e])) == rk:
+                continue
+            best = int(e.sum())
+        return best
+
+    assert min(sector_distance(Hz, Hx), sector_distance(Hx, Hz)) == D

--- a/tests/test_run_memory.py
+++ b/tests/test_run_memory.py
@@ -19,7 +19,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 RUNNER = REPO / "benchmarks" / "memory" / "run_memory.py"
-PYTHON = REPO / "venv" / "bin" / "python"
+PYTHON = Path(sys.executable)              # the running interpreter, not a hardcoded venv
 
 sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / "benchmarks" / "memory"))
@@ -433,7 +433,7 @@ def test_cli_cpu_bposd_bb(tmp_path):
     out = tmp_path / "bb_bposd.csv"
     r = _run_cli(["--codes", "bb_72_12_6", "--p-values", "1e-2",
                   "--decoder", "cpu_bposd",
-                  "--max-shots", "300", "--max-errors", "3"], out, timeout=300)
+                  "--max-shots", "300", "--max-errors", "3"], out, timeout=1200)
     assert r.returncode == 0, r.stderr
     df = pd.read_csv(out)
     assert df["decoder_name"].iloc[0] == "cpu_bposd"
@@ -446,7 +446,7 @@ def test_cli_gpu_bposd_bb(tmp_path):
     out = tmp_path / "bb_gpu.csv"
     r = _run_cli(["--codes", "bb_72_12_6", "--p-values", "1e-2",
                   "--decoder", "gpu_bposd",
-                  "--max-shots", "300", "--max-errors", "3"], out, timeout=300)
+                  "--max-shots", "300", "--max-errors", "3"], out, timeout=1200)
     assert r.returncode == 0, r.stderr
 
 

--- a/tests/test_sequential_ppm.py
+++ b/tests/test_sequential_ppm.py
@@ -1,0 +1,219 @@
+"""Sequential PPM (explicit-route minimal driver) —
+lightstim/protocols/ppm (spec / seam_rules / coupler / sequential).
+
+These modules are copied from the author's CircLS repository
+(https://github.com/John-YuehanZhang/CircLS @ 8802a5b) and intentionally
+independent of it: route is REQUIRED on every PPMStep (no auto-router),
+liveness / rotations / snake / Y births are not included.
+
+Covered here (noiseless silence + deterministic observables + graphlike
+distance d at p=1e-3):
+  * explicit one-cell corridor Z⊗Z;
+  * all four rule-table rows on cell-adjacent pairs (route=[]);
+  * the Handbook Sec. 10.4 cap-slot regression (transposed row-3 E/W wall);
+  * route-required enforcement at every layer;
+  * independence from the circls package (subprocess import probe).
+"""
+import contextlib
+import io
+import subprocess
+import sys
+
+import pytest
+
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.ppm.spec import PatchSpec, PPMStep, origin_of
+from lightstim.protocols.ppm.coupler import route_and_build, BentLayoutError
+from lightstim.protocols.ppm.seam_rules import SeamRuleError
+from lightstim.protocols.ppm.sequential import SequentialPPMExperiment
+
+pytestmark = pytest.mark.smoke
+
+D = 3
+NP = NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3, p_reset=1e-3, p_idle=1e-3)
+
+
+def _spec(nm, a, b, o):
+    return PatchSpec(nm, origin_of(a, b, D, seam=True), D, o)
+
+
+def _run(px, target, states, *, route=(), **kw):
+    step_kw = kw.pop('step_kw', {})
+    exp = SequentialPPMExperiment(
+        px, [PPMStep(target, route=list(route), **step_kw)],
+        initial_states=states, final_measure_states=states,
+        rounds=D, rounds_init=1, **kw)
+    with contextlib.redirect_stdout(io.StringIO()):
+        c = exp.build()
+    return exp, c
+
+
+def _verify(exp, c, row=None, wall=None):
+    if row is not None:
+        assert exp._rules[0].row == row
+    if wall is not None:
+        assert (0 in exp._walls) == wall
+    det, obs = c.compile_detector_sampler(seed=0).sample(
+        512, separate_observables=True)
+    assert not det.any(), "detector fired at p=0"
+    assert not obs.any(), "observable not deterministic at p=0"
+    noisy = exp.builder.build_noisy_circuit(noise_params=NP,
+                                            noise_model='circuit_level')
+    noisy.detector_error_model(decompose_errors=True)
+    assert len(noisy.shortest_graphlike_error()) == D
+
+
+# ── route is REQUIRED at every layer ─────────────────────────────────────────
+
+def test_ppmstep_route_is_required():
+    with pytest.raises(TypeError):
+        PPMStep([("A", "Z"), ("B", "Z")])          # no route argument
+
+
+def test_experiment_rejects_route_none():
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 0, "X_horizontal")]
+    with pytest.raises(ValueError, match="route is required"):
+        SequentialPPMExperiment(
+            px, [PPMStep([("A", "Z"), ("B", "Z")], route=None)],
+            initial_states={"A": "Z", "B": "Z"},
+            final_measure_states={"A": "Z", "B": "Z"})
+
+
+def test_route_and_build_rejects_route_none():
+    px = [_spec("A", 0, 0, "X_horizontal"), _spec("B", 2, 0, "X_horizontal")]
+    with pytest.raises(BentLayoutError, match="no auto-router"):
+        route_and_build(px, [("A", "Z"), ("B", "Z")], seam=True)
+
+
+# ── explicit corridor ────────────────────────────────────────────────────────
+
+def test_explicit_corridor_zz_full_distance():
+    exp, c = _run([_spec("A", 0, 0, "X_horizontal"),
+                   _spec("B", 2, 0, "X_horizontal")],
+                  [("A", "Z"), ("B", "Z")], {"A": "Z", "B": "Z"},
+                  route=[(1, 0)])
+    assert c.num_observables == 1
+    _verify(exp, c)
+
+
+def test_joint_closure_detector_emitted():
+    # Review blocker #1: the terminal closure of a measurement-promoted
+    # joint is a legitimate long-range detector; the support-weight
+    # suppression heuristic is removed (matches upstream main).  Paired-
+    # noise MWPM LER is ~30% better with the closure emitted (2026-08-09
+    # nine-config sweep; decompose_errors=True stays viable in all of them).
+    exp, c = _run([_spec("A", 0, 0, "X_horizontal"),
+                   _spec("B", 2, 0, "X_horizontal")],
+                  [("A", "Z"), ("B", "Z")], {"A": "Z", "B": "Z"},
+                  route=[(1, 0)])
+    longrange = [inst for inst in c.flattened() if inst.name == "DETECTOR"
+                 and len(inst.targets_copy()) > 2 * D + 2]
+    assert longrange, "joint-closure long-range detector was not emitted"
+    _verify(exp, c)
+
+
+def test_three_target_one_step_t_corridor():
+    # one step measures 3 patches through a 3-cell T corridor: two
+    # independent pairwise products (obs=2), full distance
+    exp, c = _run([_spec("q1", 0, 0, "X_horizontal"),
+                   _spec("q2", 4, 0, "X_horizontal"),
+                   _spec("q3", 2, 1, "X_vertical")],
+                  [("q1", "Z"), ("q2", "Z"), ("q3", "Z")],
+                  {"q1": "Z", "q2": "Z", "q3": "Z"},
+                  route=[(1, 0), (2, 0), (3, 0)])
+    assert c.num_observables == 2
+    _verify(exp, c)
+
+
+# ── the four rule-table rows on cell-adjacent pairs (route=[]) ──────────────
+
+def test_row1_same_pauli_same_type_plain_merge():
+    # both place(X_horizontal) = conjugate type; Z⊗Z through the E/W seam:
+    # plain merge (seam line is DATA), bent schedule
+    exp, c = _run([_spec("A", 0, 0, "X_horizontal"),
+                   _spec("B", 1, 0, "X_horizontal")],
+                  [("A", "Z"), ("B", "Z")], {"A": "Z", "B": "Z"})
+    assert exp._sched[0] == 'bent'
+    _verify(exp, c, row=1, wall=False)
+
+
+def test_row2_same_pauli_diff_type_wall():
+    # A = place(X_horizontal), B = place(X_vertical) with swapped colours
+    # (live X̄ horizontal, textbook positions); X⊗X through the N/S seam ->
+    # uniform-domino wall on the diagonal schedule
+    exp, c = _run([_spec("A", 0, 0, "X_horizontal"),
+                   _spec("B", 0, 1, "X_vertical")],
+                  [("A", "X"), ("B", "X")], {"A": "X", "B": "X"},
+                  colour_swapped={"B"})
+    assert exp._sched[0] == 'diagonal'
+    _verify(exp, c, row=2, wall=True)
+
+
+def test_row3_mixed_diff_type_wall():
+    # A minority -> conjugate type, Z̄ horizontal; B colour-swapped ->
+    # textbook type, X̄ horizontal; Z⊗X through the N/S seam ->
+    # mixed-domino wall, diagonal schedule
+    exp, c = _run([_spec("A", 0, 0, "X_horizontal"),
+                   _spec("B", 0, 1, "X_vertical")],
+                  [("A", "Z"), ("B", "X")], {"A": "Z", "B": "X"},
+                  colour_swapped={"A", "B"})
+    assert exp._sched[0] == 'diagonal'
+    _verify(exp, c, row=3, wall=True)
+
+
+def test_row4_mixed_same_type_recoloured_merge():
+    # both textbook positions, one recoloured; X⊗Z through the E/W seam ->
+    # recoloured single-cell mixed checks, straight seam stays bent
+    exp, c = _run([_spec("A", 0, 0, "X_vertical"),
+                   _spec("B", 1, 0, "X_vertical")],
+                  [("A", "X"), ("B", "Z")], {"A": "X", "B": "Z"},
+                  colour_swapped={"B"})
+    assert exp._sched[0] == 'bent'
+    _verify(exp, c, row=4, wall=False)
+
+
+def test_row3_transposed_ew_wall_cap_slot():
+    # Handbook Sec. 10.4 regression: X⊗Z through the E/W (vertical) seam —
+    # ve/ho pair, same colour phase, no colour swap -> row-3 mixed stretched
+    # wall.  The south end row already carries both patches' corner lobes
+    # one gap away (no slot), so the cap must sit at the free NORTH end;
+    # the old far-side-colour proxy put it south (three checks fighting one
+    # corner -> 50% random detectors).
+    exp, c = _run([_spec("A", 0, 0, "X_vertical"),
+                   _spec("B", 1, 0, "X_horizontal")],
+                  [("A", "X"), ("B", "Z")], {"A": "Z", "B": "Z"})
+    _verify(exp, c, row=3, wall=True)
+    wall = [st for st in exp.system.stabilizers
+            if st.get('patch_name') == 'ppm_0']
+    caps = [st for st in wall if len(st['data_indices']) == 2]
+    assert len(caps) == 1
+    assert caps[0]['syn_coord'][1] == 0, \
+        f"cap must sit at the free north end, got {caps[0]['syn_coord']}"
+
+
+def test_wall_step_rejects_bent_schedule():
+    with pytest.raises(SeamRuleError, match="bent"):
+        _run([_spec("A", 0, 0, "X_horizontal"),
+              _spec("B", 0, 1, "X_vertical")],
+             [("A", "X"), ("B", "X")], {"A": "X", "B": "X"},
+             colour_swapped={"B"}, step_kw={'schedule': 'bent'})
+
+
+# ── independence from CircLS ─────────────────────────────────────────────────
+
+def test_independent_of_circls():
+    # in-process guard (cheap) …
+    assert 'circls' not in sys.modules
+    # … and the strong form: a fresh interpreter that imports the whole
+    # protocol stack must never pull in circls
+    code = ("import sys; "
+            "import lightstim.protocols.ppm.sequential; "
+            "import lightstim.protocols.ppm.coupler; "
+            "import lightstim.protocols.ppm.seam_rules; "
+            "import lightstim.protocols.ppm.spec; "
+            "assert 'circls' not in sys.modules, 'circls leaked'; "
+            "print('ok')")
+    out = subprocess.run([sys.executable, "-c", code],
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == 'ok'

--- a/tests/test_shrink_patch.py
+++ b/tests/test_shrink_patch.py
@@ -1,0 +1,160 @@
+"""Circuit-level verification of shrink_patch (Litinski Fig 45 step 6→7).
+
+Ground truth read off 800/1600-dpi crops of Fig 45 panel 7 (the shrunk, ROTATED
+q2 at the bottom tile, bar-local coords):
+
+* bulk (2,4)X, (4,4)Z, (2,2)Z, (4,2)X — all four kept verbatim;
+* lobes X(2,0), Z(6,2), Z(0,4) kept; NEW top lobe X(4,6) = the cut-line bulk
+  X(4,6) truncated to {(3,5),(5,5)} (its value bridges via the X readouts);
+* the cut-line Z bulk (2,6) does NOT survive (Z info destroyed by X readout);
+* boundary walk left Z / top X / right Z / bottom X → X̄ VERTICAL, Z̄ HORIZONTAL:
+  the patch is ROTATED relative to the original q2 (X̄ horizontal).
+
+Sequence under test: start → grow (|0⟩) → move_corners → X-readout of the top
+d−1 rows → shrink_patch → d rounds → readout.  All phases d diagonal rounds.
+Gates: p=0 determinism, kept-uid anchoring, the §3.2 coverage criterion (asserted
+inside shrink_patch itself), graphlike distance == d for both bases.
+"""
+import pytest
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.qec_code.surface_code.rotated.diagonal_se import (
+    DiagonalSurfaceCodeExtractionBlock)
+from lightstim.qec_code.surface_code.rotated.rule_based_patch import RuleBasedRectPatch
+from lightstim.noise.config import NoiseConfig
+
+from tests.test_grow_patch import paper_start_w2, grown_forced, ptype
+from tests.test_move_corners import moved_w2, grown_patch
+
+pytestmark = pytest.mark.smoke
+
+NP = NoiseConfig(p_1q=1e-3, p_2q=1e-3, p_meas=1e-3, p_reset=1e-3, p_idle=1e-3)
+
+
+# the closed-form rotated-convention square (== panel 7 AND panel 9's local layout)
+from lightstim.qec_code.surface_code.rotated.litinski_layouts import shrunk_w2   # noqa: F401
+
+
+def _shrunk_w2_by_truncation(d):
+    """Independent derivation: the moved bar's w2 fully inside the bottom d×d, plus
+    the truncated X lobes on the cut line (cy = 2d, X checkerboard positions)."""
+    out = {sc: v for sc, v in moved_w2(d).items() if sc[1] < 2 * d
+           and all(y < 2 * d for _, y in v[1])}
+    for cx in range(2, 2 * d, 2):
+        if ptype(cx, 2 * d) == 'X':
+            out[(cx, 2 * d)] = ('X', [(cx - 1, 2 * d - 1), (cx + 1, 2 * d - 1)])
+    return out
+
+
+def test_truncation_derivation_equals_closed_form():
+    """Physically shrinking the moved bar must land exactly on the closed-form
+    rotated-convention square — two independent constructions, one layout."""
+    for d in (3, 5):
+        a = {sc: (t, sorted(map(tuple, sup)))
+             for sc, (t, sup) in _shrunk_w2_by_truncation(d).items()}
+        b = {sc: (t, sorted(map(tuple, sup)))
+             for sc, (t, sup) in shrunk_w2(d).items()}
+        assert a == b
+
+
+PANEL7_W2 = {   # Fig 45 panel 7, hand-read ground truth (d=3, bar-local coords)
+    (2, 0): ('X', [(1, 1), (3, 1)]),
+    (6, 2): ('Z', [(5, 1), (5, 3)]),
+    (0, 4): ('Z', [(1, 3), (1, 5)]),
+    (4, 6): ('X', [(3, 5), (5, 5)]),
+}
+
+
+def test_shrunk_boundary_matches_panel7():
+    assert shrunk_w2(3) == {sc: (t, sorted(map(tuple, sup)))
+                            for sc, (t, sup) in PANEL7_W2.items()}
+
+
+def test_shrunk_geometry_is_rotated():
+    """The shrunk code's logicals have SWAPPED orientation vs the original q2."""
+    for d in (3, 5):
+        patch = RuleBasedRectPatch(distance_x=d, distance_z=d,
+                                   forced=shrunk_w2(d), phase=0)
+        assert len(patch.stabilizers) == d * d - 1
+        xs = {tuple(int(round(v)) for v in patch.qubit_coords[i])
+              for i in patch.logical_ops[0]['data_indices']}
+        zs = {tuple(int(round(v)) for v in patch.qubit_coords[i])
+              for i in patch.logical_ops[1]['data_indices']}
+        assert len({x for x, y in xs}) == 1     # X̄ vertical (one column)
+        assert len({y for x, y in zs}) == 1     # Z̄ horizontal (one row)
+
+
+def build_full_shrink(d, basis):
+    dy = 2 * (d - 1)
+    system = QECSystem()
+    system.add_patch(RuleBasedRectPatch(distance_x=d, distance_z=d,
+                                        forced=paper_start_w2(d), phase=0),
+                     offset=(0, dy), name="q2")
+    tracker = SyndromeTracker(num_qubits=system.num_qubits,
+                              expected_num_logicals=system.num_logicals)
+    builder = CircuitBuilder(tracker=tracker, system_config=system, if_detector=True)
+    system.register_tracker(tracker)
+    system.register_builder(builder)
+    builder.write_coordinates()
+    builder.initialize({q: basis for q in sorted(system.data_indices)},
+                       n=system.num_qubits)
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    new_data, _ = system.grow_patch("q2", grown_patch(d), offset=(0, 0))
+    builder.initialize({q: 'Z' for q in new_data}, n=system.num_qubits)
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    system.move_corners("q2", RuleBasedRectPatch(distance_x=2 * d - 1, distance_z=d,
+                                                 forced=moved_w2(d), phase=0),
+                        offset=(0, 0))
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    # ---- SHRINK: X-readout of the top d−1 rows, then retire them ----
+    removed_q = [q for q in sorted(system.data_indices)
+                 if system.index_to_owner_map.get(q) == "q2"
+                 and system.qubit_coords[q][1] > 2 * d - 1]
+    builder.apply_data_readout(final_measurements={q: 'X' for q in removed_q})
+    shrunk_geom = RuleBasedRectPatch(distance_x=d, distance_z=d,
+                                     forced=shrunk_w2(d), phase=0)
+    old_active = {u for u in system.active_stabilizer_indices
+                  if system.stabilizers[u].get('patch_name') == "q2"}
+    retired = system.shrink_patch("q2", shrunk_geom, offset=(0, 0))
+    assert sorted(retired) == removed_q
+    kept = len(old_active & set(system.active_stabilizer_indices))
+    builder.apply_syndrome_extraction(
+        DiagonalSurfaceCodeExtractionBlock(system).circuit, rounds=d)
+
+    live = [q for q in sorted(system.data_indices)
+            if q in system.qubit_coords and q not in retired
+            and system.index_to_owner_map.get(q) == "q2"]
+    builder.apply_data_readout({q: basis for q in live})
+    return builder, kept
+
+
+def _check(d, basis, kept_expect):
+    builder, kept = build_full_shrink(d, basis)
+    assert kept == kept_expect
+    det, obs = builder.circuit.compile_detector_sampler(seed=0).sample(
+        512, separate_observables=True)
+    assert not det.any(), f"d={d} {basis}: detector fired at p=0"
+    assert not obs.any(), f"d={d} {basis}: observable not deterministic at p=0"
+    noisy = builder.build_noisy_circuit(noise_params=NP, noise_model='circuit_level')
+    noisy.detector_error_model(decompose_errors=True)
+    assert len(noisy.shortest_graphlike_error()) == d
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_shrink_d3(basis):
+    # shrunk code: 8 checks; kept-uid = 4 bulk + 3 lobes = 7; new = truncated X(4,6)
+    _check(3, basis, kept_expect=7)
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_shrink_d5(basis):
+    # 24 checks; kept-uid = 16 bulk + 6 lobes = 22; new = 2 truncated X lobes
+    _check(5, basis, kept_expect=22)

--- a/tests/test_tracker_closure_contract.py
+++ b/tests/test_tracker_closure_contract.py
@@ -63,3 +63,48 @@ def test_high_weight_product_row_still_emits_closure_detector():
 
     # The assembled history is physically consistent: silent at p=0.
     assert not circuit.compile_detector_sampler(seed=0).sample(1024).any()
+
+
+def test_sentinel_tagged_gauge_row_emits_no_detector():
+    """The sentinel-record branch (kept by design, review follow-up: 'keep
+    its semantics covered separately'): a stabilizer row whose records
+    carry UNMEASURED_STAB_RECORD is an unwatched gauge direction's
+    close-out — its only content is init-parity == readout-parity with no
+    banked init record, so emitting it would attach an unbanked,
+    per-shot-random parity.  The terminal readout must skip exactly these
+    rows, by PROVENANCE (the sentinel), never by support weight."""
+    import numpy as np
+    import stim
+    from lightstim.ir.tracker import SyndromeTracker, UNMEASURED_STAB_RECORD
+
+    n = 4
+    circuit = stim.Circuit("""
+        R 0 1 2 3
+        MPP Z0*Z1
+        M 0 1 2 3
+    """)
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 1
+
+    watched = np.zeros(2 * n, dtype=np.uint8)
+    watched[[n + 0, n + 1]] = 1
+    unwatched = np.zeros(2 * n, dtype=np.uint8)
+    unwatched[[n + 2, n + 3]] = 1
+    tracker.stabilizers.matrix = np.vstack([watched, unwatched])
+    tracker.stabilizers.records = [[0], [UNMEASURED_STAB_RECORD]]
+
+    final_paulis = np.zeros((n, 2 * n), dtype=np.uint8)
+    for q in range(n):
+        final_paulis[q, n + q] = 1
+    tracker.process_data_measurement(
+        circuit, final_paulis,
+        idx_to_coord_map={q: (float(q), 0.0) for q in range(n)})
+
+    detectors = [i for i in circuit.flattened() if i.name == "DETECTOR"]
+    assert len(detectors) == 1, (
+        f"only the record-carrying row may close out; got {len(detectors)}")
+    recs = {t.value + circuit.num_measurements
+            for t in detectors[0].targets_copy()}
+    assert recs == {0, 1, 2}, (
+        f"the emitted closure must be the WATCHED row's (MPP rec 0 + finals "
+        f"of qubits 0/1); got absolute records {sorted(recs)}")

--- a/tests/test_tracker_closure_contract.py
+++ b/tests/test_tracker_closure_contract.py
@@ -1,0 +1,65 @@
+"""Terminal-readout closure contract, independent of any patch/PPM geometry.
+
+The tracker's stabilizer bank is not a canonical basis: row updates during
+measurement processing multiply rows together, so a bank row can be a
+product of local checks whose Pauli support exceeds any single physical
+check.  Its terminal closure is legitimate syndrome information and must be
+emitted like every other determined row's — suppressing it by a support
+weight threshold silently costs decoder information (paired-noise MWPM LER
+is ~30% worse without the closure; PR #68 review, blocker #1).
+
+This test drives SyndromeTracker directly with a deliberately non-canonical
+bank so the contract is pinned at the tracker layer, not via any lattice
+surgery construction.
+"""
+import numpy as np
+import stim
+
+from lightstim.ir.tracker import SyndromeTracker
+
+
+def test_high_weight_product_row_still_emits_closure_detector():
+    n = 6
+    # Physical history on |0..0>: MPP C2 = Z3Z4Z5 (rec 0), then
+    # MPP C1 = Z0Z1Z2Z3 (rec 1), then transversal Z readout (recs 2..7).
+    # Every parity below is deterministic.
+    circuit = stim.Circuit("""
+        R 0 1 2 3 4 5
+        MPP Z3*Z4*Z5
+        MPP Z0*Z1*Z2*Z3
+        M 0 1 2 3 4 5
+    """)
+
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 2  # the two MPPs above
+
+    # Non-canonical bank: row A = C2 (support 3, record [0]); row B = C1*C2
+    # = Z0 Z1 Z2 Z4 Z5 (support 5 — above any single check), records [0, 1].
+    row_a = np.zeros(2 * n, dtype=np.uint8)
+    row_a[[n + 3, n + 4, n + 5]] = 1
+    row_b = np.zeros(2 * n, dtype=np.uint8)
+    row_b[[n + 0, n + 1, n + 2, n + 4, n + 5]] = 1
+    tracker.stabilizers.matrix = np.vstack([row_a, row_b])
+    tracker.stabilizers.records = [[0], [0, 1]]
+
+    final_paulis = np.zeros((n, 2 * n), dtype=np.uint8)
+    for q in range(n):
+        final_paulis[q, n + q] = 1  # Z readout, order matches the M above
+
+    tracker.process_data_measurement(
+        circuit,
+        final_paulis,
+        idx_to_coord_map={q: (float(q), 0.0) for q in range(n)},
+    )
+
+    detectors = [i for i in circuit.flattened() if i.name == "DETECTOR"]
+    assert len(detectors) == 2, (
+        "every determined stabilizer bank row must emit its closure "
+        f"detector; got {len(detectors)}"
+    )
+    # Row A closes over 1 historical + 3 final records; row B (the
+    # high-support product) over 2 historical + 5 final records.
+    assert sorted(len(i.targets_copy()) for i in detectors) == [4, 7]
+
+    # The assembled history is physically consistent: silent at p=0.
+    assert not circuit.compile_detector_sampler(seed=0).sample(1024).any()

--- a/tests/test_tracker_row_metadata.py
+++ b/tests/test_tracker_row_metadata.py
@@ -1,0 +1,116 @@
+"""Stabilizer-row metadata stays valid across row deletion/reordering.
+
+post_select_row_indices and stabilizer_with_logical_components hold ROW
+indices into the stabilizer tableau.  Any path that deletes rows must shift
+them (a stale index silently post-selects or reclassifies a DIFFERENT row),
+and any path that recombines the basis — where old indices lose all meaning
+— must fail loud instead.  Geometry-independent: drives SyndromeTracker
+directly, like test_tracker_closure_contract.
+"""
+import numpy as np
+import pytest
+import stim
+
+from lightstim.ir.tracker import SyndromeTracker
+
+
+def _z_row(n, qubits):
+    row = np.zeros(2 * n, dtype=np.uint8)
+    for q in qubits:
+        row[n + q] = 1
+    return row
+
+
+def test_declare_logical_remaps_row_metadata():
+    n = 6
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 3
+    tracker.stabilizers.matrix = np.vstack(
+        [_z_row(n, [0, 1]), _z_row(n, [2, 3]), _z_row(n, [4, 5])])
+    tracker.stabilizers.records = [[0], [1], [2]]
+    tracker.post_select_row_indices = {2}
+    tracker.stabilizer_with_logical_components = {2}
+    tracker._gauge_logical_vectors = [np.zeros(0, dtype=np.uint8)]
+
+    # Declaring Z2Z3 pins exactly row 1; row 1 is dropped, row 2 shifts to 1.
+    tracker.declare_logical(_z_row(n, [2, 3]))
+
+    assert tracker.post_select_row_indices == {1}
+    assert tracker.stabilizer_with_logical_components == {1}
+    assert len(tracker._gauge_logical_vectors) == 1
+
+
+def test_declare_logical_drops_metadata_of_consumed_row():
+    n = 4
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 2
+    tracker.stabilizers.matrix = np.vstack(
+        [_z_row(n, [0, 1]), _z_row(n, [2, 3])])
+    tracker.stabilizers.records = [[0], [1]]
+    tracker.post_select_row_indices = {1}
+
+    # Row 1 itself is the pinning row being dropped: its mark must vanish,
+    # not dangle at an out-of-range or recycled index.
+    tracker.declare_logical(_z_row(n, [2, 3]))
+
+    assert tracker.post_select_row_indices == set()
+
+
+def test_retire_qubits_remaps_swlc_and_post_select():
+    n = 3
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 2
+    tracker.stabilizers.matrix = np.vstack(
+        [_z_row(n, [0]), _z_row(n, [1, 2])])
+    tracker.stabilizers.records = [[0], [1]]
+    tracker.post_select_row_indices = {1}
+    tracker.stabilizer_with_logical_components = {1}
+    tracker._gauge_logical_vectors = [np.zeros(0, dtype=np.uint8)]
+
+    # q0's destructive readout drops the pure-q0 pivot row 0.
+    tracker.retire_qubits([0])
+
+    assert tracker.post_select_row_indices == {0}
+    assert tracker.stabilizer_with_logical_components == {0}
+
+
+def test_terminal_readout_shifts_surviving_post_select():
+    n = 4
+    circuit = stim.Circuit("""
+        R 0 1 2 3
+        MPP Z0*Z1
+        MPP Z2*Z3
+        M 0 1
+    """)
+    tracker = SyndromeTracker(n, 0)
+    tracker.total_measurements = 2
+    tracker.stabilizers.matrix = np.vstack(
+        [_z_row(n, [0, 1]), _z_row(n, [2, 3])])
+    tracker.stabilizers.records = [[0], [1]]
+    tracker.post_select_row_indices = {1}
+
+    final_paulis = np.zeros((2, 2 * n), dtype=np.uint8)
+    final_paulis[0, n + 0] = 1
+    final_paulis[1, n + 1] = 1
+    tracker.process_data_measurement(
+        circuit, final_paulis,
+        idx_to_coord_map={q: (float(q), 0.0) for q in range(n)})
+
+    # Row 0 closed out (consumed); row 1 survived and now sits at index 0.
+    assert tracker.stabilizers.count == 1
+    assert tracker.post_select_row_indices == {0}
+
+
+@pytest.mark.parametrize("method", ["stabilizer_canonicalization",
+                                    "rebase_stabilizers_onto_code_basis"])
+@pytest.mark.parametrize("pending", ["post_select_row_indices",
+                                     "stabilizer_with_logical_components"])
+def test_basis_recombination_rejects_pending_row_metadata(method, pending):
+    tracker = SyndromeTracker(4, 0)
+    tracker.stabilizers.matrix = _z_row(4, [0, 1]).reshape(1, -1)
+    tracker.stabilizers.records = [[0]]
+    getattr(tracker, pending).add(0)
+
+    # The guard sits at function entry, before the system is touched.
+    with pytest.raises(RuntimeError, match="recombined"):
+        getattr(tracker, method)(system=None)


### PR DESCRIPTION
**Stacked on #75** — the first 11 commits are that PR's tracker/lifecycle contract; review this one from `89bc8e9` onward. After #75 merges, a rebase shrinks this diff to the PPM layer alone.

This is the general-PPM PR requested in the #68 review: the sequential PPM stack ported from the design branch onto the repaired tracker contract and reshaped into the requested general lowering layer — a pure kernel behind an explicit compiler-facing API, per-lowering algebraic certificates, protocol-output handles, and the sequential experiment layer, with every unsupported case rejected loudly and pinned by a fixture.

## Layers (review in this order)

| commit | layer |
|---|---|
| 89bc8e9 | **Port** of `protocols/ppm/` (spec, seam_rules, coupler, sequential) + its minimal geometry closure onto the repaired tracker. 35 ported tests unchanged; the built circuit is byte-identical to the design branch (sha256 under a pinned `PYTHONHASHSEED`) |
| 752c783 | **Lowering kernel**: `PPMRequest` → `lower_ppm()` (pure) → `LoweringPlan` → `apply_plan()` (the single mutation). The route is explicit everywhere — no auto-router exists and no name implies one. `Y` raises `UnsupportedPauliError` naming the missing twist/Y-wall construction. The eleven-item algebraic oracle, previously computed inside `route_and_build` and discarded to a boolean, is captured as `LoweringPlan.certificate`; `certificate.measures_exactly_the_product` pins the true weight-w instrument guarantee (joint measured; no single logical, no proper subset product exposed) |
| fb04b6a | **Protocol outputs**: every applied PPM banks a `PPMOutcome` — the joint's measurement-record parity before the merge (`None` = legitimately random) and after the split. Deliberately distinct from the EVALUATION observables the readout emits |
| fe84244, f24eeb5 | **Verification matrix**: weights 2/3 with the exact-product certificate asserted and weight-4 as an explicit-gap fixture; straight / longer-straight / bent-L (forces the diagonal schedule) / branched-T routes; commuting repeat (shot-by-shot reproducible) and an anti-commuting corner pair (free-coin protocol output, certified correlations silent); d=5 representative (slow-marked); and a measurement-block engine round over post-PPM tracker state driven through the kernel API with no experiment driver — the test that caught the census-quotient bug fixed in #75 |
| af7e02e, 760df15 | **Design note + capability table** (`docs/specs/ppm-lowering.md`), including a "Known interface gaps" section that lists every deliberate scope cut against the review's interface spec (wall plans carry `certificate=None`; paused checks live in activation, not a plan field; no `post_state` field; corridor-path representatives derived from registered logical operators; the evaluation specification is implicit). `record_parity` refuses reconstruction through UNMEASURED-sentinel rows |
| e6758d1 | **Runnable example notebook** (`notebooks/LogicalOps/ppm_lowering.ipynb`, committed output-free, indexed in the README): one two-step sequence on three patches — `M(Z̄A Z̄B)` then `M(Z̄B Z̄C)` — built through the kernel API alone and through `SequentialPPMExperiment`; both flows produce identical circuits (113 qubits, 56 ticks, 249 detectors, 2 observables) and each section renders the full-circuit `detslice-with-ops-svg` |

## Capability summary

Standard rotated rectangular patches (`PatchSpec` adapter; colour-swap knob; cell-adjacent classification probes the LIVE system). Letters X/Z, homogeneous and mixed. Weights 2 and 3. Routes: zero-cell, straight, bent/L, branched/T. Commuting and anti-commuting sequences, corridor reuse, idle spectators, composition with the measurement-block engine. **Explicit rejections, each pinned by a fixture**: `Y` (needs a twist/Y-wall construction; silently rewriting it would be a different quantum instrument) and weight ≥ 4 chains (need the snake/kf-wall attach machinery not carried by this variant).

## Intentionally NOT ported from #68

Litinski/SWAP rotation stacks, Y-boundary/Y-transition rounds, snake steps, liveness/first-use-init, decoder correlation changes (this PR uses `main`'s decoder as-is), and the notebook deletions. #68 stays open as the design/reference branch.

## Suite

`pytest tests/ -m "not slow"`: **475 passed, 10 skipped** (the #75 base: 425). Circuit builds are process-nondeterministic without a pinned `PYTHONHASHSEED` (set ordering reaches detector-coordinate assignment; physics unaffected) — byte-level equivalence claims here were measured under a pinned seed with the resolved source tree printed.

@x8fangQ this is the second of the stacked pair — opened as draft per the review instruction; it does not wait for #75 to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
