### PR TITLE
Fix toric logical operator representatives

### DIFF
--- a/lightstim/qec_code/surface_code/toric/code_patch.py
+++ b/lightstim/qec_code/surface_code/toric/code_patch.py
@@ -98,16 +98,21 @@ class ToricCode(QECPatch):
             self.create_stim_stabilizer(targets, syn_coord, "Z")
 
         # Phase 3: Logical Operators (2 logical qubits)
-        # Logical 0: Z horizontal, X vertical
-        z0_targets = {(2 * x, 0): "Z" for x in range(dz)}
+        #
+        # The checkerboard contains two data-qubit sublattices.  A logical
+        # loop must stay on the appropriate sublattice so that every
+        # opposite-type stabilizer has even overlap with it.
+        #
+        # Logical 0: horizontal Z and vertical X on the odd sublattice.
+        z0_targets = {(2 * x + 1, 1): "Z" for x in range(dz)}
         self.create_stim_logical(z0_targets, "Z")
-        x0_targets = {(0, 2 * y): "X" for y in range(dx)}
+        x0_targets = {(1, 2 * y + 1): "X" for y in range(dx)}
         self.create_stim_logical(x0_targets, "X")
 
-        # Logical 1: Z horizontal shifted, X vertical shifted
-        z1_targets = {(2 * x, 2): "Z" for x in range(dz)}
+        # Logical 1: vertical Z and horizontal X on the even sublattice.
+        z1_targets = {(0, 2 * y): "Z" for y in range(dx)}
         self.create_stim_logical(z1_targets, "Z")
-        x1_targets = {(2, 2 * y): "X" for y in range(dx)}
+        x1_targets = {(2 * x, 0): "X" for x in range(dz)}
         self.create_stim_logical(x1_targets, "X")
 
         self.num_logicals = 2

--- a/tests/test_toric_code.py
+++ b/tests/test_toric_code.py
@@ -1,0 +1,99 @@
+"""Algebraic regression tests for the explicit toric logical operators."""
+
+import numpy as np
+import pytest
+
+from lightstim.qec_code.surface_code.toric import ToricCode
+
+
+def _support(record):
+    return set(record["data_indices"])
+
+
+def _opposite_type_overlap(left, right):
+    if left["type"] == right["type"]:
+        return 0
+    return len(_support(left) & _support(right)) % 2
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"distance": 2},
+        {"distance": 3},
+        {"l_z": 4, "l_x": 3},
+        {"l_z": 3, "l_x": 2, "shift": (7, -2)},
+    ],
+)
+def test_explicit_logical_operators_form_two_valid_pairs(params):
+    code = ToricCode(**params)
+    logical_z = [op for op in code.logical_ops if op["type"] == "Z"]
+    logical_x = [op for op in code.logical_ops if op["type"] == "X"]
+
+    assert len(logical_z) == len(logical_x) == code.num_logicals == 2
+
+    # Every logical representative must lie in the stabilizer normalizer.
+    for logical in code.logical_ops:
+        assert set(logical["pauli"]) == _support(logical)
+        assert set(logical["pauli"].values()) == {logical["type"]}
+        assert _support(logical) <= code.data_indices
+        assert all(
+            _opposite_type_overlap(logical, stabilizer) == 0
+            for stabilizer in code.stabilizers
+        )
+
+    # The declared order is (Z_0, X_0, Z_1, X_1), so the symplectic
+    # pairing between the extracted X and Z lists must be the identity.
+    pairing = np.array(
+        [
+            [len(_support(x_op) & _support(z_op)) % 2 for z_op in logical_z]
+            for x_op in logical_x
+        ],
+        dtype=np.uint8,
+    )
+    assert np.array_equal(pairing, np.eye(code.num_logicals, dtype=np.uint8))
+
+    assert [len(_support(op)) for op in logical_z] == [code.l_z, code.l_x]
+    assert [len(_support(op)) for op in logical_x] == [code.l_x, code.l_z]
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_supports"),
+    [
+        (
+            {"distance": 2},
+            [
+                {(1, 1), (3, 1)},
+                {(1, 1), (1, 3)},
+                {(0, 0), (0, 2)},
+                {(0, 0), (2, 0)},
+            ],
+        ),
+        (
+            {"distance": 3},
+            [
+                {(1, 1), (3, 1), (5, 1)},
+                {(1, 1), (1, 3), (1, 5)},
+                {(0, 0), (0, 2), (0, 4)},
+                {(0, 0), (2, 0), (4, 0)},
+            ],
+        ),
+        (
+            {"l_z": 2, "l_x": 3, "shift": (7, -2)},
+            [
+                {(8, -1), (10, -1)},
+                {(8, -1), (8, 1), (8, 3)},
+                {(7, -2), (7, 0), (7, 2)},
+                {(7, -2), (9, -2)},
+            ],
+        ),
+    ],
+)
+def test_logical_support_coordinates(params, expected_supports):
+    code = ToricCode(**params)
+    supports = [
+        {code.qubit_coords[index] for index in op["data_indices"]}
+        for op in code.logical_ops
+    ]
+
+    assert supports == expected_supports


### PR DESCRIPTION
## Summary

- correct the four explicit logical representatives of the periodic checkerboard toric patch
- place the two logical pairs on the appropriate odd/even data sublattices
- add algebraic regressions for normalizer membership, canonical symplectic pairing, support size, rectangular patches, and coordinate shifts

## Root cause

The previous logical strings followed rows and columns on the wrong data sublattices. Each declared operator therefore had odd overlap with several opposite-type stabilizers and was not in the stabilizer normalizer. The two declared pairs were also not symplectically independent.

This affected consumers that read `ToricCode.logical_ops` directly, such as a future joint logical parity measurement. Existing memory circuits were unaffected because the Pauli tracker derives their observables dynamically.

## Validation

- `tests/test_toric_code.py` plus toric scheduling selection: 13 passed
- HGP/toric Tanner-equivalence regression: 1 passed
- toric memory protocol smoke test: 1 passed
- verified that clearing `patch.logical_ops` still produces the identical existing d=3 Z-memory circuit (56 detectors, 2 observables)
