### PR TITLE
Fix TG distillation decoder selection

### DIFF
--- a/benchmarks/logical_circuits/README.md
+++ b/benchmarks/logical_circuits/README.md
@@ -94,6 +94,8 @@ fault-tolerant verification path.
 > hyperedge DEMs. Use `mwpf` (CPU), `cpu_bposd` (CPU BP+OSD), or `gpu_bposd`
 > (CUDA BP+OSD via `cudaq_qec`) for these.
 > LS-based experiments (ZZ-LS, XX-LS, LS distillation) use `pymatching`.
+> The runner defaults TG distillation to `cpu_bposd` and LS distillation to
+> `pymatching` when `--decoder` is omitted.
 > `gpu_bposd` requires a visible NVIDIA GPU (`nvidia-smi -L`).
 
 ## Output format

--- a/benchmarks/logical_circuits/run_logical_circuits.py
+++ b/benchmarks/logical_circuits/run_logical_circuits.py
@@ -363,7 +363,9 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
     noise_modes = args.noise_mode or ["injection"]
     p_injected_list = args.p_injected or [1e-3, 5e-3, 2e-2]
     p_list = args.p_values if args.p_values else [1e-3]
-    decoder_name = args.decoder or "pymatching"
+    decoder_name = args.decoder or (
+        "cpu_bposd" if which == "tg" else "pymatching"
+    )
     decoder_cfg = _checked_decoder_config(decoder_name)
 
     if which == "ls" and decoder_cfg.backend != "cpu":
@@ -411,11 +413,20 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
                 # Calibrate p_in (injection and both modes only)
                 if mode in ("injection", "both"):
                     p_bg = p if mode == "both" else 0.0
-                    p_in = p_in_fn(d, rounds_init, p_injected=p_inj,
-                                   p_background=p_bg,
-                                   max_shots=args.max_shots // 10,
-                                   max_errors=50,
-                                   batch_size=5_000)
+                    calibration_kwargs = {
+                        "p_injected": p_inj,
+                        "p_background": p_bg,
+                        "max_shots": args.max_shots // 10,
+                        "max_errors": 50,
+                        "batch_size": 5_000,
+                    }
+                    if which == "tg":
+                        calibration_kwargs.update({
+                            "decoder_name": decoder_cfg.name,
+                            "backend": decoder_cfg.backend,
+                            "decoder_params": decoder_cfg.params,
+                        })
+                    p_in = p_in_fn(d, rounds_init, **calibration_kwargs)
                 else:
                     p_in = float("nan")
 

--- a/lightstim/protocols/tg_distillation.py
+++ b/lightstim/protocols/tg_distillation.py
@@ -228,7 +228,8 @@ def inject_noise(circuit, magic_qubits, p, p_injected, mode="full"):
 
 
 def estimate_p_in(d, rounds_init=None, p_injected=1e-3, p_background=0.0,
-                  max_shots=10_000_000, max_errors=100, batch_size=5_000):
+                  max_shots=10_000_000, max_errors=100, batch_size=5_000,
+                  decoder_name="bposd", backend="cpu", decoder_params=None):
     """
     Estimate effective logical input infidelity P_in for TG |Y⟩ magic state.
 
@@ -237,6 +238,9 @@ def estimate_p_in(d, rounds_init=None, p_injected=1e-3, p_background=0.0,
 
     Args:
         rounds_init: SE rounds after corner injection. Defaults to d (paper setting).
+        decoder_name: Hypergraph-capable decoder used for calibration.
+        backend: Decoder backend. The notebook uses CPU BP+OSD.
+        decoder_params: Optional decoder-specific parameters.
 
     Returns:
         p_in (float): logical error rate of the corner-injected |Y⟩ state.
@@ -280,10 +284,15 @@ def estimate_p_in(d, rounds_init=None, p_injected=1e-3, p_background=0.0,
     noisy = inj.inject_noise(circuit)
 
     pipeline = SimulationPipeline(
-        decoder_config=DecoderConfig("pymatching"),
+        decoder_config=DecoderConfig(
+            decoder_name,
+            backend=backend,
+            params=decoder_params or {},
+        ),
         max_shots=max_shots,
         max_errors=max_errors,
         batch_size=batch_size,
+        num_workers=1,
         target_observable_indices=[0],
         print_progress=False,
     )
@@ -291,7 +300,7 @@ def estimate_p_in(d, rounds_init=None, p_injected=1e-3, p_background=0.0,
 
 
 def run_simulation(circuit, magic_qubits, p, p_injected, mode,
-                   T, ps_indices, target_indices, decoder_name,
+                   T, ps_indices, target_indices, decoder_name="bposd",
                    max_shots=10_000_000, max_errors=200,
                    num_workers=32, backend="cpu", batch_size=50_000,
                    decoder_params=None):

--- a/lightstim/simulation/decoder_backend/decoders/bposd.py
+++ b/lightstim/simulation/decoder_backend/decoders/bposd.py
@@ -1,11 +1,15 @@
-"""BP+OSD decoder (CPU) for quantum LDPC codes.
+"""BP+OSD decoder (CPU) for hypergraph detector error models.
 
 Prefers stimbposd; falls back to ldpc package if stimbposd not installed.
 Accepts unified parameter names shared with the GPU backend (see cudaqx.py).
 """
 
+import numpy as np
+import scipy.sparse as sp
 import sinter
+import stim
 
+from ..dem_matrices import dem_to_matrices
 from ..registry import register_decoder
 
 _BPOSD_AVAILABLE = False
@@ -91,11 +95,110 @@ class BpOsdCpuDecoder(sinter.Decoder):
     """Thin wrapper around SinterDecoder_BPOSD that accepts unified parameter names."""
 
     def __init__(self, **params):
-        translated = _unified_to_cpu({**_DEFAULTS, **params})
-        self._inner = SinterDecoder_BPOSD(**translated)
+        self._translated = _unified_to_cpu({**_DEFAULTS, **params})
+        self._inner = SinterDecoder_BPOSD(**self._translated)
 
     def compile_decoder_for_dem(self, *, dem):
+        # stimbposd limits the requested OSD order to n_columns - n_rows.
+        # Detector-rich, low-rank DEMs (notably injection-only protocols) can
+        # have more detector rows than error mechanisms, making that value
+        # negative and causing ldpc to reject the decoder at compile time.
+        # Keep the normal path untouched, and row-reduce only when it would
+        # otherwise be impossible for stimbposd to select a valid OSD order.
+        if dem.num_detectors > dem.num_errors:
+            reduced_dem, detector_rows = _independent_detector_dem(dem)
+            compiled = self._inner.compile_decoder_for_dem(dem=reduced_dem)
+            return _DetectorSubsetCompiledDecoder(
+                compiled=compiled,
+                detector_rows=detector_rows,
+                num_detectors=dem.num_detectors,
+            )
         return self._inner.compile_decoder_for_dem(dem=dem)
+
+
+class _DetectorSubsetCompiledDecoder(sinter.CompiledDecoder):
+    """Project packed syndromes onto independent original detector rows."""
+
+    def __init__(self, *, compiled, detector_rows, num_detectors):
+        self._compiled = compiled
+        self._detector_rows = np.asarray(detector_rows, dtype=np.int64)
+        self._num_detectors = num_detectors
+
+    def decode_shots_bit_packed(self, *, bit_packed_detection_event_data):
+        syndromes = np.unpackbits(
+            bit_packed_detection_event_data,
+            axis=1,
+            bitorder="little",
+        )[:, :self._num_detectors]
+        reduced = syndromes[:, self._detector_rows]
+        reduced_packed = np.packbits(reduced, axis=1, bitorder="little")
+        return self._compiled.decode_shots_bit_packed(
+            bit_packed_detection_event_data=reduced_packed
+        )
+
+
+def _independent_detector_dem(dem):
+    """Return an equivalent DEM containing only independent detector rows."""
+    check_matrix, observables_matrix, priors = dem_to_matrices(
+        dem,
+        sparse=True,
+        merge_duplicates=False,
+    )
+    detector_rows = _independent_row_indices(check_matrix)
+    reduced_checks = check_matrix[detector_rows].tocsc()
+    observables = observables_matrix.tocsc()
+
+    reduced_dem = stim.DetectorErrorModel()
+    for error_index, probability in enumerate(priors):
+        targets = [
+            stim.target_relative_detector_id(int(row))
+            for row in reduced_checks.indices[
+                reduced_checks.indptr[error_index]:
+                reduced_checks.indptr[error_index + 1]
+            ]
+        ]
+        targets.extend(
+            stim.target_logical_observable_id(int(observable))
+            for observable in observables.indices[
+                observables.indptr[error_index]:
+                observables.indptr[error_index + 1]
+            ]
+        )
+        reduced_dem.append("error", float(probability), targets)
+
+    # An observable with no error mechanism still contributes an output bit.
+    # Preserve the original DEM's output width for the sinter contract.
+    if reduced_dem.num_observables < dem.num_observables:
+        reduced_dem.append(
+            "logical_observable",
+            [],
+            [stim.target_logical_observable_id(dem.num_observables - 1)],
+        )
+
+    return reduced_dem, detector_rows
+
+
+def _independent_row_indices(check_matrix):
+    """Select original rows forming a GF(2) basis without densifying H."""
+    matrix = sp.csr_matrix(check_matrix, dtype=np.uint8)
+    pivots = {}
+    selected = []
+
+    for row in range(matrix.shape[0]):
+        value = 0
+        for column in matrix.indices[matrix.indptr[row]:matrix.indptr[row + 1]]:
+            value ^= 1 << int(column)
+
+        while value:
+            pivot = value.bit_length() - 1
+            basis_row = pivots.get(pivot)
+            if basis_row is None:
+                pivots[pivot] = value
+                selected.append(row)
+                break
+            value ^= basis_row
+
+    return np.asarray(selected, dtype=np.int64)
 
 
 if _BPOSD_AVAILABLE:

--- a/notebooks/LogicalCircuits/tg_distillation.ipynb
+++ b/notebooks/LogicalCircuits/tg_distillation.ipynb
@@ -19,7 +19,8 @@
     "  - Calibration circuit: corner_inject('Y') → SE(rounds) → noiseless S†_L → MX\n",
     "  - Noise model: Z_ERROR(p_injected) on corner qubit\n",
     "- **p_out**: post-selected LER of W0 output (post-select on M1–M7 observables)\n",
-    "- **Theory**: p_out ≈ 7 · p_in³ (third-order Steane distillation, same as LS)"
+    "- **Theory**: p_out ≈ 7 · p_in³ (third-order Steane distillation, same as LS)\n",
+    "- **Decoder**: CPU BP+OSD, which supports the hyperedge DEM produced by the TG circuit"
    ]
   },
   {
@@ -171,7 +172,8 @@
     "TG uses **corner injection**: inject |Y⟩ at one corner data qubit, run d SE rounds,\n",
     "then apply noiseless S†_L and MX to read out the logical Y error rate.\n",
     "\n",
-    "Noise model: `Z_ERROR(p_injected)` on the corner qubit only (injection-only mode)."
+    "Noise model: `Z_ERROR(p_injected)` on the corner qubit only (injection-only mode).  \n",
+    "In this restricted model the injection mechanisms flip logical observables but no detector rows. We still use CPU BP+OSD so the decoder choice remains valid when circuit-level noise introduces TG hyperedges."
    ]
   },
   {
@@ -196,7 +198,8 @@
     "\n",
     "for p_inj in p_injected_values:\n",
     "    p_in = estimate_p_in(d, rounds_init=rounds_init, p_injected=p_inj,\n",
-    "                         max_shots=500_000, max_errors=50, batch_size=5_000)\n",
+    "                         max_shots=500_000, max_errors=50, batch_size=5_000,\n",
+    "                         decoder_name=\"bposd\", backend=\"cpu\")\n",
     "    p_in_values[p_inj] = p_in\n",
     "    print(f\"p_injected={p_inj:.0e}  →  p_in={p_in:.3e}\")"
    ]
@@ -334,7 +337,7 @@
     "print(f\"\\np_injected={p_inj:.0e}  (p_in≈{p_in_values[p_inj]:.2e})\")\n",
     "stats = run_simulation(\n",
     "    circuit, magic_qubits, 0.0, p_inj, \"injection\",\n",
-    "    T, ps_obs, target_obs, \"pymatching\",\n",
+    "    T, ps_obs, target_obs, \"bposd\",\n",
     "    max_shots=500_000, max_errors=30, batch_size=5_000,\n",
     ")\n",
     "results.append({\n",

--- a/tests/test_simulation_backend_quality.py
+++ b/tests/test_simulation_backend_quality.py
@@ -148,6 +148,73 @@ def test_ldpc_bp_registered_and_runs():
     assert stats.shots > 0
 
 
+def test_bposd_handles_more_detector_rows_than_error_mechanisms():
+    """Redundant/zero detector rows must not produce a negative OSD order."""
+    importorskip_safe("stimbposd")
+
+    dem = stim.DetectorErrorModel(
+        """
+        error(0.1) D0 D1 L2
+        error(0.2) D1 D2
+        detector D3
+        detector D4
+        """
+    )
+    decoder = get_decoder("bposd", backend="cpu")
+    compiled = decoder.compile_decoder_for_dem(dem=dem)
+
+    # The first two rows are an independent basis. D2 is their XOR and D3/D4
+    # are zero rows. These valid syndromes uniquely identify the two errors.
+    syndromes = np.array(
+        [
+            [0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0],
+            [0, 1, 1, 0, 0],
+            [1, 0, 1, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    predictions = compiled.decode_shots_bit_packed(
+        bit_packed_detection_event_data=np.packbits(
+            syndromes, axis=1, bitorder="little"
+        )
+    )
+    predictions = np.unpackbits(
+        predictions, axis=1, bitorder="little"
+    )[:, :3]
+
+    np.testing.assert_array_equal(
+        predictions,
+        [
+            [0, 0, 0],
+            [0, 0, 1],
+            [0, 0, 0],
+            [0, 0, 1],
+        ],
+    )
+
+
+def test_bposd_handles_observable_only_error_mechanisms():
+    """Injection-only DEMs may contain detectors untouched by every error."""
+    importorskip_safe("stimbposd")
+
+    dem = stim.DetectorErrorModel(
+        """
+        error(0.1) L0
+        detector D0
+        detector D1
+        """
+    )
+    compiled = get_decoder("bposd", backend="cpu").compile_decoder_for_dem(
+        dem=dem
+    )
+    predictions = compiled.decode_shots_bit_packed(
+        bit_packed_detection_event_data=np.zeros((3, 1), dtype=np.uint8)
+    )
+
+    np.testing.assert_array_equal(predictions, np.zeros((3, 1), dtype=np.uint8))
+
+
 def test_tesseract_registered_and_runs():
     """Tesseract (sinter-native, Pattern A, lazy import) registers and decodes.
 


### PR DESCRIPTION
## Summary

- use CPU BP+OSD by default for TG distillation while keeping PyMatching for LS distillation
- pass the selected decoder through TG input-state calibration instead of hard-coding PyMatching
- update the TG notebook to use CPU BP+OSD and document why injection-only noise is a degenerate zero-syndrome case
- make the CPU BP+OSD wrapper handle detector-rich, low-rank DEMs by projecting syndromes onto independent GF(2) detector rows before compiling `stimbposd`

## Root cause

TG circuits produce hyperedge detector error models under circuit-level noise, but the notebook and distillation runner selected PyMatching. Injection-only runs happened to work because their error mechanisms flip logical observables without touching detector rows, so PyMatching was not doing meaningful syndrome decoding.

Switching that path to BP+OSD exposed a second issue: `stimbposd` clips OSD order using `num_errors - num_detectors`. Injection-only DEMs can have many zero or dependent detector rows and very few error mechanisms, producing a negative OSD order. The adapter now keeps an independent set of original detector checks and projects packed input syndromes onto that equivalent basis.

## Validation

- `pytest -q tests/test_simulation_backend_quality.py tests/test_protocols.py --disable-warnings`
- executed `notebooks/LogicalCircuits/tg_distillation.ipynb` end to end with CPU BP+OSD
- notebook sample: 500,000 shots, 434,351 retained, 22 errors, `p_out = 5.07e-5`
- ran the TG benchmark without `--decoder` and confirmed the result records `decoder=cpu_bposd`
- checked a normal rotated-surface-code BP+OSD memory run to confirm the existing non-reduced path remains operational
