### PR TITLE
feat(decoders): add exact MLE decoding with ACG-ALP and MILP fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ print(f"LER: {stats.logical_error_rate:.3e} ± {stats.ler_error_bar():.3e}")
 | MWPF | `DecoderConfig('mwpf')` | Hyperedges (CrossLS, PQRM, color code). |
 | Relay-BP | `DecoderConfig('relay-bp')` | LDPC / hyperedge circuits. Needs `.[decoders]`. |
 | Tesseract | `DecoderConfig('tesseract', params={'det_beam': 50})` | Beam-search MLE. Needs `.[decoders]`. |
+| Exact MLE | `DecoderConfig('mle-ilp')` | Exact reference decoder; unlimited by default. |
 | GPU BP+OSD | `DecoderConfig('nv-qldpc-decoder')` | NVIDIA GPU. Large d or high p. |
 
 ### Available QEC codes

--- a/benchmarks/logical_circuits/README.md
+++ b/benchmarks/logical_circuits/README.md
@@ -77,7 +77,9 @@ PYTHONPATH=. venv/bin/python benchmarks/logical_circuits/run_logical_circuits.py
 | `--state-preps` | `logical_gate` | S-gate resource-state preparation modes (`logical_gate` or `inject`) |
 | `--noise-mode` | `circuit_level` | `circuit_level` or `injection` |
 | `--p-injected` | — | Injection noise p (injection mode only) |
-| `--decoder` | auto | `pymatching`, `mwpf`, `cpu_bposd`, `gpu_bposd` (`bposd` and `nv-qldpc-decoder` are accepted aliases) |
+| `--decoder` | auto | `pymatching`, `mwpf`, `cpu_bposd`, `gpu_bposd`, `mle-ilp` (`bposd` and `nv-qldpc-decoder` are accepted aliases) |
+| `--mle-time-limit` | `0` | Soft seconds-per-shot limit for `mle-ilp`; zero is unlimited |
+| `--on-decode-failure` | `error` | Count, discard, or ignore decoder timeout/failure shots |
 | `--num-workers` | `8` | Parallel CPU workers (use 1 for GPU) |
 | `--max-shots` | `1e9` | Max shots per task |
 | `--max-errors` | `100` | Stop after N logical errors |
@@ -91,10 +93,21 @@ kept as protocol/notebook smoke demos until rotated logical S/S† provides a
 fault-tolerant verification path.
 
 > **Decoder guidance**: Bell teleportation (TG protocol) and TG distillation produce
-> hyperedge DEMs. Use `mwpf` (CPU), `cpu_bposd` (CPU BP+OSD), or `gpu_bposd`
+> hyperedge DEMs. Use `mle-ilp` for an exact small-instance reference, `mwpf`
+> (CPU), `cpu_bposd` (CPU BP+OSD), or `gpu_bposd`
 > (CUDA BP+OSD via `cudaq_qec`) for these.
 > LS-based experiments (ZZ-LS, XX-LS, LS distillation) use `pymatching`.
 > `gpu_bposd` requires a visible NVIDIA GPU (`nvidia-smi -L`).
+
+Exact MLE is unlimited by default. Large DEMs can have long solve tails, so a
+bounded benchmark should set both `--mle-time-limit` and an explicit
+`--on-decode-failure` policy, for example:
+
+```bash
+PYTHONPATH=. venv/bin/python benchmarks/logical_circuits/run_logical_circuits.py \
+    --experiment distill_tg --distances 3 --p-values 1e-3 \
+    --decoder mle-ilp --mle-time-limit 2 --on-decode-failure discard
+```
 
 ## Output format
 
@@ -102,22 +115,25 @@ fault-tolerant verification path.
 
 ```
 gate, protocol, state, routing_mult, d, rounds, p,
-shots, errors, logical_error_rate, decoder, seconds
+decoder, decoder_time_limit, on_decode_failure,
+shots, errors, logical_error_rate, seconds
 ```
 
 ### s_gate_tele
 
 ```
 experiment, code, method, state_prep, d, rounds, p,
-shots, errors, logical_error_rate, decoder, seconds
+decoder, decoder_time_limit, on_decode_failure,
+shots, errors, logical_error_rate, seconds
 ```
 
 ### distill_ls / distill_tg
 
 ```
 experiment, d, rounds, p_injected, noise_mode, p, p_in,
+decoder, decoder_time_limit, on_decode_failure,
 shots, post_selected_shots, post_selection_rate,
-errors, logical_error_rate, decoder, seconds
+errors, logical_error_rate, seconds
 ```
 
 ## How to plot

--- a/benchmarks/logical_circuits/run_logical_circuits.py
+++ b/benchmarks/logical_circuits/run_logical_circuits.py
@@ -20,8 +20,9 @@ CSV output
 
     distill_ls / distill_tg → results/{distill_ls|distill_tg}_results.csv
         experiment, d, rounds, p_injected, noise_mode, p, p_in,
+        decoder, decoder_time_limit, on_decode_failure,
         shots, post_selected_shots, post_selection_rate,
-        errors, logical_error_rate, decoder, seconds
+        errors, logical_error_rate, seconds
 
 All outputs use per-task checkpointing (append-on-complete).
 
@@ -104,23 +105,30 @@ from lightstim.protocols.tg_distillation import (
 
 _BELL_COLS = [
     "experiment", "protocol", "state", "routing_mult", "d", "rounds", "p",
-    "shots", "errors", "logical_error_rate", "decoder", "seconds",
+    "decoder", "decoder_time_limit", "on_decode_failure",
+    "shots", "errors", "logical_error_rate", "seconds",
 ]
 _S_GATE_COLS = [
     "experiment", "code", "method", "state_prep", "d", "rounds", "p",
-    "shots", "errors", "logical_error_rate", "decoder", "seconds",
+    "decoder", "decoder_time_limit", "on_decode_failure",
+    "shots", "errors", "logical_error_rate", "seconds",
 ]
 _DISTILL_COLS = [
     "experiment", "d", "rounds", "p_injected", "noise_mode", "p", "p_in",
+    "decoder", "decoder_time_limit", "on_decode_failure",
     "shots", "post_selected_shots", "post_selection_rate",
-    "errors", "logical_error_rate", "decoder", "seconds",
+    "errors", "logical_error_rate", "seconds",
 ]
-_BELL_RESULT_KEYS = frozenset({"shots", "errors", "logical_error_rate", "decoder", "seconds"})
+_BELL_RESULT_KEYS = frozenset({"shots", "errors", "logical_error_rate", "seconds"})
 _S_GATE_RESULT_KEYS = _BELL_RESULT_KEYS
 _DISTILL_RESULT_KEYS = frozenset({
-    "shots", "post_selected_shots", "post_selection_rate",
-    "errors", "logical_error_rate", "decoder", "seconds",
+    "p_in", "shots", "post_selected_shots", "post_selection_rate",
+    "errors", "logical_error_rate", "seconds",
 })
+_RESULT_METADATA_DEFAULTS = {
+    "decoder_time_limit": 0.0,
+    "on_decode_failure": "error",
+}
 
 
 # ── Checkpointing ─────────────────────────────────────────────────────────────
@@ -132,9 +140,31 @@ def _ck_key(row: dict, result_keys: frozenset) -> tuple:
     )
 
 
-def _load_done(path: Path, result_keys: frozenset) -> set:
+def _ensure_result_schema(path: Path, columns: list[str]) -> None:
+    """Upgrade pre-MLE benchmark CSVs before checkpointing or appending."""
+    if not path.exists():
+        return
+    import pandas as pd
+
+    df = pd.read_csv(path)
+    unknown = set(df.columns) - set(columns)
+    if unknown:
+        raise ValueError(
+            f"Cannot migrate {path}: unknown result columns {sorted(unknown)}"
+        )
+    changed = False
+    for column, default in _RESULT_METADATA_DEFAULTS.items():
+        if column not in df.columns:
+            df[column] = default
+            changed = True
+    if changed or list(df.columns) != columns:
+        df.reindex(columns=columns).to_csv(path, index=False)
+
+
+def _load_done(path: Path, result_keys: frozenset, columns: list[str]) -> set:
     if not path.exists():
         return set()
+    _ensure_result_schema(path, columns)
     import pandas as pd
     df = pd.read_csv(path)
     return {_ck_key(r, result_keys) for r in df.to_dict("records")}
@@ -149,8 +179,12 @@ def _append_row(path: Path, row: dict, cols: list) -> None:
         w.writerow(row)
 
 
-def _checked_decoder_config(name: str) -> DecoderConfig:
-    cfg = _decoder_config(name)
+def _checked_decoder_config(
+    name: str,
+    mle_time_limit: float = 0.0,
+    on_decode_failure: str = "error",
+) -> DecoderConfig:
+    cfg = _decoder_config(name, mle_time_limit, on_decode_failure)
     if cfg.backend != "gpu":
         return cfg
 
@@ -187,7 +221,7 @@ _BELL_DEFAULT_DECODER = {
 
 
 def _run_bell_tele(args, output_path: Path) -> None:
-    done = _load_done(output_path, _BELL_RESULT_KEYS)
+    done = _load_done(output_path, _BELL_RESULT_KEYS, _BELL_COLS)
     protocols = args.protocols if args.protocols else list(_BELL_DEFAULT_DECODER)
 
     pipeline_cache: dict = {}
@@ -204,6 +238,10 @@ def _run_bell_tele(args, output_path: Path) -> None:
             "rounds": f"pre={d} mid=1 post=1" if protocol == "tg" else f"pre={d} ls={d}",
             "p": p,
             "decoder": decoder_name,
+            "decoder_time_limit": (
+                args.mle_time_limit if decoder_name == "mle-ilp" else 0.0
+            ),
+            "on_decode_failure": args.on_decode_failure,
         }
         if _ck_key(row_proto, _BELL_RESULT_KEYS) in done:
             print(f"  SKIP {protocol} {state} d={d} p={p:.0e}")
@@ -216,7 +254,11 @@ def _run_bell_tele(args, output_path: Path) -> None:
 
         if decoder_name not in pipeline_cache:
             pipeline_cache[decoder_name] = SimulationPipeline(
-                decoder_config=_checked_decoder_config(decoder_name),
+                decoder_config=_checked_decoder_config(
+                    decoder_name,
+                    args.mle_time_limit,
+                    args.on_decode_failure,
+                ),
                 max_shots=args.max_shots,
                 max_errors=args.max_errors,
                 batch_size=args.batch_size,
@@ -276,7 +318,7 @@ def _s_gate_rounds(d: int, method: str) -> tuple[int, int]:
 
 
 def _run_s_gate_tele(args, output_path: Path) -> None:
-    done = _load_done(output_path, _S_GATE_RESULT_KEYS)
+    done = _load_done(output_path, _S_GATE_RESULT_KEYS, _S_GATE_COLS)
     pipeline_cache: dict = {}
 
     for code, method, state_prep in _valid_s_gate_combos(args):
@@ -292,6 +334,10 @@ def _run_s_gate_tele(args, output_path: Path) -> None:
                 "rounds": f"prep={rounds_prep} gate={rounds_gate}",
                 "p": p,
                 "decoder": decoder_name,
+                "decoder_time_limit": (
+                    args.mle_time_limit if decoder_name == "mle-ilp" else 0.0
+                ),
+                "on_decode_failure": args.on_decode_failure,
             }
             if _ck_key(row_proto, _S_GATE_RESULT_KEYS) in done:
                 print(f"  SKIP {code} {method} {state_prep} d={d} p={p:.0e}")
@@ -314,7 +360,11 @@ def _run_s_gate_tele(args, output_path: Path) -> None:
 
             if decoder_name not in pipeline_cache:
                 pipeline_cache[decoder_name] = SimulationPipeline(
-                    decoder_config=_checked_decoder_config(decoder_name),
+                    decoder_config=_checked_decoder_config(
+                        decoder_name,
+                        args.mle_time_limit,
+                        args.on_decode_failure,
+                    ),
                     max_shots=args.max_shots,
                     max_errors=args.max_errors,
                     batch_size=args.batch_size,
@@ -345,7 +395,7 @@ def _run_s_gate_tele(args, output_path: Path) -> None:
 # ── Distillation ──────────────────────────────────────────────────────────────
 
 def _run_distillation(args, which: str, output_path: Path) -> None:
-    done = _load_done(output_path, _DISTILL_RESULT_KEYS)
+    done = _load_done(output_path, _DISTILL_RESULT_KEYS, _DISTILL_COLS)
 
     if which == "ls":
         build_fn    = _build_ls_distill
@@ -364,7 +414,11 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
     p_injected_list = args.p_injected or [1e-3, 5e-3, 2e-2]
     p_list = args.p_values if args.p_values else [1e-3]
     decoder_name = args.decoder or "pymatching"
-    decoder_cfg = _checked_decoder_config(decoder_name)
+    decoder_cfg = _checked_decoder_config(
+        decoder_name,
+        args.mle_time_limit,
+        args.on_decode_failure,
+    )
 
     if which == "ls" and decoder_cfg.backend != "cpu":
         raise ValueError("LS distillation currently expects a CPU decoder; use `pymatching`.")
@@ -403,6 +457,10 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
                     "noise_mode": mode,
                     "p": p,
                     "decoder": decoder_name,
+                    "decoder_time_limit": (
+                        args.mle_time_limit if decoder_name == "mle-ilp" else 0.0
+                    ),
+                    "on_decode_failure": args.on_decode_failure,
                 }
                 if _ck_key(row_proto, _DISTILL_RESULT_KEYS) in done:
                     print(f"  SKIP d={d} mode={mode} p={p:.0e} p_inj={p_inj:.0e}")
@@ -429,6 +487,8 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
                         args.max_shots, args.max_errors,
                         batch_size=50_000, num_workers=args.num_workers,
                         data_indices=magic_data,
+                        decoder_params=decoder_cfg.params,
+                        on_decode_failure=decoder_cfg.on_decode_failure,
                     )
                 else:
                     stats = _run_tg_sim(
@@ -439,6 +499,7 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
                         backend=decoder_cfg.backend,
                         batch_size=50_000,
                         decoder_params=decoder_cfg.params,
+                        on_decode_failure=decoder_cfg.on_decode_failure,
                     )
                 row = {
                     **row_proto,
@@ -458,15 +519,24 @@ def _run_distillation(args, which: str, output_path: Path) -> None:
 
 # ── Decoder config ─────────────────────────────────────────────────────────────
 
-def _decoder_config(name: str) -> DecoderConfig:
+def _decoder_config(
+    name: str,
+    mle_time_limit: float = 0.0,
+    on_decode_failure: str = "error",
+) -> DecoderConfig:
     if name == "pymatching":
-        return DecoderConfig("pymatching", backend="cpu")
+        return DecoderConfig(
+            "pymatching", backend="cpu", on_decode_failure=on_decode_failure
+        )
     if name in ("bposd", "cpu_bposd"):
-        return DecoderConfig("bposd", backend="cpu", params={
-            "max_iterations": 1000, "osd_order": 10,
-            "bp_method": "min_sum", "ms_scaling_factor": 0,
-            "osd_method": "osd_cs",
-        })
+        return DecoderConfig(
+            "bposd", backend="cpu", params={
+                "max_iterations": 1000, "osd_order": 10,
+                "bp_method": "min_sum", "ms_scaling_factor": 0,
+                "osd_method": "osd_cs",
+            },
+            on_decode_failure=on_decode_failure,
+        )
     if name in ("gpu_bposd", "nv-qldpc-decoder"):
         return DecoderConfig(
             "nv-qldpc-decoder",
@@ -479,12 +549,21 @@ def _decoder_config(name: str) -> DecoderConfig:
                 "osd_method": "osd_cs",
                 "use_osd": True,
             },
+            on_decode_failure=on_decode_failure,
         )
     if name == "mwpf":
-        return DecoderConfig("mwpf", backend="cpu", params={"cluster_node_limit": 50})
+        return DecoderConfig(
+            "mwpf", backend="cpu", params={"cluster_node_limit": 50},
+            on_decode_failure=on_decode_failure,
+        )
+    if name == "mle-ilp":
+        return DecoderConfig(
+            "mle-ilp", backend="cpu", params={"time_limit": mle_time_limit},
+            on_decode_failure=on_decode_failure,
+        )
     raise ValueError(
         f"Unknown decoder: {name!r}. "
-        "Choose: pymatching, mwpf, cpu_bposd, gpu_bposd"
+        "Choose: pymatching, mwpf, cpu_bposd, gpu_bposd, mle-ilp"
     )
 
 
@@ -553,8 +632,17 @@ def main():
     )
     ap.add_argument(
         "--decoder", default=None,
-        choices=["pymatching", "mwpf", "bposd", "cpu_bposd", "gpu_bposd", "nv-qldpc-decoder"],
+        choices=["pymatching", "mwpf", "bposd", "cpu_bposd", "gpu_bposd", "nv-qldpc-decoder", "mle-ilp"],
         help="Override decoder for all experiments (default: per-experiment default)",
+    )
+    ap.add_argument(
+        "--mle-time-limit", type=float, default=0.0,
+        help="Soft seconds/shot limit for mle-ilp; 0 is exact/unlimited (default: 0)",
+    )
+    ap.add_argument(
+        "--on-decode-failure", choices=["error", "discard", "ignore"],
+        default="error",
+        help="Policy for decoder timeouts/failures (default: error)",
     )
     ap.add_argument("--max-shots",   type=int, default=1_000_000_000)
     ap.add_argument("--max-errors",  type=int, default=100)
@@ -577,6 +665,11 @@ def main():
         help="Output directory for results CSVs (default: benchmarks/logical_circuits/results/)",
     )
     args = ap.parse_args()
+
+    if not np.isfinite(args.mle_time_limit) or args.mle_time_limit < 0:
+        ap.error("--mle-time-limit must be finite and non-negative")
+    if args.mle_time_limit > 0 and args.decoder != "mle-ilp":
+        ap.error("--mle-time-limit is only valid with --decoder mle-ilp")
 
     if args.quick:
         args.distances  = [3]

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -48,6 +48,19 @@ venv/bin/python benchmarks/memory/plot_memory.py \
 | `mwpf` | CPU | General QLDPC |
 | `cpu_bposd` | CPU | QLDPC codes, no GPU |
 | `gpu_bposd` | GPU (CUDA) | BB/HGP codes at scale |
+| `mle-ilp` | CPU | Exact reference decoding on small instances |
+
+`mle-ilp` has an unlimited per-shot budget by default. For practical large-DEM
+runs, set `--mle-time-limit SECONDS` and choose an explicit
+`--on-decode-failure error|discard|ignore` policy. `error` is the conservative
+default. A positive MLE time limit is rejected for other decoders.
+
+```bash
+venv/bin/python benchmarks/memory/run_memory.py \
+    --codes rotated_sc --distances 3 5 --p-values 5e-3 \
+    --decoder mle-ilp --mle-time-limit 2 \
+    --on-decode-failure discard --num-workers 8
+```
 
 ## Color Code SE Circuits
 
@@ -199,7 +212,8 @@ Results are saved as CSV with one row per complete benchmark configuration:
 
 ```
 code, distance, p, basis, rounds, se_circuit, noise_model, decoder_name,
-layout, block_class, shots, errors, logical_error_rate, seconds,
+decoder_time_limit, on_decode_failure, layout, block_class,
+shots, errors, logical_error_rate, seconds,
 n_data, n_total, k
 ```
 

--- a/benchmarks/memory/run_memory.py
+++ b/benchmarks/memory/run_memory.py
@@ -208,17 +208,32 @@ def _make_code(code_name: str, distance: int, se_circuit: str | None = None):
     raise ValueError(f"Unknown code: {code_name!r}. Available: {ALL_CODES}")
 
 
-def _decoder_config(name: str, osd_order: int = 10, max_iterations: int = 1000) -> DecoderConfig:
+def _decoder_config(
+    name: str,
+    osd_order: int = 10,
+    max_iterations: int = 1000,
+    mle_time_limit: float = 0.0,
+    on_decode_failure: str = "error",
+) -> DecoderConfig:
     if name == "pymatching":
-        return DecoderConfig(name="pymatching", backend="cpu")
+        return DecoderConfig(
+            name="pymatching", backend="cpu",
+            on_decode_failure=on_decode_failure,
+        )
     if name == "mwpf":
-        return DecoderConfig(name="mwpf", backend="cpu", params={"cluster_node_limit": 50})
+        return DecoderConfig(
+            name="mwpf", backend="cpu", params={"cluster_node_limit": 50},
+            on_decode_failure=on_decode_failure,
+        )
     if name == "cpu_bposd":
-        return DecoderConfig(name="bposd", backend="cpu", params={
-            "max_iterations": max_iterations, "osd_order": osd_order,
-            "bp_method": "min_sum", "ms_scaling_factor": 0,
-            "osd_method": "osd_cs",
-        })
+        return DecoderConfig(
+            name="bposd", backend="cpu", params={
+                "max_iterations": max_iterations, "osd_order": osd_order,
+                "bp_method": "min_sum", "ms_scaling_factor": 0,
+                "osd_method": "osd_cs",
+            },
+            on_decode_failure=on_decode_failure,
+        )
     if name == "gpu_bposd":
         return DecoderConfig(
             name="nv-qldpc-decoder", backend="gpu",
@@ -227,8 +242,18 @@ def _decoder_config(name: str, osd_order: int = 10, max_iterations: int = 1000) 
                 "bp_method": "min_sum", "ms_scaling_factor": 0,
                 "osd_method": "osd_cs", "use_osd": True,
             },
+            on_decode_failure=on_decode_failure,
         )
-    raise ValueError(f"Unknown decoder: {name!r}. Choose: pymatching, mwpf, cpu_bposd, gpu_bposd")
+    if name == "mle-ilp":
+        return DecoderConfig(
+            name="mle-ilp", backend="cpu",
+            params={"time_limit": mle_time_limit},
+            on_decode_failure=on_decode_failure,
+        )
+    raise ValueError(
+        f"Unknown decoder: {name!r}. Choose: pymatching, mwpf, cpu_bposd, "
+        "gpu_bposd, mle-ilp"
+    )
 
 
 # ── Circuit builder ───────────────────────────────────────────────────────────
@@ -302,6 +327,36 @@ _RESULT_COLS = frozenset({
     "block_class",
 })
 
+_RESULT_COLUMNS = [
+    "code", "distance", "p", "basis", "rounds", "se_circuit",
+    "noise_model", "decoder_name", "decoder_time_limit",
+    "on_decode_failure", "layout", "block_class", "shots", "errors",
+    "logical_error_rate", "seconds", "n_data", "n_total", "k",
+]
+_RESULT_METADATA_DEFAULTS = {
+    "decoder_time_limit": 0.0,
+    "on_decode_failure": "error",
+}
+
+
+def _ensure_result_schema(path: Path) -> None:
+    """Upgrade pre-MLE benchmark CSVs before checkpointing or appending."""
+    if not path.exists():
+        return
+    df = pd.read_csv(path)
+    unknown = set(df.columns) - set(_RESULT_COLUMNS)
+    if unknown:
+        raise ValueError(
+            f"Cannot migrate {path}: unknown result columns {sorted(unknown)}"
+        )
+    changed = False
+    for column, default in _RESULT_METADATA_DEFAULTS.items():
+        if column not in df.columns:
+            df[column] = default
+            changed = True
+    if changed or list(df.columns) != _RESULT_COLUMNS:
+        df.reindex(columns=_RESULT_COLUMNS).to_csv(path, index=False)
+
 
 def _task_key(row: dict) -> tuple:
     """Stable key from input-only columns (used to skip completed tasks)."""
@@ -314,6 +369,7 @@ def _task_key(row: dict) -> tuple:
 def _load_done_keys(path: Path) -> set:
     if not path.exists():
         return set()
+    _ensure_result_schema(path)
     df = pd.read_csv(path)
     return {_task_key(r) for r in df.to_dict("records")}
 
@@ -395,7 +451,7 @@ def run(tasks: list[dict], decoder_cfg: DecoderConfig,
             "n_total":             n_total,
             "k":                   k,
         }
-        pd.DataFrame([row]).to_csv(
+        pd.DataFrame([row], columns=_RESULT_COLUMNS).to_csv(
             output_path, mode="a", header=not output_path.exists(), index=False,
         )
         print(f"  LER={stats.logical_error_rate:.2e} | "
@@ -433,13 +489,22 @@ def main():
     )
     ap.add_argument("--rounds", type=int, default=None,
                     help="SE rounds per cycle (default: distance)")
-    ap.add_argument("--decoder", choices=["pymatching", "mwpf", "cpu_bposd", "gpu_bposd"],
+    ap.add_argument("--decoder", choices=["pymatching", "mwpf", "cpu_bposd", "gpu_bposd", "mle-ilp"],
                     default="pymatching",
                     help="Decoder (default: pymatching)")
     ap.add_argument("--osd-order", type=int, default=10,
                     help="OSD order for cpu_bposd/gpu_bposd decoders (default: 10)")
     ap.add_argument("--max-iterations", type=int, default=1000,
                     help="BP iteration limit for cpu_bposd/gpu_bposd decoders (default: 1000)")
+    ap.add_argument(
+        "--mle-time-limit", type=float, default=0.0,
+        help="Soft seconds/shot limit for mle-ilp; 0 is exact/unlimited (default: 0)",
+    )
+    ap.add_argument(
+        "--on-decode-failure", choices=["error", "discard", "ignore"],
+        default="error",
+        help="Policy for decoder timeouts/failures (default: error)",
+    )
     ap.add_argument("--max-shots",   type=int, default=1_000_000)
     ap.add_argument("--max-errors",  type=int, default=200)
     ap.add_argument("--num-workers", type=int, default=8)
@@ -461,6 +526,10 @@ def main():
         ap.error("--num-workers must be between 1 and 48")
     if args.batch_size < 1:
         ap.error("--batch-size must be positive")
+    if not np.isfinite(args.mle_time_limit) or args.mle_time_limit < 0:
+        ap.error("--mle-time-limit must be finite and non-negative")
+    if args.mle_time_limit > 0 and args.decoder != "mle-ilp":
+        ap.error("--mle-time-limit is only valid with --decoder mle-ilp")
 
     if args.quick:
         args.codes = args.codes if args.codes else ["rotated_sc"]
@@ -515,6 +584,11 @@ def main():
                             "se_circuit": se_circuit,
                             "noise_model": args.noise_model,
                             "decoder_name": args.decoder,
+                            "decoder_time_limit": (
+                                args.mle_time_limit
+                                if args.decoder == "mle-ilp" else 0.0
+                            ),
+                            "on_decode_failure": args.on_decode_failure,
                         })
 
     # Default output path
@@ -528,6 +602,9 @@ def main():
     print(f"Tasks:       {len(tasks)} total")
     print(f"Decoder:     {args.decoder} | noise_model={args.noise_model} | "
           f"osd_order={args.osd_order} | max_iterations={args.max_iterations}")
+    if args.decoder == "mle-ilp":
+        limit = "unlimited" if args.mle_time_limit == 0 else f"{args.mle_time_limit:g}s/shot"
+        print(f"MLE budget:  {limit} | failure_policy={args.on_decode_failure}")
     if "color" in args.codes:
         print(f"Color SE:    {', '.join(args.color_se_circuits)}")
     print(f"batch_size:  {args.batch_size}")
@@ -535,7 +612,13 @@ def main():
     print(f"workers:     {effective_workers}")
     print(f"max_shots:   {args.max_shots:.0e} | max_errors={args.max_errors}\n")
 
-    run(tasks, _decoder_config(args.decoder, args.osd_order, args.max_iterations),
+    run(tasks, _decoder_config(
+            args.decoder,
+            args.osd_order,
+            args.max_iterations,
+            args.mle_time_limit,
+            args.on_decode_failure,
+        ),
         args.max_shots, args.max_errors,
         args.num_workers, args.batch_size,
         output)

--- a/benchmarks/mle/README.md
+++ b/benchmarks/mle/README.md
@@ -1,0 +1,20 @@
+# Exact MLE Core Benchmark
+
+This benchmark compares LightStim's optimized ACG-ALP/RPC decoder with a
+direct `scipy.optimize.milp` solve on identical, deterministic syndromes. It
+checks parity and objective agreement before reporting timing, so a faster but
+inexact result cannot be recorded as a speedup.
+
+```bash
+PYTHONPATH=. venv/bin/python benchmarks/mle/run_mle.py
+```
+
+The default presets cover a rotated surface-code DEM and the denser BB
+`[[72,12,6]]` DEM. Use `--quick` for a two-shot smoke test, `--shots N` to
+override preset counts, or `--output path.json` to archive the JSON report.
+Timing depends on the host and SciPy's vendored HiGHS version; the report
+includes Python, platform, NumPy, SciPy, and Stim versions for that reason.
+
+This harness intentionally does not install or compare highspy, SCIP, or
+CP-SAT. Those packages substantially increase environment complexity and are
+not runtime dependencies of the decoder.

--- a/benchmarks/mle/run_mle.py
+++ b/benchmarks/mle/run_mle.py
@@ -1,0 +1,199 @@
+"""Reproduce the core exact-MLE optimization benchmark.
+
+The optimized ACG-ALP/RPC path and a direct SciPy MILP decode the same fixed
+syndromes. The output records objective agreement, parity validity, timing,
+and package versions as JSON so results can be archived and compared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import scipy
+import stim
+from scipy.optimize import LinearConstraint, milp
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.BB_code import BBCode, BBCodeExtractionBlock
+from lightstim.simulation.decoder_backend.dem_matrices import dem_to_matrices
+from lightstim.simulation.decoder_backend.registry import get_decoder
+
+
+PRESETS = {
+    "surface-d5": {"kind": "surface", "distance": 5, "rounds": 5,
+                   "p": 1e-3, "shots": 20, "seed": 11},
+    "bb-72-r2": {"kind": "bb", "rounds": 2, "p": 1e-3,
+                  "shots": 5, "seed": 7},
+}
+
+
+def _surface_dem(distance: int, rounds: int, p: float) -> stim.DetectorErrorModel:
+    circuit = stim.Circuit.generated(
+        "surface_code:rotated_memory_z",
+        distance=distance,
+        rounds=rounds,
+        after_clifford_depolarization=p,
+        before_measure_flip_probability=p,
+        after_reset_flip_probability=p,
+        before_round_data_depolarization=p,
+    )
+    return circuit.detector_error_model(
+        decompose_errors=False, flatten_loops=True
+    )
+
+
+def _bb_dem(rounds: int, p: float) -> stim.DetectorErrorModel:
+    code = BBCode(
+        l=6, m=6,
+        A=[[3, 0], [0, 1], [0, 2]],
+        B=[[0, 3], [1, 0], [2, 0]],
+    )
+    system = QECSystem()
+    system.add_patch(code, name="bb")
+    circuit = MemoryExperiment(
+        qec_system=system,
+        extraction_block_class=BBCodeExtractionBlock,
+        rounds=rounds,
+        noise_params=NoiseConfig(
+            p_1q=p, p_2q=p, p_meas=p, p_reset=p, p_idle=p
+        ),
+        noise_model="circuit_level",
+        basis="Z",
+    ).build()
+    return circuit.detector_error_model(
+        decompose_errors=False, flatten_loops=True
+    )
+
+
+def _build_dem(config: dict) -> stim.DetectorErrorModel:
+    if config["kind"] == "surface":
+        return _surface_dem(
+            config["distance"], config["rounds"], config["p"]
+        )
+    return _bb_dem(config["rounds"], config["p"])
+
+
+def _direct_milp(decoder, syndrome: np.ndarray) -> tuple[np.ndarray, float]:
+    sf = syndrome.astype(float)
+    result = milp(
+        c=decoder._c,
+        constraints=LinearConstraint(decoder._A, sf, sf),
+        integrality=decoder._integrality,
+        bounds=decoder._bounds,
+    )
+    if not result.success:
+        raise RuntimeError(f"direct MILP failed: {result.message}")
+    correction = np.round(result.x[:decoder._n]).astype(np.uint8)
+    return correction, float(result.fun)
+
+
+def run_preset(name: str, shots: int | None = None) -> dict:
+    """Run one deterministic preset and return its JSON-ready result."""
+    config = dict(PRESETS[name])
+    shot_count = config["shots"] if shots is None else shots
+    if shot_count < 1:
+        raise ValueError("shots must be positive")
+    config["shots"] = shot_count
+
+    dem = _build_dem(config)
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    detectors, _, _ = dem.compile_sampler(seed=config["seed"]).sample(
+        shots=shot_count
+    )
+    syndromes = detectors.astype(np.uint8)
+
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+
+    optimized_costs = []
+    started = time.perf_counter()
+    for syndrome in syndromes:
+        correction, ok = decoder.decode_single(syndrome)
+        if not ok:
+            raise RuntimeError("unlimited optimized MLE unexpectedly failed")
+        if not np.array_equal((H @ correction) % 2, syndrome):
+            raise RuntimeError("optimized MLE returned an invalid correction")
+        optimized_costs.append(float(decoder._w @ correction))
+    optimized_seconds = time.perf_counter() - started
+
+    direct_costs = []
+    started = time.perf_counter()
+    for syndrome in syndromes:
+        correction, cost = _direct_milp(decoder, syndrome)
+        if not np.array_equal((H @ correction) % 2, syndrome):
+            raise RuntimeError("direct MILP returned an invalid correction")
+        direct_costs.append(cost)
+    direct_seconds = time.perf_counter() - started
+
+    optimized_costs = np.asarray(optimized_costs)
+    direct_costs = np.asarray(direct_costs)
+    max_cost_delta = float(np.max(np.abs(optimized_costs - direct_costs)))
+    return {
+        "preset": name,
+        "config": config,
+        "shots": shot_count,
+        "num_detectors": int(H.shape[0]),
+        "num_error_mechanisms": int(H.shape[1]),
+        "parity_valid": True,
+        "objective_agreement": bool(max_cost_delta <= 1e-6),
+        "max_objective_delta": max_cost_delta,
+        "optimized_seconds": optimized_seconds,
+        "direct_milp_seconds": direct_seconds,
+        "optimized_ms_per_shot": 1e3 * optimized_seconds / shot_count,
+        "direct_milp_ms_per_shot": 1e3 * direct_seconds / shot_count,
+        "speedup": direct_seconds / optimized_seconds,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--preset", nargs="+", choices=sorted(PRESETS),
+        default=list(PRESETS), help="Preset(s) to run (default: all)",
+    )
+    parser.add_argument(
+        "--shots", type=int, default=None,
+        help="Override the shot count in every selected preset",
+    )
+    parser.add_argument(
+        "--quick", action="store_true",
+        help="Run two surface-d5 shots for a fast correctness smoke test",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    presets = ["surface-d5"] if args.quick else args.preset
+    shots = 2 if args.quick else args.shots
+    report = {
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "numpy": np.__version__,
+            "scipy": scipy.__version__,
+            "stim": stim.__version__,
+        },
+        "results": [run_preset(name, shots=shots) for name in presets],
+    }
+    if not all(result["objective_agreement"] for result in report["results"]):
+        raise RuntimeError("optimized and direct MILP objectives disagree")
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/lightstim/protocols/ls_distillation.py
+++ b/lightstim/protocols/ls_distillation.py
@@ -291,7 +291,8 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
                    decoder_name="pymatching",
                    max_shots=10_000_000, max_errors=100,
                    batch_size=50_000, num_workers=1,
-                   data_indices=None):
+                   data_indices=None, decoder_params=None,
+                   on_decode_failure="error"):
     """
     Run noisy LS simulation with post-decode post-selection.
 
@@ -299,12 +300,19 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
         ps_obs:       Observable indices to post-select on.
         target_obs:   Observable indices to measure LER on.
         data_indices: system.data_indices — restricts injection to data qubits.
+        decoder_params: Parameters forwarded to the selected decoder.
+        on_decode_failure: Error/discard/ignore policy for flagged failures.
     """
     noisy = inject_noise(circuit, magic_qubits, p, p_injected, mode,
                          data_indices=data_indices)
 
     pipeline = SimulationPipeline(
-        decoder_config=DecoderConfig(decoder_name, backend="cpu"),
+        decoder_config=DecoderConfig(
+            decoder_name,
+            backend="cpu",
+            params=decoder_params or {},
+            on_decode_failure=on_decode_failure,
+        ),
         max_shots=max_shots,
         max_errors=max_errors,
         batch_size=batch_size,

--- a/lightstim/protocols/tg_distillation.py
+++ b/lightstim/protocols/tg_distillation.py
@@ -294,27 +294,31 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
                    T, ps_indices, target_indices, decoder_name,
                    max_shots=10_000_000, max_errors=200,
                    num_workers=32, backend="cpu", batch_size=50_000,
-                   decoder_params=None):
+                   decoder_params=None, on_decode_failure="error"):
     """
     Run noisy TG simulation with GF(2)-transformed post-selection.
 
     If T is the identity matrix, uses standard SimulationPipeline.
     Otherwise, uses a custom decode loop with observable transformation.
+    ``on_decode_failure`` has the same error/discard/ignore semantics in both
+    paths, including for timeout flags emitted by ``mle-ilp``.
     """
     import math
 
     decoder_params = decoder_params or {}
+    decoder_config = DecoderConfig(
+        decoder_name,
+        backend=backend,
+        params=decoder_params,
+        on_decode_failure=on_decode_failure,
+    )
     noisy = inject_noise(circuit, magic_qubits, p, p_injected, mode)
     n_obs = circuit.num_observables
     n_det = circuit.num_detectors
 
     if np.array_equal(T, np.eye(T.shape[0], dtype=int)):
         pipeline = SimulationPipeline(
-            decoder_config=DecoderConfig(
-                decoder_name,
-                backend=backend,
-                params=decoder_params,
-            ),
+            decoder_config=decoder_config,
             max_shots=max_shots,
             max_errors=max_errors,
             batch_size=batch_size,
@@ -326,9 +330,14 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
         )
         return pipeline.run(noisy)
 
+    from lightstim.simulation.decoder_backend._accounting import count_batch
     from lightstim.simulation.decoder_backend.registry import get_decoder
 
-    decoder = get_decoder(decoder_name, backend=backend, **decoder_params)
+    decoder = get_decoder(
+        decoder_config.name,
+        backend=decoder_config.backend,
+        **decoder_config.params,
+    )
     dem = noisy.detector_error_model(
         decompose_errors=getattr(decoder, "decompose_errors", False),
         approximate_disjoint_errors=True,
@@ -355,7 +364,6 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
 
         dets_kept = dets[mask]
         obs_t_kept = obs_t[mask]
-        kept_shots += dets_kept.shape[0]
 
         n_det_bytes = math.ceil(n_det / 8)
         dets_packed = np.packbits(dets_kept, axis=1, bitorder="little")[:, :n_det_bytes]
@@ -364,9 +372,17 @@ def run_simulation(circuit, magic_qubits, p, p_injected, mode,
         )
         pred_unpacked = np.unpackbits(pred_packed, axis=1, bitorder="little")[:, :n_obs]
         pred_t = transform_observables(pred_unpacked, T)
-
-        corrected = obs_t_kept[:, target_indices] ^ pred_t[:, target_indices]
-        errors += int(np.sum(np.any(corrected, axis=1)))
+        pred_t_packed = np.packbits(pred_t, axis=1, bitorder="little")
+        batch_kept, batch_errors = count_batch(
+            obs_filtered=obs_t_kept,
+            pred_packed=pred_t_packed,
+            post_select_corrected_observable_indices=None,
+            target_observable_indices=target_indices,
+            flags=getattr(compiled, "last_flags", None),
+            on_decode_failure=decoder_config.on_decode_failure,
+        )
+        kept_shots += batch_kept
+        errors += batch_errors
 
         elapsed = time.perf_counter() - t0
         ler = errors / kept_shots if kept_shots > 0 else 0

--- a/lightstim/simulation/README.md
+++ b/lightstim/simulation/README.md
@@ -41,6 +41,7 @@
 | `"relay-bp"` | `"cpu"` | `relay_bp` | Relay-BP; aliases `"relay_bp"`, `"relaybp"` |
 | `"tesseract"` | `"cpu"` | `tesseract_decoder` | Beam-search MLE; lazy import |
 | `"ldpc-bp"` | `"cpu"` | `ldpc` | Plain BP (no OSD), via `ldpc.BpDecoder`; aliases `"ldpc_bp"`, `"bp"` |
+| `"mle-ilp"` | `"cpu"` | `scipy>=1.9` | Exact most-likely-error via ACG-ALP/RPC with MILP fallback; aliases `"mle"`, `"ilp"` |
 | `"chain"` | `"cpu"` | *(none — composes other registered decoders)* | Multi-level escalation, e.g. BP → relay-BP → MLE; aliases `"decoder-chain"`, `"multi-level"` — see §11 |
 
 Requesting a backend with no registration raises `ImportError` immediately (e.g. `backend="gpu"` without `cudaq_qec`).
@@ -59,6 +60,31 @@ Both CPU and GPU bposd backends accept the same parameter names:
 | `osd_order` | `osd_order` | `osd_order` | `10` |
 | `osd_method` | `'osd_cs'` etc | `3` (int) | `'osd_cs'` |
 | `use_osd` | *(ignored; always on)* | `use_osd` | `True` |
+
+### Exact MLE parameters
+
+`DecoderConfig("mle-ilp")` is exact for supplied priors in `[0, 0.5]` by default and has
+no solve deadline. Large detector error models can have long MILP tails; use a
+positive `time_limit` together with an explicit `on_decode_failure` policy when
+bounded throughput is more important than completing every shot.
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `time_limit` | `0.0` | Soft seconds-per-shot budget; zero is unlimited |
+| `max_prior` | `0.5` | Optional cap applied after validation; `c<0.5` maps each positive `p` to `min(p, c)` |
+| `max_cut_rounds` | `200` | Maximum forbidden-set cut rounds before MILP fallback |
+| `max_rpc_rounds` | `8` | Redundant-parity-check rounds; zero disables RPC generation |
+| `max_rpc_pivots` | `64` | Gaussian-elimination pivots per RPC round |
+| `max_rpc_weight` | `256` | Skip denser derived checks |
+| `max_rpc_memory_mb` | `512` | Packed RPC workspace cap; zero is unlimited |
+
+Supplied priors must be in `[0, 0.5]`; values above `0.5` are rejected rather
+than clamped. The default `max_prior=0.5` changes no accepted prior. A smaller
+cap intentionally changes accepted priors above that cap. Zero-probability
+mechanisms are fixed off, and probability-0.5 mechanisms have exactly zero
+objective weight. A timed-out shot is flagged; `"error"`
+counts it as wrong, `"discard"` removes it, and `"ignore"` trusts the partial
+prediction.
 
 ---
 
@@ -118,6 +144,7 @@ simulation/
 │   │   ├── relay_bp.py    # Relay-BP decoder (CPU, sinter-native)
 │   │   ├── tesseract.py   # Tesseract beam-search MLE (CPU, lazy import)
 │   │   ├── ldpc_bp.py     # Plain BP decoder (CPU, ExternalDecoder facade)
+│   │   ├── mle_ilp.py     # Exact most-likely-error decoder (CPU, SciPy MILP)
 │   │   └── chain.py       # Multi-level decoder chain (CPU, composes other decoders)
 │   ├── pipeline.py        # SimulationPipeline, ExperimentTask
 │   ├── post_select.py     # apply_post_selection, get_post_select_detector_indices
@@ -138,6 +165,7 @@ simulation/
 - `relay_bp` — Relay-BP decoder: `pip install "relay-bp[stim]"`
 - `tesseract_decoder` — Tesseract beam-search MLE: `pip install tesseract-decoder` (a prebuilt wheel may not match every CPU; build from source if it fails to import)
 - `ldpc` — Plain BP decoder: `pip install ldpc`
+- `scipy>=1.9` — exact MLE (`scipy.optimize.milp`)
 - `cudaq_qec` — GPU BP+OSD: `pip install cudaq_qec` (NVIDIA GPU required)
 
 ---
@@ -157,6 +185,22 @@ pipeline = SimulationPipeline(
     progress_interval_sec=10.0,
 )
 stats = pipeline.run(circuit, json_metadata={"d": 3, "p": 0.001})
+
+# Exact MLE: unlimited by default.
+mle_pipeline = SimulationPipeline(
+    decoder_config=DecoderConfig("mle-ilp"),
+    max_shots=2_000,
+    num_workers=4,
+)
+
+# A practical bounded run. Timeout shots are explicitly discarded.
+bounded_mle_pipeline = SimulationPipeline(
+    decoder_config=DecoderConfig(
+        "mle-ilp",
+        params={"time_limit": 2.0},
+        on_decode_failure="discard",
+    ),
+)
 
 # GPU BP+OSD (cudaq_qec nv-qldpc-decoder)
 pipeline = SimulationPipeline(

--- a/lightstim/simulation/decoder_backend/decoders/__init__.py
+++ b/lightstim/simulation/decoder_backend/decoders/__init__.py
@@ -60,6 +60,13 @@ try:
 except ImportError as exc:
     _log.debug("tesseract registration skipped: %s", exc)
 
+# mle_ilp — exact most-likely-error decoder over HiGHS. Imported unconditionally:
+# its scipy backend needs nothing beyond LightStim's own dependencies, and the
+# faster highspy backend is imported lazily at construction, so an absent (or
+# broken) highspy downgrades one decoder to the scipy path rather than breaking
+# the registry.
+from . import mle_ilp  # noqa: F401 — registers mle-ilp/cpu
+
 # chain — multi-level escalation over other registered decoders. No external
 # deps of its own; stage decoders are resolved lazily at construction, so a
 # chain only needs its *own* stages' backends installed.

--- a/lightstim/simulation/decoder_backend/decoders/__init__.py
+++ b/lightstim/simulation/decoder_backend/decoders/__init__.py
@@ -60,11 +60,9 @@ try:
 except ImportError as exc:
     _log.debug("tesseract registration skipped: %s", exc)
 
-# mle_ilp — exact most-likely-error decoder over HiGHS. Imported unconditionally:
-# its scipy backend needs nothing beyond LightStim's own dependencies, and the
-# faster highspy backend is imported lazily at construction, so an absent (or
-# broken) highspy downgrades one decoder to the scipy path rather than breaking
-# the registry.
+# mle_ilp — exact most-likely-error decoder. Imported unconditionally and with
+# no soft-import guard: it solves with scipy.optimize.milp, and scipy is already
+# a hard LightStim dependency, so there is no optional backend to detect.
 from . import mle_ilp  # noqa: F401 — registers mle-ilp/cpu
 
 # chain — multi-level escalation over other registered decoders. No external

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -16,12 +16,18 @@ exponential in the worst case and is intended as a **ground-truth reference**
 for small instances, not for production sampling throughput.
 
 The MILP is the fallback, not the first move. Each shot is first attempted with
-adaptive-LP (ALP) decoding -- Feldman's fundamental-polytope relaxation with
-forbidden-set cuts generated on demand, in the manner of Taghavi & Siegel --
-and only escalated to the MILP when that leaves a fractional pseudocodeword.
-This stays exact; see :meth:`MleIlpDecoder._adaptive_lp`. ALP settles 85-100%
-of shots and is worth 2.0-11.0x over calling the MILP directly, with the
-largest gains on QLDPC codes.
+ACG-ALP: Feldman's fundamental-polytope relaxation with forbidden-set cuts
+generated on demand (Taghavi & Siegel), plus redundant-parity-check cuts when
+that stalls (Zhang & Siegel). Only a shot that survives both escalates to the
+MILP. This stays exact; see :meth:`MleIlpDecoder._adaptive_lp`.
+
+Plain ALP already settles 85-100% of shots and is worth 2.0-11.0x over calling
+the MILP directly, with the largest gains on QLDPC codes. RPC cuts then clear
+most of what is left -- on surface d=7 and d=9 at p=1e-3 they took the MILP
+fallback rate from 7/60 and 3/30 to zero -- for a further 1.4-3.2x on surface
+codes. They earn nothing on the BB codes tried (no stalled shot was rescued)
+and cost ~8% there, which is why ``max_rpc_rounds`` exists: set it to 0 for
+plain ALP.
 
 The solver is ``scipy.optimize.milp``, which needs no dependency beyond the
 scipy LightStim already requires. Alternatives were benchmarked and rejected;
@@ -72,6 +78,10 @@ _DEFAULTS = {
                            # the limit is reported as a decode failure, so
                            # DecoderConfig(on_decode_failure=...) can herald it.
     "max_cut_rounds": 200,  # give up on cut generation and fall back to MILP
+    "max_rpc_rounds": 8,    # redundant-parity-check rounds once ALP stalls;
+                            # 0 disables ACG and leaves plain ALP
+    "max_rpc_pivots": 64,   # Gaussian-elimination pivots per RPC round
+    "max_rpc_weight": 256,  # skip derived checks denser than this
 }
 
 
@@ -100,6 +110,10 @@ class MleIlpDecoder(ExternalDecoder):
         self._starts = H.indptr[:-1]
         self._nonempty = H.indptr[1:] > H.indptr[:-1]
         self._max_rounds = int(params["max_cut_rounds"])
+        self._max_rpc_rounds = int(params["max_rpc_rounds"])
+        self._max_rpc_pivots = int(params["max_rpc_pivots"])
+        self._max_rpc_weight = int(params["max_rpc_weight"])
+        self._packed = None            # built lazily on the first stalled shot
 
         rowsum = np.asarray(H.sum(axis=1)).ravel()
         lower = np.zeros(self._n + self._m)
@@ -158,27 +172,103 @@ class MleIlpDecoder(ExternalDecoder):
             in_s[np.argmin(np.abs(2.0 * v - 1.0))] ^= True
         return cols, np.where(in_s, 1.0, -1.0), float(in_s.sum()) - 1.0
 
+    def _packed_rows(self):
+        """Bit-pack H's rows (little bitorder), built once on first use.
+
+        Packed directly from the CSR indices -- an (m, n) dense intermediate
+        would be hundreds of MB on a large QLDPC detector error model.
+        """
+        if self._packed is None:
+            packed = np.zeros((self._m, (self._n + 7) // 8), dtype=np.uint8)
+            counts = np.diff(self._indptr)
+            row_of = np.repeat(np.arange(self._m), counts)
+            np.bitwise_or.at(
+                packed, (row_of, self._indices >> 3),
+                (np.uint8(1) << (self._indices & 7).astype(np.uint8)))
+            self._packed = packed
+        return self._packed
+
+    def _rpc_cuts(self, e, s):
+        """Derive redundant parity checks and return any violated cuts.
+
+        When ALP stalls, every original check already satisfies its cuts, so no
+        further cut exists from H's own rows. But any GF(2) combination of rows
+        is also a valid check -- with syndrome the XOR of the combined bits --
+        and one of those may still be violated. Following Zhang & Siegel, the
+        combinations come from Gaussian-eliminating the augmented [H | s] with
+        the most fractional columns as pivots, so the derived checks isolate
+        the fractional variables.
+        """
+        frac = np.abs(e - np.round(e))
+        order = np.flatnonzero(frac > _CUT_TOL)
+        if order.size == 0:
+            return []
+        order = order[np.argsort(-frac[order])]
+
+        a = self._packed_rows().copy()
+        sy = np.asarray(s, dtype=np.uint8).copy()
+        used = np.zeros(self._m, dtype=bool)
+        n_piv = 0
+        for col in order:
+            bits = (a[:, col >> 3] >> (col & 7)) & 1
+            ones = np.flatnonzero(bits)
+            if ones.size == 0:
+                continue
+            free = ones[~used[ones]]
+            if free.size == 0:
+                continue
+            p = free[0]
+            used[p] = True
+            others = ones[ones != p]
+            if others.size:
+                a[others] ^= a[p]
+                sy[others] ^= sy[p]
+            n_piv += 1
+            if n_piv >= self._max_rpc_pivots:
+                break
+
+        rows = np.unpackbits(a, axis=1, bitorder="little", count=self._n)
+        cuts = []
+        for i in range(self._m):
+            cols = np.flatnonzero(rows[i])
+            # Dense derived checks give weak cuts for a lot of work.
+            if cols.size == 0 or cols.size > self._max_rpc_weight:
+                continue
+            v = e[cols]
+            in_s = v > 0.5
+            if (int(in_s.sum()) & 1) == (int(sy[i]) & 1):
+                in_s = in_s.copy()
+                in_s[np.argmin(np.abs(2.0 * v - 1.0))] ^= True
+            g = (1.0 - v[in_s]).sum() + v[~in_s].sum()
+            if g < 1.0 - _CUT_TOL:
+                cuts.append((cols, np.where(in_s, 1.0, -1.0),
+                             float(in_s.sum()) - 1.0))
+        return cuts
+
     def _adaptive_lp(self, s):
-        """Adaptive-LP decode (Taghavi-Siegel). Returns the error or None.
+        """ACG-ALP decode. Returns the error, or None to escalate to the MILP.
 
         Solves over the fundamental polytope, generating forbidden-set cuts on
-        demand. Terminating with no violated cut and an integral solution means
-        every parity holds and the solution is optimal over a relaxation that
-        contains every valid error, so it is the exact MLE answer.
+        demand (Taghavi & Siegel). If that stalls on a fractional
+        pseudocodeword, redundant-parity-check cuts are added to break it
+        (Zhang & Siegel) and plain cut generation resumes.
+
+        Terminating with no violated cut and an integral solution means every
+        parity holds and the solution is optimal over a relaxation containing
+        every valid error, so it is the exact MLE answer.
         """
         rows, cols, vals, rhs = [], [], [], []
         e = np.zeros(self._n)
 
-        for _ in range(self._max_rounds):
-            violated = self._violated_checks(e, s)
-            if violated.size == 0:
-                break
-            for i in violated:
-                c_cols, c_vals, c_rhs = self._build_cut(e, s, i)
+        def add(cut_list):
+            for c_cols, c_vals, c_rhs in cut_list:
                 rows.append(np.full(c_cols.size, len(rhs), dtype=np.int64))
                 cols.append(c_cols.astype(np.int64))
                 vals.append(c_vals)
                 rhs.append(c_rhs)
+
+        def resolve():
+            nonlocal e
             a_ub = sp.csr_matrix(
                 (np.concatenate(vals),
                  (np.concatenate(rows), np.concatenate(cols))),
@@ -186,10 +276,33 @@ class MleIlpDecoder(ExternalDecoder):
             lp = linprog(c=self._w, A_ub=a_ub, b_ub=np.asarray(rhs),
                          bounds=(0, 1), method="highs")
             if not lp.success:
-                return None
+                return False
             e = lp.x
-        else:
-            return None                     # cut generation did not converge
+            return True
+
+        def separate_to_convergence():
+            for _ in range(self._max_rounds):
+                violated = self._violated_checks(e, s)
+                if violated.size == 0:
+                    return True
+                add([self._build_cut(e, s, i) for i in violated])
+                if not resolve():
+                    return False
+            return False                    # cut generation did not converge
+
+        if not separate_to_convergence():
+            return None
+
+        for _ in range(self._max_rpc_rounds):
+            if np.abs(e - np.round(e)).max() < _INT_TOL:
+                break
+            rpc = self._rpc_cuts(e, s)
+            if not rpc:
+                break                       # no derived check is violated
+            add(rpc)
+            # RPC cuts move the solution, which can re-violate original checks.
+            if not resolve() or not separate_to_convergence():
+                return None
 
         if np.abs(e - np.round(e)).max() >= _INT_TOL:
             return None                     # fractional: a pseudocodeword
@@ -198,7 +311,7 @@ class MleIlpDecoder(ExternalDecoder):
         return ei if np.array_equal((self._H @ ei) % 2, s) else None
 
     def decode_single(self, syndrome):
-        """Solve one shot: adaptive LP first, MILP only if it doesn't settle.
+        """Solve one shot: ACG-ALP first, MILP only if it doesn't settle.
 
         Both paths return the same answer -- see :meth:`_adaptive_lp` for why
         the LP result, when integral, is provably the MILP optimum. Only the

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -15,9 +15,13 @@ highest-probability error, it does not sum over the logical coset). It is
 exponential in the worst case and is intended as a **ground-truth reference**
 for small instances, not for production sampling throughput.
 
-Each shot is attempted as an LP first and only escalated to the MILP if that
-does not settle it -- see :meth:`MleIlpDecoder.decode_single`. This stays
-exact; it is a shortcut, not a relaxation-based heuristic.
+The MILP is the fallback, not the first move. Each shot is first attempted with
+adaptive-LP (ALP) decoding -- Feldman's fundamental-polytope relaxation with
+forbidden-set cuts generated on demand, in the manner of Taghavi & Siegel --
+and only escalated to the MILP when that leaves a fractional pseudocodeword.
+This stays exact; see :meth:`MleIlpDecoder._adaptive_lp`. ALP settles 85-100%
+of shots and is worth 2.0-11.0x over calling the MILP directly, with the
+largest gains on QLDPC codes.
 
 The solver is ``scipy.optimize.milp``, which needs no dependency beyond the
 scipy LightStim already requires. Alternatives were benchmarked and rejected;
@@ -60,12 +64,14 @@ from ..external import ExternalDecoder
 from ..registry import register_decoder
 
 _INT_TOL = 1e-6        # treat an LP component as integral within this
+_CUT_TOL = 1e-7        # minimum violation before a cut is worth adding
 
 _DEFAULTS = {
     "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
     "time_limit": 0.0,     # seconds per shot; 0 = unlimited. A shot that hits
                            # the limit is reported as a decode failure, so
                            # DecoderConfig(on_decode_failure=...) can herald it.
+    "max_cut_rounds": 200,  # give up on cut generation and fall back to MILP
 }
 
 
@@ -89,11 +95,16 @@ class MleIlpDecoder(ExternalDecoder):
         self._w = _weights(priors, float(params["max_prior"]))
 
         self._H = H
+        self._indptr = H.indptr
+        self._indices = H.indices
+        self._starts = H.indptr[:-1]
+        self._nonempty = H.indptr[1:] > H.indptr[:-1]
+        self._max_rounds = int(params["max_cut_rounds"])
+
         rowsum = np.asarray(H.sum(axis=1)).ravel()
         lower = np.zeros(self._n + self._m)
         upper = np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)])
         self._bounds = Bounds(lower, upper)
-        self._lp_bounds = np.column_stack([lower, upper])
         self._c = np.concatenate([self._w, np.zeros(self._m)])
         self._integrality = np.ones(self._n + self._m)
         # [H | -2I] -- one slack column per detector row.
@@ -104,36 +115,114 @@ class MleIlpDecoder(ExternalDecoder):
         self._options = ({"time_limit": self._time_limit}
                          if self._time_limit > 0 else {})
 
+    def _violated_checks(self, e, s):
+        """Screen every check for a violated forbidden-set cut, vectorised.
+
+        For a check with support N, writing
+        ``g(S) = sum_{j in S}(1 - e_j) + sum_{j not in S} e_j``, the cut's
+        violation is ``1 - g(S)``. So the most-violated cut minimises g: take
+        ``S = {j : e_j > 0.5}``, and if ``|S|`` has the wrong parity flip the
+        single element whose ``e_j`` is nearest 0.5 (each flip costs
+        ``|2 e_j - 1|``). Returns the indices of checks whose best cut is
+        violated.
+        """
+        v = e[self._indices]
+        in_s = v > 0.5
+        # Per element: cost of its cheapest side, and of being flipped.
+        base = np.where(in_s, 1.0 - v, v)
+        flip = np.abs(2.0 * v - 1.0)
+
+        starts = self._starts[self._nonempty]
+        g = np.full(self._m, np.inf)
+        count = np.zeros(self._m, dtype=np.int64)
+        cheapest = np.zeros(self._m)
+        g[self._nonempty] = np.add.reduceat(base, starts)
+        count[self._nonempty] = np.add.reduceat(in_s.astype(np.int64), starts)
+        cheapest[self._nonempty] = np.minimum.reduceat(flip, starts)
+
+        # |S| must have parity s_i + 1; where it matches s_i, pay one flip.
+        needs_flip = (count & 1) == (s & 1)
+        g = g + np.where(needs_flip & self._nonempty, cheapest, 0.0)
+        return np.flatnonzero(self._nonempty & (g < 1.0 - _CUT_TOL))
+
+    def _build_cut(self, e, s, i):
+        """Materialise the most-violated cut for check ``i``.
+
+        Returns ``(columns, coefficients, rhs)`` for ``coeffs . e[cols] <= rhs``.
+        """
+        cols = self._indices[self._indptr[i]:self._indptr[i + 1]]
+        v = e[cols]
+        in_s = v > 0.5
+        if (int(in_s.sum()) & 1) == (int(s[i]) & 1):
+            in_s = in_s.copy()
+            in_s[np.argmin(np.abs(2.0 * v - 1.0))] ^= True
+        return cols, np.where(in_s, 1.0, -1.0), float(in_s.sum()) - 1.0
+
+    def _adaptive_lp(self, s):
+        """Adaptive-LP decode (Taghavi-Siegel). Returns the error or None.
+
+        Solves over the fundamental polytope, generating forbidden-set cuts on
+        demand. Terminating with no violated cut and an integral solution means
+        every parity holds and the solution is optimal over a relaxation that
+        contains every valid error, so it is the exact MLE answer.
+        """
+        rows, cols, vals, rhs = [], [], [], []
+        e = np.zeros(self._n)
+
+        for _ in range(self._max_rounds):
+            violated = self._violated_checks(e, s)
+            if violated.size == 0:
+                break
+            for i in violated:
+                c_cols, c_vals, c_rhs = self._build_cut(e, s, i)
+                rows.append(np.full(c_cols.size, len(rhs), dtype=np.int64))
+                cols.append(c_cols.astype(np.int64))
+                vals.append(c_vals)
+                rhs.append(c_rhs)
+            a_ub = sp.csr_matrix(
+                (np.concatenate(vals),
+                 (np.concatenate(rows), np.concatenate(cols))),
+                shape=(len(rhs), self._n))
+            lp = linprog(c=self._w, A_ub=a_ub, b_ub=np.asarray(rhs),
+                         bounds=(0, 1), method="highs")
+            if not lp.success:
+                return None
+            e = lp.x
+        else:
+            return None                     # cut generation did not converge
+
+        if np.abs(e - np.round(e)).max() >= _INT_TOL:
+            return None                     # fractional: a pseudocodeword
+        ei = np.round(e).astype(np.uint8)
+        # Verify the parity exactly rather than trusting _INT_TOL.
+        return ei if np.array_equal((self._H @ ei) % 2, s) else None
+
     def decode_single(self, syndrome):
-        """Solve one shot: LP relaxation first, MILP only if it doesn't settle.
+        """Solve one shot: adaptive LP first, MILP only if it doesn't settle.
 
-        An integral optimum of the relaxation *is* the MILP optimum -- the LP
-        optimum lower-bounds the MILP's, and an integral LP solution is
-        MILP-feasible, so the two coincide. So this shortcut returns exactly
-        what the MILP would, and only its cost changes.
+        Both paths return the same answer -- see :meth:`_adaptive_lp` for why
+        the LP result, when integral, is provably the MILP optimum. Only the
+        cost of getting there differs.
 
-        It is worth taking because the relaxation is usually tight here: HiGHS
-        reports a branch-and-bound node count of 1 on essentially every shot,
-        and the LP alone settles 77-100% of them depending on the instance.
-        Measured end to end against calling the MILP directly: 2.1x on surface
-        d=7 (100 shots) and 1.6x on BB [[72,12,6]] r=4 (60 shots), and 3.5-4.7x
-        on the median shot. Totals gain less than the median because both paths
-        are dominated by the same rare hard shots, which the LP never settles
-        -- those pay one extra LP, which is noise against a multi-second solve.
+        The relaxation is tight enough on these models that HiGHS reports a
+        branch-and-bound node count of 1 on essentially every shot, so the win
+        is skipping MIP machinery that changes nothing. Measured against
+        calling the MILP directly: 3.9x on surface d=5, 2.0x on d=7, 11.0x on
+        BB [[72,12,6]] r=2 and 7.9x on r=4, with the LP settling 34/40 to 40/40
+        of shots. Totals gain least where a few hard shots dominate, and those
+        shots pay only the discarded cut-generation work.
+
+        Against the plain (slack-formulation) relaxation this replaced, the
+        end-to-end gain is larger still -- a 100-shot BB r=4 run went from 727
+        to 38 ms/shot -- because ALP settles hard shots that the slack
+        relaxation left fractional, so they never reach the MILP at all.
         """
         s = np.asarray(syndrome, dtype=np.uint8).ravel()
+        e = self._adaptive_lp(s)
+        if e is not None:
+            return e, True
+
         sf = s.astype(float)
-
-        lp = linprog(c=self._c, A_eq=self._A, b_eq=sf,
-                     bounds=self._lp_bounds, method="highs")
-        if lp.success and np.abs(lp.x - np.round(lp.x)).max() < _INT_TOL:
-            e = np.round(lp.x[:self._n]).astype(np.uint8)
-            # Re-check the parity exactly rather than trusting _INT_TOL: the
-            # slacks must be integral too, or H e - 2k = s says nothing about
-            # H e = s (mod 2).
-            if np.array_equal((self._H @ e) % 2, s):
-                return e, True
-
         res = milp(
             c=self._c,
             constraints=LinearConstraint(self._A, sf, sf),

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -15,29 +15,44 @@ highest-probability error, it does not sum over the logical coset). It is
 exponential in the worst case and is intended as a **ground-truth reference**
 for small instances, not for production sampling throughput.
 
-Both backends are HiGHS (MIT-licensed) and return identical optima; they differ
-only in how the model is handed to it (``DecoderConfig(params={"solver": ...})``):
+Both backends are HiGHS (MIT-licensed) and return identical optima
+(``DecoderConfig(params={"solver": ...})``):
 
-    "auto"  (default) -- ``highspy`` if importable, else ``scipy``.
-    "highs"           -- ``highspy``. Builds the model once and rewrites only the
-                         row bounds per shot; ~1.5x faster than ``scipy`` by d=7.
-    "scipy"           -- ``scipy.optimize.milp``. Rebuilds the model per shot,
-                         but needs no dependency beyond LightStim's own scipy.
+    "auto"  (default) -- currently always ``scipy``; see below.
+    "scipy"           -- ``scipy.optimize.milp``. No dependency beyond
+                         LightStim's own scipy.
+    "highs"            -- the standalone ``highspy`` package.
 
-Measured on rotated-surface-code circuit noise at p=1e-3, single-threaded,
-against the alternatives (all cross-checked to agree on the optimal cost):
-HiGHS 91 ms/shot at d=7 and 371 ms at d=9, versus SCIP 131 ms at d=7 and
-OR-Tools CP-SAT 616 ms at d=7 *using 8 threads*. HiGHS wins on a single core,
-which is what matters here — :class:`SimulationPipeline` already parallelises
-across shots, so intra-solve threads only oversubscribe.
+**Prefer "scipy".** These are not the same binary: scipy vendors its own HiGHS
+(1.8.0 in scipy 1.15) rather than importing ``highspy`` (1.15.1), and the older
+vendored build is consistently ~2x faster on these models. Median ms/shot,
+same syndromes, same formulation:
+
+    instance                    scipy   highspy
+    surface d=5                  11.8      21.5
+    surface d=7                  41.4      76.5
+    BB [[72,12,6]] r=2           56.7     132.6
+    BB [[72,12,6]] r=4          113.7     270.6
+
+That ordering held on every instance tried, and is not explained by threads,
+matrix format, presolve, ``mip_rel_gap``, incremental-vs-rebuild model
+updates, or ``passModel`` — all were tested and are a wash. So ``highspy``
+is kept only as an escape hatch if a future scipy vendors a slower HiGHS.
+
+Against other solver families, on BB [[72,12,6]] r=4 (10 shots, 60 s cap):
+SCIP via ``pyscipopt`` 271 ms median, and OR-Tools CP-SAT 5.5 s median with
+8 threads (2 of 10 shots hit the cap). CP-SAT degrades far worse than the MILP
+solvers as the DEM gets denser -- BB detector rows average ~214 error
+mechanisms against the surface code's handful -- so its native XOR handling
+does not pay off here. Single-threaded is the right comparison regardless:
+:class:`SimulationPipeline` already parallelises across shots, so intra-solve
+threads only oversubscribe.
 
 Do not install ``highspy`` and ``ortools`` into the same environment: both
 vendor HiGHS and clash on symbols at import time, in either order.
 """
 
 from __future__ import annotations
-
-import importlib.util
 
 import numpy as np
 import scipy.sparse as sp
@@ -55,10 +70,14 @@ _DEFAULTS = {
 
 
 def _resolve_solver(name: str) -> str:
-    """Map ``"auto"`` onto whichever HiGHS binding is actually installed."""
+    """Resolve the ``solver`` param to a concrete backend.
+
+    ``"auto"`` picks scipy unconditionally: it is both the faster HiGHS build
+    (see module docstring) and always present, so there is nothing to detect.
+    """
     name = str(name).lower()
     if name == "auto":
-        return "highs" if importlib.util.find_spec("highspy") else "scipy"
+        return "scipy"
     if name not in ("highs", "scipy"):
         raise ValueError(
             f"Unknown solver {name!r}; expected 'auto', 'highs' or 'scipy'.")
@@ -129,8 +148,9 @@ class MleIlpDecoder(ExternalDecoder):
 
     def _decode_highs(self, syndrome):
         s = syndrome.astype(float)
-        # Only the RHS changes between shots: the matrix, costs and
-        # integrality stay resident inside HiGHS across solves.
+        # Only the RHS changes between shots, so the model stays resident.
+        # Measured as a wash against rebuilding it per shot -- kept because it
+        # is no more code, not because it buys speed.
         self._h.changeRowsBounds(self._m, self._rows, s, s)
         self._h.run()
         optimal = (self._h.getModelStatus()

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -1,0 +1,168 @@
+"""Exact most-likely-error (MLE) decoder via integer programming.
+
+Solves, for each shot, the exact most-likely-error problem
+
+    minimize   sum_j w_j e_j        with w_j = log((1 - p_j) / p_j)
+    subject to H e == s   (mod 2),  e in {0,1}^n
+
+The GF(2) parity is linearised with one bounded integer slack per detector:
+
+    sum_j H[i,j] e_j - 2 k_i == s_i,   0 <= k_i <= floor(rowweight_i / 2)
+
+This is the decoder papers mean by "exact MLE with Gurobi" (more precisely
+*most-likely-error*, not degenerate maximum-likelihood: it finds the single
+highest-probability error, it does not sum over the logical coset). It is
+exponential in the worst case and is intended as a **ground-truth reference**
+for small instances, not for production sampling throughput.
+
+Both backends are HiGHS (MIT-licensed) and return identical optima; they differ
+only in how the model is handed to it (``DecoderConfig(params={"solver": ...})``):
+
+    "auto"  (default) -- ``highspy`` if importable, else ``scipy``.
+    "highs"           -- ``highspy``. Builds the model once and rewrites only the
+                         row bounds per shot; ~1.5x faster than ``scipy`` by d=7.
+    "scipy"           -- ``scipy.optimize.milp``. Rebuilds the model per shot,
+                         but needs no dependency beyond LightStim's own scipy.
+
+Measured on rotated-surface-code circuit noise at p=1e-3, single-threaded,
+against the alternatives (all cross-checked to agree on the optimal cost):
+HiGHS 91 ms/shot at d=7 and 371 ms at d=9, versus SCIP 131 ms at d=7 and
+OR-Tools CP-SAT 616 ms at d=7 *using 8 threads*. HiGHS wins on a single core,
+which is what matters here — :class:`SimulationPipeline` already parallelises
+across shots, so intra-solve threads only oversubscribe.
+
+Do not install ``highspy`` and ``ortools`` into the same environment: both
+vendor HiGHS and clash on symbols at import time, in either order.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import scipy.sparse as sp
+
+from ..external import ExternalDecoder
+from ..registry import register_decoder
+
+_DEFAULTS = {
+    "solver": "auto",
+    "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
+    "time_limit": 0.0,     # seconds per shot; 0 = unlimited. A shot that hits
+                           # the limit is reported as a decode failure, so
+                           # DecoderConfig(on_decode_failure=...) can herald it.
+}
+
+
+def _resolve_solver(name: str) -> str:
+    """Map ``"auto"`` onto whichever HiGHS binding is actually installed."""
+    name = str(name).lower()
+    if name == "auto":
+        return "highs" if importlib.util.find_spec("highspy") else "scipy"
+    if name not in ("highs", "scipy"):
+        raise ValueError(
+            f"Unknown solver {name!r}; expected 'auto', 'highs' or 'scipy'.")
+    return name
+
+
+def _weights(priors: np.ndarray, max_prior: float) -> np.ndarray:
+    """Negative-log-likelihood-ratio cost per error mechanism."""
+    q = np.clip(np.asarray(priors, dtype=float), 1e-15, max_prior - 1e-15)
+    return np.log((1.0 - q) / q)
+
+
+class MleIlpDecoder(ExternalDecoder):
+    """Exact MLE decoder backed by an open-source MILP solver."""
+
+    output_type = "correction"
+
+    def setup(self, *, H, priors, **_):
+        params = {**_DEFAULTS, **self.params}
+        self._solver = _resolve_solver(params["solver"])
+        self._time_limit = float(params["time_limit"])
+
+        H = sp.csr_matrix(H, dtype=np.uint8)
+        self._m, self._n = H.shape
+        self._w = _weights(priors, float(params["max_prior"]))
+
+        rowsum = np.asarray(H.sum(axis=1)).ravel()
+        self._lb = np.zeros(self._n + self._m)
+        self._ub = np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)])
+        self._c = np.concatenate([self._w, np.zeros(self._m)])
+        # [H | -2I] -- one slack column per detector row.
+        self._A = sp.hstack(
+            [H.astype(float), -2.0 * sp.eye(self._m, format="csr")],
+            format="csr",
+        )
+
+        if self._solver == "highs":
+            self._setup_highs()
+
+    # ------------------------------------------------------------- HiGHS
+    def _setup_highs(self):
+        import highspy
+
+        self._highspy = highspy
+        h = highspy.Highs()
+        h.setOptionValue("output_flag", False)
+        # One solver thread: the pipeline already parallelises across shots
+        # with multiple worker processes, so intra-solve threads oversubscribe.
+        h.setOptionValue("threads", 1)
+        if self._time_limit > 0:
+            h.setOptionValue("time_limit", self._time_limit)
+
+        nvars = self._n + self._m
+        idx = np.arange(nvars, dtype=np.int32)
+        h.addVars(nvars, self._lb, self._ub)
+        h.changeColsCost(nvars, idx, self._c)
+        h.changeColsIntegrality(
+            nvars, idx, np.full(nvars, highspy.HighsVarType.kInteger))
+
+        # Row bounds are placeholders; decode_single rewrites them per shot.
+        z = np.zeros(self._m)
+        A = self._A
+        h.addRows(self._m, z, z, A.nnz,
+                  A.indptr[:-1].astype(np.int32),
+                  A.indices.astype(np.int32), A.data)
+        self._h = h
+        self._rows = np.arange(self._m, dtype=np.int32)
+
+    def _decode_highs(self, syndrome):
+        s = syndrome.astype(float)
+        # Only the RHS changes between shots: the matrix, costs and
+        # integrality stay resident inside HiGHS across solves.
+        self._h.changeRowsBounds(self._m, self._rows, s, s)
+        self._h.run()
+        optimal = (self._h.getModelStatus()
+                   == self._highspy.HighsModelStatus.kOptimal)
+        if not optimal:
+            return np.zeros(self._n, dtype=np.uint8), False
+        sol = np.asarray(self._h.getSolution().col_value)
+        return np.round(sol[:self._n]).astype(np.uint8), True
+
+    # ------------------------------------------------------------- scipy
+    def _decode_scipy(self, syndrome):
+        from scipy.optimize import Bounds, LinearConstraint, milp
+
+        s = syndrome.astype(float)
+        options = {"time_limit": self._time_limit} if self._time_limit > 0 else {}
+        res = milp(
+            c=self._c,
+            constraints=LinearConstraint(self._A, s, s),
+            integrality=np.ones(self._n + self._m),
+            bounds=Bounds(self._lb, self._ub),
+            options=options,
+        )
+        if not res.success:
+            return np.zeros(self._n, dtype=np.uint8), False
+        return np.round(res.x[:self._n]).astype(np.uint8), True
+
+    def decode_single(self, syndrome):
+        syndrome = np.asarray(syndrome, dtype=np.uint8).ravel()
+        if self._solver == "highs":
+            return self._decode_highs(syndrome)
+        return self._decode_scipy(syndrome)
+
+
+register_decoder("mle-ilp", MleIlpDecoder, aliases=["mle", "ilp"],
+                 backend="cpu")

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -9,7 +9,7 @@ The GF(2) parity is linearised with one bounded integer slack per detector:
 
     sum_j H[i,j] e_j - 2 k_i == s_i,   0 <= k_i <= floor(rowweight_i / 2)
 
-This is the decoder papers mean by "exact MLE with Gurobi" (more precisely
+This is the decoder papers mean by "exact MLE" (more precisely
 *most-likely-error*, not degenerate maximum-likelihood: it finds the single
 highest-probability error, it does not sum over the logical coset). It is
 exponential in the worst case and is intended as a **ground-truth reference**
@@ -63,6 +63,8 @@ clash on symbols at import, in either order.
 
 from __future__ import annotations
 
+import time
+
 import numpy as np
 import scipy.sparse as sp
 from scipy.optimize import Bounds, LinearConstraint, linprog, milp
@@ -75,9 +77,18 @@ _CUT_TOL = 1e-7        # minimum violation before a cut is worth adding
 
 _DEFAULTS = {
     "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
-    "time_limit": 0.0,     # seconds per shot; 0 = unlimited. A shot that hits
-                           # the limit is reported as a decode failure, so
-                           # DecoderConfig(on_decode_failure=...) can herald it.
+    "time_limit": 0.0,     # soft wall-clock budget per shot; 0 = unlimited.
+                           # Cut generation and the MILP fallback share one
+                           # deadline, and a shot that exhausts it is reported
+                           # as a decode failure so
+                           # DecoderConfig(on_decode_failure=...) can herald it
+                           # instead of silently recording a wrong answer.
+                           # Worth setting: the tail is brutal without it. On
+                           # BB [[72,12,6]] r=4, 200 shots, the worst shot goes
+                           # 38.8 s -> 1.0 s at time_limit=0.5 (5 heralded) and
+                           # -> 2.6 s at 2.0 (2 heralded), mean 232 -> 37/57 ms.
+                           # Soft, not hard: HiGHS polices its own limit only
+                           # at checkpoints, so expect overshoot up to ~2x.
     "max_cut_rounds": 200,  # give up on cut generation and fall back to MILP
     "max_rpc_rounds": 8,    # redundant-parity-check rounds once ALP stalls;
                             # 0 disables ACG and leaves plain ALP
@@ -127,8 +138,6 @@ class MleIlpDecoder(ExternalDecoder):
             [H.astype(float), -2.0 * sp.eye(self._m, format="csr")],
             format="csr",
         )
-        self._options = ({"time_limit": self._time_limit}
-                         if self._time_limit > 0 else {})
 
     def _violated_checks(self, e, s):
         """Screen every check for a violated forbidden-set cut, vectorised.
@@ -246,7 +255,7 @@ class MleIlpDecoder(ExternalDecoder):
                              float(in_s.sum()) - 1.0))
         return cuts
 
-    def _adaptive_lp(self, s):
+    def _adaptive_lp(self, s, deadline=None):
         """ACG-ALP decode. Returns the error, or None to escalate to the MILP.
 
         Solves over the fundamental polytope, generating forbidden-set cuts on
@@ -257,6 +266,9 @@ class MleIlpDecoder(ExternalDecoder):
         Terminating with no violated cut and an integral solution means every
         parity holds and the solution is optimal over a relaxation containing
         every valid error, so it is the exact MLE answer.
+
+        ``deadline`` is an absolute :func:`time.monotonic` value; cut generation
+        gives up once past it so the caller's per-shot budget is respected.
         """
         rows, cols, vals, rhs = [], [], [], []
         e = np.zeros(self._n)
@@ -274,15 +286,28 @@ class MleIlpDecoder(ExternalDecoder):
                 (np.concatenate(vals),
                  (np.concatenate(rows), np.concatenate(cols))),
                 shape=(len(rhs), self._n))
+            # Hand the LP whatever budget is left, so one pathological solve
+            # cannot blow the per-shot limit on its own.
+            options = {}
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                options["time_limit"] = remaining
             lp = linprog(c=self._w, A_ub=a_ub, b_ub=np.asarray(rhs),
-                         bounds=(0, 1), method="highs")
+                         bounds=(0, 1), method="highs", options=options)
             if not lp.success:
                 return False
             e = lp.x
             return True
 
+        def out_of_time():
+            return deadline is not None and time.monotonic() >= deadline
+
         def separate_to_convergence():
             for _ in range(self._max_rounds):
+                if out_of_time():
+                    return False
                 violated = self._violated_checks(e, s)
                 if violated.size == 0:
                     return True
@@ -297,6 +322,8 @@ class MleIlpDecoder(ExternalDecoder):
         for _ in range(self._max_rpc_rounds):
             if np.abs(e - np.round(e)).max() < _INT_TOL:
                 break
+            if out_of_time():
+                return None
             rpc = self._rpc_cuts(e, s)
             if not rpc:
                 break                       # no derived check is violated
@@ -332,9 +359,21 @@ class MleIlpDecoder(ExternalDecoder):
         relaxation left fractional, so they never reach the MILP at all.
         """
         s = np.asarray(syndrome, dtype=np.uint8).ravel()
-        e = self._adaptive_lp(s)
+        deadline = (time.monotonic() + self._time_limit
+                    if self._time_limit > 0 else None)
+
+        e = self._adaptive_lp(s, deadline)
         if e is not None:
             return e, True
+
+        # The MILP gets what is *left* of the budget, not a fresh copy of it --
+        # otherwise a shot could spend the full limit twice over.
+        options = {}
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return np.zeros(self._n, dtype=np.uint8), False
+            options["time_limit"] = remaining
 
         sf = s.astype(float)
         res = milp(
@@ -342,7 +381,7 @@ class MleIlpDecoder(ExternalDecoder):
             constraints=LinearConstraint(self._A, sf, sf),
             integrality=self._integrality,
             bounds=self._bounds,
-            options=self._options,
+            options=options,
         )
         if not res.success:
             return np.zeros(self._n, dtype=np.uint8), False

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -15,6 +15,10 @@ highest-probability error, it does not sum over the logical coset). It is
 exponential in the worst case and is intended as a **ground-truth reference**
 for small instances, not for production sampling throughput.
 
+Each shot is attempted as an LP first and only escalated to the MILP if that
+does not settle it -- see :meth:`MleIlpDecoder.decode_single`. This stays
+exact; it is a shortcut, not a relaxation-based heuristic.
+
 The solver is ``scipy.optimize.milp``, which needs no dependency beyond the
 scipy LightStim already requires. Alternatives were benchmarked and rejected;
 median ms/shot on identical syndromes with an identical formulation, all
@@ -50,10 +54,12 @@ from __future__ import annotations
 
 import numpy as np
 import scipy.sparse as sp
-from scipy.optimize import Bounds, LinearConstraint, milp
+from scipy.optimize import Bounds, LinearConstraint, linprog, milp
 
 from ..external import ExternalDecoder
 from ..registry import register_decoder
+
+_INT_TOL = 1e-6        # treat an LP component as integral within this
 
 _DEFAULTS = {
     "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
@@ -82,11 +88,12 @@ class MleIlpDecoder(ExternalDecoder):
         self._m, self._n = H.shape
         self._w = _weights(priors, float(params["max_prior"]))
 
+        self._H = H
         rowsum = np.asarray(H.sum(axis=1)).ravel()
-        self._bounds = Bounds(
-            np.zeros(self._n + self._m),
-            np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)]),
-        )
+        lower = np.zeros(self._n + self._m)
+        upper = np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)])
+        self._bounds = Bounds(lower, upper)
+        self._lp_bounds = np.column_stack([lower, upper])
         self._c = np.concatenate([self._w, np.zeros(self._m)])
         self._integrality = np.ones(self._n + self._m)
         # [H | -2I] -- one slack column per detector row.
@@ -98,10 +105,38 @@ class MleIlpDecoder(ExternalDecoder):
                          if self._time_limit > 0 else {})
 
     def decode_single(self, syndrome):
-        s = np.asarray(syndrome, dtype=np.uint8).ravel().astype(float)
+        """Solve one shot: LP relaxation first, MILP only if it doesn't settle.
+
+        An integral optimum of the relaxation *is* the MILP optimum -- the LP
+        optimum lower-bounds the MILP's, and an integral LP solution is
+        MILP-feasible, so the two coincide. So this shortcut returns exactly
+        what the MILP would, and only its cost changes.
+
+        It is worth taking because the relaxation is usually tight here: HiGHS
+        reports a branch-and-bound node count of 1 on essentially every shot,
+        and the LP alone settles 77-100% of them depending on the instance.
+        Measured end to end against calling the MILP directly: 2.1x on surface
+        d=7 (100 shots) and 1.6x on BB [[72,12,6]] r=4 (60 shots), and 3.5-4.7x
+        on the median shot. Totals gain less than the median because both paths
+        are dominated by the same rare hard shots, which the LP never settles
+        -- those pay one extra LP, which is noise against a multi-second solve.
+        """
+        s = np.asarray(syndrome, dtype=np.uint8).ravel()
+        sf = s.astype(float)
+
+        lp = linprog(c=self._c, A_eq=self._A, b_eq=sf,
+                     bounds=self._lp_bounds, method="highs")
+        if lp.success and np.abs(lp.x - np.round(lp.x)).max() < _INT_TOL:
+            e = np.round(lp.x[:self._n]).astype(np.uint8)
+            # Re-check the parity exactly rather than trusting _INT_TOL: the
+            # slacks must be integral too, or H e - 2k = s says nothing about
+            # H e = s (mod 2).
+            if np.array_equal((self._H @ e) % 2, s):
+                return e, True
+
         res = milp(
             c=self._c,
-            constraints=LinearConstraint(self._A, s, s),
+            constraints=LinearConstraint(self._A, sf, sf),
             integrality=self._integrality,
             bounds=self._bounds,
             options=self._options,

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -24,44 +24,23 @@ of being discarded; they tighten the branch-and-bound relaxation without
 changing the integer feasible set. This stays exact; see
 :meth:`MleIlpDecoder._adaptive_lp`.
 
-Plain ALP already settles 85-100% of shots and is worth 2.0-11.0x over calling
-the MILP directly, with the largest gains on QLDPC codes. RPC cuts then clear
-most of what is left -- on surface d=7 and d=9 at p=1e-3 they took the MILP
-fallback rate from 7/60 and 3/30 to zero -- for a further 1.4-3.2x on surface
-codes. They earn nothing on the BB codes tried (no stalled shot was rescued)
-and cost ~8% there, which is why ``max_rpc_rounds`` exists: set it to 0 for
-plain ALP.
+ALP settles many shots without invoking mixed-integer branch-and-bound, while
+RPC cuts can settle additional fractional cases. ``max_rpc_rounds=0`` disables
+the RPC stage when its overhead is not useful for a particular code family.
 
 Both stages go through scipy -- ``linprog`` for the cuts, ``milp`` for the
-fallback -- which needs no dependency beyond the scipy LightStim already
-requires. Other solvers were benchmarked against the MILP formulation and
-rejected; median ms/shot on identical syndromes, all cross-checked to return
-the same optimal cost:
-
-    instance              scipy   highspy    SCIP   CP-SAT (8 threads)
-    surface d=5            11.8      21.5      26                  60
-    surface d=7            41.4      76.5     271                 616
-    BB [[72,12,6]] r=2     56.7     132.6      79                 119
-    BB [[72,12,6]] r=4    113.7     270.6     271                5488
-
-Two results there are worth not re-deriving. First, scipy and ``highspy`` are
-*not* the same binary — scipy vendors its own HiGHS (1.8.0 in scipy 1.15)
-rather than importing ``highspy`` (1.15.1), and the older vendored build wins
-everywhere. The gap is not explained by threads, matrix format, presolve,
-``mip_rel_gap``, incremental-vs-rebuild model updates, or ``passModel``; all
-were tested and are a wash. Second, CP-SAT degrades far worse than the MILP
-solvers as the DEM densifies (a BB detector row averages ~214 error mechanisms
-against a handful for the surface code), so its native ``AddBoolXOr`` handling
-of the parity constraints does not pay off. At BB r=4 it left 2 of 10 shots
-unproven at a 60 s cap.
+fallback. The deterministic benchmark in ``benchmarks/mle`` compares the
+optimised path with a direct SciPy MILP on identical surface-code and BB-code
+syndromes, checks objective agreement, and records the local environment.
 
 Single-threaded is the right comparison throughout: :class:`SimulationPipeline`
 already parallelises across shots, so intra-solve threads only oversubscribe.
 
-If a future scipy vendors a slower HiGHS, the alternatives are worth re-testing
--- ``git log`` for this file has a working ``highspy`` backend. Note that
-``highspy`` and ``ortools`` cannot share an environment: both vendor HiGHS and
-clash on symbols at import, in either order.
+Supplied priors are first validated to be in [0, 0.5]; values above 0.5 are
+rejected, not clamped. ``max_prior`` is a separate compatibility/model-tuning
+cap. Its default of 0.5 leaves every accepted prior unchanged. Setting
+``max_prior=c<0.5`` replaces each positive prior ``p`` with ``min(p, c)``, so
+accepted priors above ``c`` are intentionally decoded under an altered model.
 """
 
 from __future__ import annotations
@@ -84,17 +63,18 @@ _BIT_MASKS = np.left_shift(np.uint8(1), np.arange(8, dtype=np.uint8))
 _RPC_XOR_CHUNK_BYTES = 8 << 20
 
 _DEFAULTS = {
-    "max_prior": 0.5,      # optional stricter clamp; priors > 0.5 are rejected
+    "max_prior": 0.5,      # Applied only after priors are validated in
+                            # [0, 0.5]; values above 0.5 are rejected. The
+                            # default changes nothing. Setting c < 0.5 maps
+                            # each positive p to min(p, c), while p=0 stays
+                            # impossible/fixed off.
     "time_limit": 0.0,     # soft wall-clock budget per shot; 0 = unlimited.
                            # Cut generation and the MILP fallback share one
                            # deadline, and a shot that exhausts it is reported
                            # as a decode failure so
                            # DecoderConfig(on_decode_failure=...) can herald it
                            # instead of silently recording a wrong answer.
-                           # Worth setting: the tail is brutal without it. On
-                           # BB [[72,12,6]] r=4, 200 shots, the worst shot goes
-                           # 38.8 s -> 1.0 s at time_limit=0.5 (5 heralded) and
-                           # -> 2.6 s at 2.0 (2 heralded), mean 232 -> 37/57 ms.
+                           # Worth setting for large DEMs with long solve tails.
                            # Soft, not hard: HiGHS polices its own limit only
                            # at checkpoints, so expect overshoot up to ~2x.
     "max_cut_rounds": 200,  # give up on cut generation and fall back to MILP
@@ -111,14 +91,25 @@ _DEFAULTS = {
 
 
 def _weights(priors: np.ndarray, max_prior: float) -> np.ndarray:
-    """Negative-log-likelihood-ratio cost per error mechanism."""
+    """Return LLR costs after validation and the optional ``max_prior`` cap.
+
+    Priors above 0.5 are rejected. For an accepted prior p, a non-default cap
+    c replaces p with min(p, c); the default c=0.5 leaves p unchanged.
+    """
     q = np.asarray(priors, dtype=float)
     if not np.all(np.isfinite(q)) or np.any(q < 0.0) or np.any(q > 0.5):
         raise ValueError("priors must be finite probabilities in [0, 0.5]")
     if not 0.0 < max_prior <= 0.5:
         raise ValueError("max_prior must be in (0, 0.5]")
-    q = np.clip(q, 1e-15, max_prior - 1e-15)
-    return np.log((1.0 - q) / q)
+    q = np.minimum(q, max_prior)
+    weights = np.zeros_like(q)
+    positive = q > 0.0
+    weights[positive] = np.log1p(-q[positive]) - np.log(q[positive])
+    # Avoid leaving a platform-dependent rounding residue at the exactly
+    # uninformative prior. Zero-prior variables are fixed off in setup, so their
+    # placeholder weight is never part of a feasible solution.
+    weights[q == 0.5] = 0.0
+    return weights
 
 
 class MleIlpDecoder(ExternalDecoder):
@@ -129,10 +120,13 @@ class MleIlpDecoder(ExternalDecoder):
     def setup(self, *, H, priors, **_):
         params = {**_DEFAULTS, **self.params}
         self._time_limit = float(params["time_limit"])
+        if not np.isfinite(self._time_limit) or self._time_limit < 0:
+            raise ValueError("time_limit must be finite and non-negative")
 
         H = sp.csr_matrix(H, dtype=np.uint8)
         self._m, self._n = H.shape
         self._w = _weights(priors, float(params["max_prior"]))
+        possible = np.asarray(priors, dtype=float) > 0.0
 
         self._H = H
         self._indptr = H.indptr
@@ -167,8 +161,12 @@ class MleIlpDecoder(ExternalDecoder):
 
         rowsum = np.asarray(H.sum(axis=1)).ravel()
         lower = np.zeros(self._n + self._m)
-        upper = np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)])
+        error_upper = possible.astype(float)
+        upper = np.concatenate([error_upper, np.floor(rowsum / 2.0)])
         self._bounds = Bounds(lower, upper)
+        self._lp_bounds = np.column_stack(
+            [np.zeros(self._n, dtype=float), error_upper]
+        )
         self._c = np.concatenate([self._w, np.zeros(self._m)])
         self._integrality = np.ones(self._n + self._m)
         # [H | -2I] -- one slack column per detector row.
@@ -365,7 +363,7 @@ class MleIlpDecoder(ExternalDecoder):
                     return False
                 options["time_limit"] = remaining
             lp = linprog(c=self._w, A_ub=a_ub, b_ub=np.asarray(rhs),
-                         bounds=(0, 1), method="highs", options=options)
+                         bounds=self._lp_bounds, method="highs", options=options)
             if not lp.success:
                 return False
             e = lp.x
@@ -422,18 +420,9 @@ class MleIlpDecoder(ExternalDecoder):
         the LP result, when integral, is provably the MILP optimum. Only the
         cost of getting there differs.
 
-        The relaxation is tight enough on these models that HiGHS reports a
-        branch-and-bound node count of 1 on essentially every shot, so the win
-        is skipping MIP machinery that changes nothing. Measured against
-        calling the MILP directly: 3.9x on surface d=5, 2.0x on d=7, 11.0x on
-        BB [[72,12,6]] r=2 and 7.9x on r=4, with the LP settling 34/40 to 40/40
-        of shots. Totals gain least where a few hard shots dominate, and those
-        shots reuse the generated cuts to tighten the MILP fallback.
-
-        Against the plain (slack-formulation) relaxation this replaced, the
-        end-to-end gain is larger still -- a 100-shot BB r=4 run went from 727
-        to 38 ms/shot -- because ALP settles hard shots that the slack
-        relaxation left fractional, so they never reach the MILP at all.
+        The LP shortcut skips mixed-integer machinery when the relaxation is
+        already integral. Fractional shots reuse all generated cuts in the
+        exact MILP fallback. See ``benchmarks/mle`` for reproducible timings.
         """
         s = np.asarray(syndrome, dtype=np.uint8).ravel()
         deadline = (time.monotonic() + self._time_limit

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -29,10 +29,11 @@ codes. They earn nothing on the BB codes tried (no stalled shot was rescued)
 and cost ~8% there, which is why ``max_rpc_rounds`` exists: set it to 0 for
 plain ALP.
 
-The solver is ``scipy.optimize.milp``, which needs no dependency beyond the
-scipy LightStim already requires. Alternatives were benchmarked and rejected;
-median ms/shot on identical syndromes with an identical formulation, all
-cross-checked to return the same optimal cost:
+Both stages go through scipy -- ``linprog`` for the cuts, ``milp`` for the
+fallback -- which needs no dependency beyond the scipy LightStim already
+requires. Other solvers were benchmarked against the MILP formulation and
+rejected; median ms/shot on identical syndromes, all cross-checked to return
+the same optimal cost:
 
     instance              scipy   highspy    SCIP   CP-SAT (8 threads)
     surface d=5            11.8      21.5      26                  60

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -15,73 +15,52 @@ highest-probability error, it does not sum over the logical coset). It is
 exponential in the worst case and is intended as a **ground-truth reference**
 for small instances, not for production sampling throughput.
 
-Both backends are HiGHS (MIT-licensed) and return identical optima
-(``DecoderConfig(params={"solver": ...})``):
+The solver is ``scipy.optimize.milp``, which needs no dependency beyond the
+scipy LightStim already requires. Alternatives were benchmarked and rejected;
+median ms/shot on identical syndromes with an identical formulation, all
+cross-checked to return the same optimal cost:
 
-    "auto"  (default) -- currently always ``scipy``; see below.
-    "scipy"           -- ``scipy.optimize.milp``. No dependency beyond
-                         LightStim's own scipy.
-    "highs"            -- the standalone ``highspy`` package.
+    instance              scipy   highspy    SCIP   CP-SAT (8 threads)
+    surface d=5            11.8      21.5      26                  60
+    surface d=7            41.4      76.5     271                 616
+    BB [[72,12,6]] r=2     56.7     132.6      79                 119
+    BB [[72,12,6]] r=4    113.7     270.6     271                5488
 
-**Prefer "scipy".** These are not the same binary: scipy vendors its own HiGHS
-(1.8.0 in scipy 1.15) rather than importing ``highspy`` (1.15.1), and the older
-vendored build is consistently ~2x faster on these models. Median ms/shot,
-same syndromes, same formulation:
+Two results there are worth not re-deriving. First, scipy and ``highspy`` are
+*not* the same binary — scipy vendors its own HiGHS (1.8.0 in scipy 1.15)
+rather than importing ``highspy`` (1.15.1), and the older vendored build wins
+everywhere. The gap is not explained by threads, matrix format, presolve,
+``mip_rel_gap``, incremental-vs-rebuild model updates, or ``passModel``; all
+were tested and are a wash. Second, CP-SAT degrades far worse than the MILP
+solvers as the DEM densifies (a BB detector row averages ~214 error mechanisms
+against a handful for the surface code), so its native ``AddBoolXOr`` handling
+of the parity constraints does not pay off. At BB r=4 it left 2 of 10 shots
+unproven at a 60 s cap.
 
-    instance                    scipy   highspy
-    surface d=5                  11.8      21.5
-    surface d=7                  41.4      76.5
-    BB [[72,12,6]] r=2           56.7     132.6
-    BB [[72,12,6]] r=4          113.7     270.6
+Single-threaded is the right comparison throughout: :class:`SimulationPipeline`
+already parallelises across shots, so intra-solve threads only oversubscribe.
 
-That ordering held on every instance tried, and is not explained by threads,
-matrix format, presolve, ``mip_rel_gap``, incremental-vs-rebuild model
-updates, or ``passModel`` — all were tested and are a wash. So ``highspy``
-is kept only as an escape hatch if a future scipy vendors a slower HiGHS.
-
-Against other solver families, on BB [[72,12,6]] r=4 (10 shots, 60 s cap):
-SCIP via ``pyscipopt`` 271 ms median, and OR-Tools CP-SAT 5.5 s median with
-8 threads (2 of 10 shots hit the cap). CP-SAT degrades far worse than the MILP
-solvers as the DEM gets denser -- BB detector rows average ~214 error
-mechanisms against the surface code's handful -- so its native XOR handling
-does not pay off here. Single-threaded is the right comparison regardless:
-:class:`SimulationPipeline` already parallelises across shots, so intra-solve
-threads only oversubscribe.
-
-Do not install ``highspy`` and ``ortools`` into the same environment: both
-vendor HiGHS and clash on symbols at import time, in either order.
+If a future scipy vendors a slower HiGHS, the alternatives are worth re-testing
+-- ``git log`` for this file has a working ``highspy`` backend. Note that
+``highspy`` and ``ortools`` cannot share an environment: both vendor HiGHS and
+clash on symbols at import, in either order.
 """
 
 from __future__ import annotations
 
 import numpy as np
 import scipy.sparse as sp
+from scipy.optimize import Bounds, LinearConstraint, milp
 
 from ..external import ExternalDecoder
 from ..registry import register_decoder
 
 _DEFAULTS = {
-    "solver": "auto",
     "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
     "time_limit": 0.0,     # seconds per shot; 0 = unlimited. A shot that hits
                            # the limit is reported as a decode failure, so
                            # DecoderConfig(on_decode_failure=...) can herald it.
 }
-
-
-def _resolve_solver(name: str) -> str:
-    """Resolve the ``solver`` param to a concrete backend.
-
-    ``"auto"`` picks scipy unconditionally: it is both the faster HiGHS build
-    (see module docstring) and always present, so there is nothing to detect.
-    """
-    name = str(name).lower()
-    if name == "auto":
-        return "scipy"
-    if name not in ("highs", "scipy"):
-        raise ValueError(
-            f"Unknown solver {name!r}; expected 'auto', 'highs' or 'scipy'.")
-    return name
 
 
 def _weights(priors: np.ndarray, max_prior: float) -> np.ndarray:
@@ -91,13 +70,12 @@ def _weights(priors: np.ndarray, max_prior: float) -> np.ndarray:
 
 
 class MleIlpDecoder(ExternalDecoder):
-    """Exact MLE decoder backed by an open-source MILP solver."""
+    """Exact MLE decoder backed by ``scipy.optimize.milp`` (HiGHS)."""
 
     output_type = "correction"
 
     def setup(self, *, H, priors, **_):
         params = {**_DEFAULTS, **self.params}
-        self._solver = _resolve_solver(params["solver"])
         self._time_limit = float(params["time_limit"])
 
         H = sp.csr_matrix(H, dtype=np.uint8)
@@ -105,83 +83,32 @@ class MleIlpDecoder(ExternalDecoder):
         self._w = _weights(priors, float(params["max_prior"]))
 
         rowsum = np.asarray(H.sum(axis=1)).ravel()
-        self._lb = np.zeros(self._n + self._m)
-        self._ub = np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)])
+        self._bounds = Bounds(
+            np.zeros(self._n + self._m),
+            np.concatenate([np.ones(self._n), np.floor(rowsum / 2.0)]),
+        )
         self._c = np.concatenate([self._w, np.zeros(self._m)])
+        self._integrality = np.ones(self._n + self._m)
         # [H | -2I] -- one slack column per detector row.
         self._A = sp.hstack(
             [H.astype(float), -2.0 * sp.eye(self._m, format="csr")],
             format="csr",
         )
+        self._options = ({"time_limit": self._time_limit}
+                         if self._time_limit > 0 else {})
 
-        if self._solver == "highs":
-            self._setup_highs()
-
-    # ------------------------------------------------------------- HiGHS
-    def _setup_highs(self):
-        import highspy
-
-        self._highspy = highspy
-        h = highspy.Highs()
-        h.setOptionValue("output_flag", False)
-        # One solver thread: the pipeline already parallelises across shots
-        # with multiple worker processes, so intra-solve threads oversubscribe.
-        h.setOptionValue("threads", 1)
-        if self._time_limit > 0:
-            h.setOptionValue("time_limit", self._time_limit)
-
-        nvars = self._n + self._m
-        idx = np.arange(nvars, dtype=np.int32)
-        h.addVars(nvars, self._lb, self._ub)
-        h.changeColsCost(nvars, idx, self._c)
-        h.changeColsIntegrality(
-            nvars, idx, np.full(nvars, highspy.HighsVarType.kInteger))
-
-        # Row bounds are placeholders; decode_single rewrites them per shot.
-        z = np.zeros(self._m)
-        A = self._A
-        h.addRows(self._m, z, z, A.nnz,
-                  A.indptr[:-1].astype(np.int32),
-                  A.indices.astype(np.int32), A.data)
-        self._h = h
-        self._rows = np.arange(self._m, dtype=np.int32)
-
-    def _decode_highs(self, syndrome):
-        s = syndrome.astype(float)
-        # Only the RHS changes between shots, so the model stays resident.
-        # Measured as a wash against rebuilding it per shot -- kept because it
-        # is no more code, not because it buys speed.
-        self._h.changeRowsBounds(self._m, self._rows, s, s)
-        self._h.run()
-        optimal = (self._h.getModelStatus()
-                   == self._highspy.HighsModelStatus.kOptimal)
-        if not optimal:
-            return np.zeros(self._n, dtype=np.uint8), False
-        sol = np.asarray(self._h.getSolution().col_value)
-        return np.round(sol[:self._n]).astype(np.uint8), True
-
-    # ------------------------------------------------------------- scipy
-    def _decode_scipy(self, syndrome):
-        from scipy.optimize import Bounds, LinearConstraint, milp
-
-        s = syndrome.astype(float)
-        options = {"time_limit": self._time_limit} if self._time_limit > 0 else {}
+    def decode_single(self, syndrome):
+        s = np.asarray(syndrome, dtype=np.uint8).ravel().astype(float)
         res = milp(
             c=self._c,
             constraints=LinearConstraint(self._A, s, s),
-            integrality=np.ones(self._n + self._m),
-            bounds=Bounds(self._lb, self._ub),
-            options=options,
+            integrality=self._integrality,
+            bounds=self._bounds,
+            options=self._options,
         )
         if not res.success:
             return np.zeros(self._n, dtype=np.uint8), False
         return np.round(res.x[:self._n]).astype(np.uint8), True
-
-    def decode_single(self, syndrome):
-        syndrome = np.asarray(syndrome, dtype=np.uint8).ravel()
-        if self._solver == "highs":
-            return self._decode_highs(syndrome)
-        return self._decode_scipy(syndrome)
 
 
 register_decoder("mle-ilp", MleIlpDecoder, aliases=["mle", "ilp"],

--- a/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
+++ b/lightstim/simulation/decoder_backend/decoders/mle_ilp.py
@@ -19,7 +19,10 @@ The MILP is the fallback, not the first move. Each shot is first attempted with
 ACG-ALP: Feldman's fundamental-polytope relaxation with forbidden-set cuts
 generated on demand (Taghavi & Siegel), plus redundant-parity-check cuts when
 that stalls (Zhang & Siegel). Only a shot that survives both escalates to the
-MILP. This stays exact; see :meth:`MleIlpDecoder._adaptive_lp`.
+MILP. The valid cuts already generated are retained as MILP constraints instead
+of being discarded; they tighten the branch-and-bound relaxation without
+changing the integer feasible set. This stays exact; see
+:meth:`MleIlpDecoder._adaptive_lp`.
 
 Plain ALP already settles 85-100% of shots and is worth 2.0-11.0x over calling
 the MILP directly, with the largest gains on QLDPC codes. RPC cuts then clear
@@ -74,9 +77,14 @@ from ..registry import register_decoder
 
 _INT_TOL = 1e-6        # treat an LP component as integral within this
 _CUT_TOL = 1e-7        # minimum violation before a cut is worth adding
+_POPCOUNT = np.unpackbits(
+    np.arange(256, dtype=np.uint8)[:, None], axis=1
+).sum(axis=1).astype(np.uint8)
+_BIT_MASKS = np.left_shift(np.uint8(1), np.arange(8, dtype=np.uint8))
+_RPC_XOR_CHUNK_BYTES = 8 << 20
 
 _DEFAULTS = {
-    "max_prior": 0.5,      # clamp: priors >= 0.5 give non-positive weights
+    "max_prior": 0.5,      # optional stricter clamp; priors > 0.5 are rejected
     "time_limit": 0.0,     # soft wall-clock budget per shot; 0 = unlimited.
                            # Cut generation and the MILP fallback share one
                            # deadline, and a shot that exhausts it is reported
@@ -94,12 +102,22 @@ _DEFAULTS = {
                             # 0 disables ACG and leaves plain ALP
     "max_rpc_pivots": 64,   # Gaussian-elimination pivots per RPC round
     "max_rpc_weight": 256,  # skip derived checks denser than this
+    "max_rpc_memory_mb": 512.0,
+                            # cap the main packed RPC workspace (cached H,
+                            # elimination copy, and bounded temporaries). If the
+                            # estimate exceeds this, skip RPC and let the exact
+                            # MILP handle the shot. 0 means unlimited.
 }
 
 
 def _weights(priors: np.ndarray, max_prior: float) -> np.ndarray:
     """Negative-log-likelihood-ratio cost per error mechanism."""
-    q = np.clip(np.asarray(priors, dtype=float), 1e-15, max_prior - 1e-15)
+    q = np.asarray(priors, dtype=float)
+    if not np.all(np.isfinite(q)) or np.any(q < 0.0) or np.any(q > 0.5):
+        raise ValueError("priors must be finite probabilities in [0, 0.5]")
+    if not 0.0 < max_prior <= 0.5:
+        raise ValueError("max_prior must be in (0, 0.5]")
+    q = np.clip(q, 1e-15, max_prior - 1e-15)
     return np.log((1.0 - q) / q)
 
 
@@ -125,6 +143,26 @@ class MleIlpDecoder(ExternalDecoder):
         self._max_rpc_rounds = int(params["max_rpc_rounds"])
         self._max_rpc_pivots = int(params["max_rpc_pivots"])
         self._max_rpc_weight = int(params["max_rpc_weight"])
+        max_rpc_memory_mb = float(params["max_rpc_memory_mb"])
+        if max_rpc_memory_mb < 0:
+            raise ValueError("max_rpc_memory_mb must be non-negative")
+        self._max_rpc_memory_bytes = (
+            int(max_rpc_memory_mb * (1 << 20))
+            if max_rpc_memory_mb > 0 else None
+        )
+        packed_row_bytes = (self._n + 7) // 8
+        packed_bytes = self._m * packed_row_bytes
+        self._rpc_xor_chunk_rows = max(
+            1, _RPC_XOR_CHUNK_BYTES // max(1, packed_row_bytes))
+        max_h_row_weight = int(np.diff(self._indptr).max(initial=0))
+        build_workspace = packed_bytes + 16 * max_h_row_weight
+        eliminate_workspace = (
+            2 * packed_bytes
+            + min(self._m, self._rpc_xor_chunk_rows) * packed_row_bytes
+            + packed_row_bytes + 16 * self._max_rpc_weight
+        )
+        self._rpc_workspace_bytes = max(
+            build_workspace, eliminate_workspace)
         self._packed = None            # built lazily on the first stalled shot
 
         rowsum = np.asarray(H.sum(axis=1)).ravel()
@@ -190,11 +228,16 @@ class MleIlpDecoder(ExternalDecoder):
         """
         if self._packed is None:
             packed = np.zeros((self._m, (self._n + 7) // 8), dtype=np.uint8)
-            counts = np.diff(self._indptr)
-            row_of = np.repeat(np.arange(self._m), counts)
-            np.bitwise_or.at(
-                packed, (row_of, self._indices >> 3),
-                (np.uint8(1) << (self._indices & 7).astype(np.uint8)))
+            # Work one CSR row at a time. Constructing a global row-index array
+            # would add O(nnz) transient memory before elimination even starts.
+            for i in range(self._m):
+                indices = self._indices[self._indptr[i]:self._indptr[i + 1]]
+                if indices.size:
+                    np.bitwise_or.at(
+                        packed[i], indices >> 3,
+                        np.left_shift(
+                            np.uint8(1),
+                            (indices & 7).astype(np.uint8)))
             self._packed = packed
         return self._packed
 
@@ -208,10 +251,20 @@ class MleIlpDecoder(ExternalDecoder):
         combinations come from Gaussian-eliminating the augmented [H | s] with
         the most fractional columns as pivots, so the derived checks isolate
         the fractional variables.
+
+        Elimination stays bit-packed because row XOR on scipy sparse matrices
+        creates substantial fill-in and allocation churn. Derived rows are
+        popcounted while packed, and the sparse support of a qualifying row is
+        extracted directly from its nonzero bytes. If the estimated main
+        workspace exceeds ``max_rpc_memory_mb``, no packed cache is allocated
+        and the caller falls back to the exact MILP.
         """
         frac = np.abs(e - np.round(e))
         order = np.flatnonzero(frac > _CUT_TOL)
         if order.size == 0:
+            return []
+        if (self._max_rpc_memory_bytes is not None
+                and self._rpc_workspace_bytes > self._max_rpc_memory_bytes):
             return []
         order = order[np.argsort(-frac[order])]
 
@@ -231,19 +284,33 @@ class MleIlpDecoder(ExternalDecoder):
             used[p] = True
             others = ones[ones != p]
             if others.size:
-                a[others] ^= a[p]
+                # Advanced indexing creates a temporary. Chunk it so dense
+                # pivot columns cannot briefly allocate another full matrix.
+                for start in range(0, others.size,
+                                   self._rpc_xor_chunk_rows):
+                    chunk = others[start:start + self._rpc_xor_chunk_rows]
+                    a[chunk] ^= a[p]
                 sy[others] ^= sy[p]
             n_piv += 1
             if n_piv >= self._max_rpc_pivots:
                 break
 
-        rows = np.unpackbits(a, axis=1, bitorder="little", count=self._n)
         cuts = []
         for i in range(self._m):
-            cols = np.flatnonzero(rows[i])
             # Dense derived checks give weak cuts for a lot of work.
-            if cols.size == 0 or cols.size > self._max_rpc_weight:
+            weight = int(_POPCOUNT[a[i]].sum())
+            if weight == 0 or weight > self._max_rpc_weight:
                 continue
+            # Extract the support directly from this row's nonzero bytes. This
+            # materialises O(weight) data instead of an m-by-n or length-n
+            # dense uint8 array.
+            nonzero_bytes = np.flatnonzero(a[i])
+            byte_pos, bit_pos = np.nonzero(
+                a[i, nonzero_bytes, None] & _BIT_MASKS)
+            cols = (nonzero_bytes[byte_pos] << 3) + bit_pos
+            # The final packed byte can have padding bits, although H itself
+            # never sets them. Keep the bound explicit for defensive safety.
+            cols = cols[cols < self._n]
             v = e[cols]
             in_s = v > 0.5
             if (int(in_s.sum()) & 1) == (int(sy[i]) & 1):
@@ -272,6 +339,8 @@ class MleIlpDecoder(ExternalDecoder):
         """
         rows, cols, vals, rhs = [], [], [], []
         e = np.zeros(self._n)
+        last_a_ub = None
+        self._fallback_cuts = None
 
         def add(cut_list):
             for c_cols, c_vals, c_rhs in cut_list:
@@ -281,11 +350,12 @@ class MleIlpDecoder(ExternalDecoder):
                 rhs.append(c_rhs)
 
         def resolve():
-            nonlocal e
+            nonlocal e, last_a_ub
             a_ub = sp.csr_matrix(
                 (np.concatenate(vals),
                  (np.concatenate(rows), np.concatenate(cols))),
                 shape=(len(rhs), self._n))
+            last_a_ub = a_ub
             # Hand the LP whatever budget is left, so one pathological solve
             # cannot blow the per-shot limit on its own.
             options = {}
@@ -300,6 +370,13 @@ class MleIlpDecoder(ExternalDecoder):
                 return False
             e = lp.x
             return True
+
+        def fallback():
+            """Preserve valid ALP/RPC cuts to tighten the exact MILP."""
+            if rhs and last_a_ub is not None:
+                self._fallback_cuts = (
+                    last_a_ub, np.asarray(rhs, dtype=float))
+            return None
 
         def out_of_time():
             return deadline is not None and time.monotonic() >= deadline
@@ -317,26 +394,26 @@ class MleIlpDecoder(ExternalDecoder):
             return False                    # cut generation did not converge
 
         if not separate_to_convergence():
-            return None
+            return fallback()
 
         for _ in range(self._max_rpc_rounds):
             if np.abs(e - np.round(e)).max() < _INT_TOL:
                 break
             if out_of_time():
-                return None
+                return fallback()
             rpc = self._rpc_cuts(e, s)
             if not rpc:
                 break                       # no derived check is violated
             add(rpc)
             # RPC cuts move the solution, which can re-violate original checks.
             if not resolve() or not separate_to_convergence():
-                return None
+                return fallback()
 
         if np.abs(e - np.round(e)).max() >= _INT_TOL:
-            return None                     # fractional: a pseudocodeword
+            return fallback()               # fractional: a pseudocodeword
         ei = np.round(e).astype(np.uint8)
         # Verify the parity exactly rather than trusting _INT_TOL.
-        return ei if np.array_equal((self._H @ ei) % 2, s) else None
+        return ei if np.array_equal((self._H @ ei) % 2, s) else fallback()
 
     def decode_single(self, syndrome):
         """Solve one shot: ACG-ALP first, MILP only if it doesn't settle.
@@ -351,7 +428,7 @@ class MleIlpDecoder(ExternalDecoder):
         calling the MILP directly: 3.9x on surface d=5, 2.0x on d=7, 11.0x on
         BB [[72,12,6]] r=2 and 7.9x on r=4, with the LP settling 34/40 to 40/40
         of shots. Totals gain least where a few hard shots dominate, and those
-        shots pay only the discarded cut-generation work.
+        shots reuse the generated cuts to tighten the MILP fallback.
 
         Against the plain (slack-formulation) relaxation this replaced, the
         end-to-end gain is larger still -- a 100-shot BB r=4 run went from 727
@@ -376,9 +453,19 @@ class MleIlpDecoder(ExternalDecoder):
             options["time_limit"] = remaining
 
         sf = s.astype(float)
+        constraints = [LinearConstraint(self._A, sf, sf)]
+        if self._fallback_cuts is not None:
+            cut_a, cut_rhs = self._fallback_cuts
+            cut_a = sp.hstack(
+                [cut_a, sp.csr_matrix((cut_a.shape[0], self._m))],
+                format="csr",
+            )
+            constraints.append(LinearConstraint(
+                cut_a, np.full(cut_rhs.size, -np.inf), cut_rhs))
+
         res = milp(
             c=self._c,
-            constraints=LinearConstraint(self._A, sf, sf),
+            constraints=constraints,
             integrality=self._integrality,
             bounds=self._bounds,
             options=options,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ decoders = [
     # build it from source if it fails to import.
     "tesseract-decoder",
     "ldpc",                     # Plain BP (ldpc-bp)
+    # Exact MLE (mle-ilp). Optional: without it mle-ilp falls back to the same
+    # HiGHS solver via scipy.optimize.milp, just rebuilding the model per shot.
+    # Do NOT add ortools alongside it — both vendor HiGHS and clash on symbols.
+    "highspy",
 ]
 gpu = [
     "cudaq-qec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ decoders = [
     # build it from source if it fails to import.
     "tesseract-decoder",
     "ldpc",                     # Plain BP (ldpc-bp)
-    # NOTE: highspy is deliberately NOT listed. The mle-ilp decoder defaults to
-    # scipy.optimize.milp, whose vendored HiGHS 1.8 measured ~2x faster than the
-    # standalone highspy 1.15 wheel on QEC detector error models. highspy stays
-    # supported as solver="highs" but is not a dependency. Do NOT add ortools
-    # either — it and highspy both vendor HiGHS and clash on symbols at import.
+    # NOTE: the exact-MLE decoder (mle-ilp) needs nothing here. It uses
+    # scipy.optimize.milp, whose vendored HiGHS 1.8 measured ~2x faster than a
+    # standalone highspy 1.15 wheel on QEC detector error models, and faster
+    # still than SCIP and OR-Tools CP-SAT. Avoid adding highspy and ortools
+    # together — both vendor HiGHS and clash on symbols at import.
 ]
 gpu = [
     "cudaq-qec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "sinter>=1.15.0",
     "PyMatching>=2.0.0",
     "pandas",
+    "scipy>=1.9.0",
 ]
 
 [project.optional-dependencies]
@@ -47,11 +48,7 @@ decoders = [
     # build it from source if it fails to import.
     "tesseract-decoder",
     "ldpc",                     # Plain BP (ldpc-bp)
-    # NOTE: the exact-MLE decoder (mle-ilp) needs nothing here. It uses
-    # scipy.optimize.milp, whose vendored HiGHS 1.8 measured ~2x faster than a
-    # standalone highspy 1.15 wheel on QEC detector error models, and faster
-    # still than SCIP and OR-Tools CP-SAT. Avoid adding highspy and ortools
-    # together — both vendor HiGHS and clash on symbols at import.
+    # The exact-MLE decoder (mle-ilp) uses the core scipy dependency.
 ]
 gpu = [
     "cudaq-qec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,11 @@ decoders = [
     # build it from source if it fails to import.
     "tesseract-decoder",
     "ldpc",                     # Plain BP (ldpc-bp)
-    # Exact MLE (mle-ilp). Optional: without it mle-ilp falls back to the same
-    # HiGHS solver via scipy.optimize.milp, just rebuilding the model per shot.
-    # Do NOT add ortools alongside it — both vendor HiGHS and clash on symbols.
-    "highspy",
+    # NOTE: highspy is deliberately NOT listed. The mle-ilp decoder defaults to
+    # scipy.optimize.milp, whose vendored HiGHS 1.8 measured ~2x faster than the
+    # standalone highspy 1.15 wheel on QEC detector error models. highspy stays
+    # supported as solver="highs" but is not a dependency. Do NOT add ortools
+    # either — it and highspy both vendor HiGHS and clash on symbols at import.
 ]
 gpu = [
     "cudaq-qec",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ stim>=1.15.0
 sinter>=1.15.0
 PyMatching>=2.0.0
 pandas
+scipy>=1.9.0
 
 # HTTP server (optional — only needed when running `uvicorn server.main:app`)
 fastapi>=0.110.0

--- a/tests/test_logical_circuits_runner.py
+++ b/tests/test_logical_circuits_runner.py
@@ -1,0 +1,76 @@
+"""MLE integration tests for the logical-circuits benchmark runner."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO = Path(__file__).resolve().parent.parent
+RUNNER_DIR = REPO / "benchmarks" / "logical_circuits"
+sys.path.insert(0, str(RUNNER_DIR))
+
+from run_logical_circuits import (
+    _BELL_COLS,
+    _BELL_RESULT_KEYS,
+    _ck_key,
+    _decoder_config,
+    _ensure_result_schema,
+)
+
+
+def test_logical_runner_mle_config_propagates_controls():
+    cfg = _decoder_config(
+        "mle-ilp", mle_time_limit=2.5, on_decode_failure="discard"
+    )
+    assert cfg.name == "mle-ilp"
+    assert cfg.backend == "cpu"
+    assert cfg.params == {"time_limit": 2.5}
+    assert cfg.on_decode_failure == "discard"
+
+
+def test_logical_checkpoint_key_includes_decoder_controls():
+    base = {
+        "experiment": "bell_tele", "protocol": "tg", "state": "Z",
+        "routing_mult": 1, "d": 3, "rounds": "pre=3 mid=1 post=1",
+        "p": 1e-3, "decoder": "mle-ilp", "decoder_time_limit": 0.0,
+        "on_decode_failure": "error",
+    }
+    assert _ck_key(base, _BELL_RESULT_KEYS) != _ck_key(
+        {**base, "decoder": "pymatching"}, _BELL_RESULT_KEYS
+    )
+    assert _ck_key(base, _BELL_RESULT_KEYS) != _ck_key(
+        {**base, "decoder_time_limit": 1.0}, _BELL_RESULT_KEYS
+    )
+    assert _ck_key(base, _BELL_RESULT_KEYS) != _ck_key(
+        {**base, "on_decode_failure": "discard"}, _BELL_RESULT_KEYS
+    )
+
+
+def test_logical_legacy_csv_migration(tmp_path):
+    path = tmp_path / "legacy.csv"
+    old_columns = [
+        column for column in _BELL_COLS
+        if column not in {"decoder_time_limit", "on_decode_failure"}
+    ]
+    pd.DataFrame([{column: 0 for column in old_columns}]).to_csv(path, index=False)
+
+    _ensure_result_schema(path, _BELL_COLS)
+
+    migrated = pd.read_csv(path)
+    assert list(migrated.columns) == _BELL_COLS
+    assert migrated["decoder_time_limit"].iloc[0] == 0.0
+    assert migrated["on_decode_failure"].iloc[0] == "error"
+
+
+def test_logical_cli_advertises_mle_controls():
+    result = subprocess.run(
+        [sys.executable, str(RUNNER_DIR / "run_logical_circuits.py"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "mle-ilp" in result.stdout
+    assert "--mle-time-limit" in result.stdout
+    assert "--on-decode-failure" in result.stdout

--- a/tests/test_mle_benchmark.py
+++ b/tests/test_mle_benchmark.py
@@ -1,0 +1,16 @@
+"""Smoke test for the checked-in exact-MLE benchmark."""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "benchmarks" / "mle"))
+
+from run_mle import run_preset
+
+
+def test_core_mle_benchmark_agrees_with_direct_milp():
+    result = run_preset("surface-d5", shots=1)
+    assert result["shots"] == 1
+    assert result["objective_agreement"]
+    assert result["max_objective_delta"] <= 1e-6

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -41,6 +41,27 @@ def test_registered():
     assert "mle-ilp" in list_decoders()
 
 
+def test_rejects_prior_above_half():
+    """A probability above 1/2 has a negative LLR and must not be clamped."""
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    with pytest.raises(ValueError, match=r"priors.*\[0, 0\.5\]"):
+        decoder.setup(H=sp.csr_matrix([[1]], dtype=np.uint8),
+                      priors=np.array([0.500001]))
+
+
+def test_rpc_memory_guard_skips_before_allocating_packed_rows():
+    """Oversized RPC workspaces must escalate without building the cache."""
+    H = sp.eye(4, 1024, dtype=np.uint8, format="csr")
+    decoder = get_decoder(
+        "mle-ilp", backend="cpu", max_rpc_memory_mb=0.001)
+    decoder.setup(H=H, priors=np.full(H.shape[1], 1e-3))
+
+    assert decoder._rpc_workspace_bytes > decoder._max_rpc_memory_bytes
+    assert decoder._rpc_cuts(np.full(H.shape[1], 0.5),
+                             np.zeros(H.shape[0], dtype=np.uint8)) == []
+    assert decoder._packed is None
+
+
 def test_solution_satisfies_syndrome():
     """The returned error must actually explain the observed syndrome."""
     dem = _surface_code_dem()
@@ -125,6 +146,48 @@ def test_lp_shortcut_matches_pure_milp():
         assert decoder._w @ correction == pytest.approx(reference.fun, abs=1e-6)
 
 
+def test_milp_fallback_reuses_adaptive_lp_cuts(monkeypatch):
+    """A fractional ALP result should strengthen, not just precede, the MILP."""
+    import itertools
+    from lightstim.simulation.decoder_backend.decoders import mle_ilp
+
+    H = np.array([
+        [0, 1, 0, 1],
+        [1, 1, 1, 1],
+        [1, 1, 1, 0],
+    ], dtype=np.uint8)
+    priors = np.array([0.2, 0.05, 0.2, 0.15])
+    syndrome = np.array([0, 1, 0], dtype=np.uint8)
+    decoder = get_decoder("mle-ilp", backend="cpu", max_rpc_rounds=0)
+    decoder.setup(H=sp.csr_matrix(H), priors=priors)
+
+    captured = {}
+    original_milp = mle_ilp.milp
+
+    def capture_milp(*args, **kwargs):
+        captured["constraints"] = kwargs["constraints"]
+        return original_milp(*args, **kwargs)
+
+    monkeypatch.setattr(mle_ilp, "milp", capture_milp)
+    correction, ok = decoder.decode_single(syndrome)
+
+    assert ok
+    assert len(captured["constraints"]) == 2
+    cut_constraint = captured["constraints"][1]
+    assert cut_constraint.A.shape[1] == H.shape[1] + H.shape[0]
+
+    # Every valid error remains feasible under the carried cuts.
+    errors = np.array(list(itertools.product([0, 1], repeat=H.shape[1])),
+                      dtype=np.uint8)
+    valid = errors[np.all((errors @ H.T) % 2 == syndrome, axis=1)]
+    extended = np.hstack([valid, np.zeros((valid.shape[0], H.shape[0]))])
+    lhs = np.asarray(cut_constraint.A @ extended.T)
+    assert np.all(lhs <= np.asarray(cut_constraint.ub)[:, None] + 1e-9)
+
+    costs = valid @ decoder._w
+    assert decoder._w @ correction == pytest.approx(costs.min(), abs=1e-9)
+
+
 def test_exhausted_time_limit_is_heralded_not_silently_wrong():
     """A shot that runs out of budget must report failure, not a bad answer.
 
@@ -158,7 +221,7 @@ def test_exhausted_time_limit_is_heralded_not_silently_wrong():
         "shots were heralded")
 
 
-def test_rpc_cuts_never_exclude_a_valid_error():
+def test_rpc_cuts_never_exclude_a_valid_error(monkeypatch):
     """Redundant-parity-check cuts must be valid inequalities.
 
     An RPC is a GF(2) combination of rows of H, so its syndrome bit is the XOR
@@ -173,6 +236,13 @@ def test_rpc_cuts_never_exclude_a_valid_error():
     H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=False)
     decoder = get_decoder("mle-ilp", backend="cpu")
     decoder.setup(H=H, priors=priors)
+
+    # Regression guard for the old m-by-n dense temporary: RPC support
+    # extraction must stay packed/sparse and never call np.unpackbits.
+    def reject_unpackbits(*args, **kwargs):
+        raise AssertionError("RPC generation must not allocate unpacked rows")
+
+    monkeypatch.setattr(np, "unpackbits", reject_unpackbits)
 
     rng = np.random.default_rng(3)
     sampler = dem.compile_sampler(seed=4)

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -26,7 +26,10 @@ def _surface_code_dem(distance=3, rounds=3, p=1e-3):
 
 
 def _decode(dem, detectors, **params):
-    decoder = get_decoder("mle-ilp", backend="cpu", params=params)
+    # get_decoder forwards **kwargs straight to the class, matching how
+    # SimulationPipeline spreads DecoderConfig(params={...}). Passing
+    # params={...} here instead would nest the dict and silently do nothing.
+    decoder = get_decoder("mle-ilp", backend="cpu", **params)
     compiled = decoder.compile_decoder_for_dem(dem=dem)
     out = compiled.decode_shots_bit_packed(
         bit_packed_detection_event_data=np.packbits(
@@ -120,6 +123,39 @@ def test_lp_shortcut_matches_pure_milp():
         assert reference.success
         # Compare cost, not the vector: equal-weight minimisers may differ.
         assert decoder._w @ correction == pytest.approx(reference.fun, abs=1e-6)
+
+
+def test_exhausted_time_limit_is_heralded_not_silently_wrong():
+    """A shot that runs out of budget must report failure, not a bad answer.
+
+    The pipeline routes ok=False to DecoderConfig(on_decode_failure=...); if
+    the decoder instead returned a zero correction with ok=True, the shot would
+    be silently counted as a logical error. A budget too small to finish any
+    stage is the cheap way to exercise that path.
+    """
+    dem = _surface_code_dem(distance=5, rounds=5)
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    detectors, _, _ = dem.compile_sampler(seed=5).sample(shots=20)
+
+    decoder = get_decoder("mle-ilp", backend="cpu", time_limit=1e-6)
+    # Guard the param convention itself: params={...} would nest the dict and
+    # leave time_limit at its default, quietly making this test vacuous.
+    assert decoder.params == {"time_limit": 1e-6}
+    decoder.setup(H=H, priors=priors)
+
+    heralded = 0
+    for syndrome in detectors.astype(np.uint8):
+        correction, ok = decoder.decode_single(syndrome)
+        # Either it genuinely finished (a zero syndrome can), or it must say
+        # so. What it must never do is claim success with a bogus correction.
+        if ok:
+            assert np.array_equal((H @ correction) % 2, syndrome)
+        else:
+            heralded += 1
+    nontrivial = int((detectors.sum(axis=1) > 0).sum())
+    assert heralded >= nontrivial, (
+        f"budget exhausted but only {heralded} of {nontrivial} non-trivial "
+        "shots were heralded")
 
 
 def test_rpc_cuts_never_exclude_a_valid_error():

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -87,18 +87,17 @@ def test_backends_agree_on_optimal_cost():
         assert costs["scipy"] == pytest.approx(costs["highs"], abs=1e-6)
 
 
-@pytest.mark.parametrize("solver", _SOLVERS)
-def test_auto_solver_resolves(solver, monkeypatch):
-    """'auto' picks highspy when present and degrades to scipy when not."""
+def test_auto_resolves_to_scipy():
+    """'auto' must pick scipy even when highspy is installed.
+
+    scipy vendors its own (older, measurably faster) HiGHS build rather than
+    importing highspy, so presence of highspy is not a reason to prefer it.
+    """
     from lightstim.simulation.decoder_backend.decoders import mle_ilp
 
-    monkeypatch.setattr(
-        mle_ilp.importlib.util, "find_spec",
-        lambda name: object() if name == "highspy" else None)
-    assert mle_ilp._resolve_solver("auto") == "highs"
-
-    monkeypatch.setattr(mle_ilp.importlib.util, "find_spec", lambda name: None)
     assert mle_ilp._resolve_solver("auto") == "scipy"
+    assert mle_ilp._resolve_solver("scipy") == "scipy"
+    assert mle_ilp._resolve_solver("highs") == "highs"
 
 
 def test_rejects_unknown_solver():
@@ -106,6 +105,45 @@ def test_rejects_unknown_solver():
 
     with pytest.raises(ValueError, match="Unknown solver"):
         mle_ilp._resolve_solver("gurobi")
+
+
+def _bb_dem(rounds=2, p=1e-3):
+    from lightstim.ir.qec_system import QECSystem
+    from lightstim.noise.config import NoiseConfig
+    from lightstim.protocols.memory import MemoryExperiment
+    from lightstim.qec_code.BB_code import BBCode, BBCodeExtractionBlock
+
+    code = BBCode(l=6, m=6, A=[[3, 0], [0, 1], [0, 2]],
+                  B=[[0, 3], [1, 0], [2, 0]])
+    system = QECSystem()
+    system.add_patch(code, name="bb")
+    experiment = MemoryExperiment(
+        qec_system=system, extraction_block_class=BBCodeExtractionBlock,
+        rounds=rounds, noise_params=NoiseConfig(p_1q=p, p_2q=p, p_meas=p,
+                                                p_reset=p, p_idle=p),
+        noise_model="circuit_level", basis="Z")
+    return experiment.build().detector_error_model(decompose_errors=False,
+                                                   flatten_loops=True)
+
+
+def test_solves_bb_code_dem():
+    """QLDPC DEMs are far denser than surface-code ones — cover that shape.
+
+    A BB [[72,12,6]] detector row touches ~200 error mechanisms and columns
+    reach weight 13, versus a handful for the surface code. This is the regime
+    where solver behaviour diverges, so it needs its own coverage.
+    """
+    dem = _bb_dem()
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    assert np.asarray(H.sum(axis=1)).ravel().mean() > 50, "expected a dense DEM"
+
+    detectors, _, _ = dem.compile_sampler(seed=7).sample(shots=5)
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+    for syndrome in detectors.astype(np.uint8):
+        correction, ok = decoder.decode_single(syndrome)
+        assert ok
+        assert np.array_equal((H @ correction) % 2, syndrome)
 
 
 @pytest.mark.slow

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -122,6 +122,42 @@ def test_lp_shortcut_matches_pure_milp():
         assert decoder._w @ correction == pytest.approx(reference.fun, abs=1e-6)
 
 
+def test_rpc_cuts_never_exclude_a_valid_error():
+    """Redundant-parity-check cuts must be valid inequalities.
+
+    An RPC is a GF(2) combination of rows of H, so its syndrome bit is the XOR
+    of the combined bits. Get that bookkeeping wrong and the derived check is
+    simply false, cutting off real solutions and making the decoder silently
+    wrong. So: generate cuts from an arbitrary fractional point, then assert
+    every genuine error consistent with the syndrome still satisfies them.
+    """
+    dem = _surface_code_dem(distance=5, rounds=5)
+    # merge_duplicates=False keeps our columns in the DEM's own error order,
+    # so stim's return_errors indexes the same variables we do.
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=False)
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+
+    rng = np.random.default_rng(3)
+    sampler = dem.compile_sampler(seed=4)
+    detectors, _, errors = sampler.sample(shots=8, return_errors=True)
+
+    checked = 0
+    for syndrome, true_error in zip(detectors.astype(np.uint8),
+                                    errors.astype(np.uint8)):
+        # Self-check: if this fails the column spaces disagree and the rest of
+        # the assertions would be meaningless.
+        assert np.array_equal((H @ true_error) % 2, syndrome)
+        # The point the cuts are generated from is arbitrary; validity of the
+        # resulting inequalities must not depend on it.
+        point = rng.uniform(0.0, 1.0, size=H.shape[1])
+        cuts = decoder._rpc_cuts(point, syndrome)
+        for cols, coeffs, rhs in cuts:
+            assert coeffs @ true_error[cols] <= rhs + 1e-9
+            checked += 1
+    assert checked > 0, "no RPC cuts generated; test proved nothing"
+
+
 def _bb_dem(rounds=2, p=1e-3):
     from lightstim.ir.qec_system import QECSystem
     from lightstim.noise.config import NoiseConfig

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -1,0 +1,139 @@
+"""Tests for the exact most-likely-error (mle-ilp) decoder."""
+
+import importlib.util
+
+import numpy as np
+import pytest
+import stim
+
+from lightstim.simulation.decoder_backend.dem_matrices import dem_to_matrices
+from lightstim.simulation.decoder_backend.registry import get_decoder, list_decoders
+
+_HAS_HIGHSPY = importlib.util.find_spec("highspy") is not None
+
+# Both backends are HiGHS and must agree exactly; "scipy" needs no extra install.
+_SOLVERS = ["scipy"] + (["highs"] if _HAS_HIGHSPY else [])
+
+
+def _surface_code_dem(distance=3, rounds=3, p=1e-3):
+    circuit = stim.Circuit.generated(
+        "surface_code:rotated_memory_z",
+        distance=distance,
+        rounds=rounds,
+        after_clifford_depolarization=p,
+        before_measure_flip_probability=p,
+        after_reset_flip_probability=p,
+        before_round_data_depolarization=p,
+    )
+    # decompose_errors=False: the ILP handles hyperedges natively, and
+    # decomposing would change the optimisation problem being solved.
+    return circuit.detector_error_model(decompose_errors=False,
+                                        flatten_loops=True)
+
+
+def _decode(dem, detectors, **params):
+    decoder = get_decoder("mle-ilp", backend="cpu", params=params)
+    compiled = decoder.compile_decoder_for_dem(dem=dem)
+    out = compiled.decode_shots_bit_packed(
+        bit_packed_detection_event_data=np.packbits(
+            detectors, axis=1, bitorder="little"))
+    return np.unpackbits(out, axis=1, bitorder="little")
+
+
+def test_registered():
+    assert "mle-ilp" in list_decoders()
+
+
+@pytest.mark.parametrize("solver", _SOLVERS)
+def test_solution_satisfies_syndrome(solver):
+    """The returned error must actually explain the observed syndrome."""
+    dem = _surface_code_dem()
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    detectors, _, _ = dem.compile_sampler(seed=5).sample(shots=25)
+
+    decoder = get_decoder("mle-ilp", backend="cpu", params={"solver": solver})
+    decoder.setup(H=H, priors=priors)
+    for syndrome in detectors.astype(np.uint8):
+        correction, ok = decoder.decode_single(syndrome)
+        assert ok
+        assert np.array_equal((H @ correction) % 2, syndrome)
+
+
+@pytest.mark.skipif(not _HAS_HIGHSPY, reason="highspy not installed")
+def test_backends_agree_on_optimal_cost():
+    """highspy and scipy are the same solver; they must find the same optimum.
+
+    Compares cost rather than the error vector itself: degenerate instances can
+    have several distinct minimisers of equal weight.
+    """
+    dem = _surface_code_dem()
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    weights = np.log((1 - np.clip(priors, 1e-15, 0.5 - 1e-15))
+                     / np.clip(priors, 1e-15, 0.5 - 1e-15))
+    detectors, _, _ = dem.compile_sampler(seed=5).sample(shots=15)
+
+    decoders = {}
+    for solver in ("scipy", "highs"):
+        d = get_decoder("mle-ilp", backend="cpu", params={"solver": solver})
+        d.setup(H=H, priors=priors)
+        decoders[solver] = d
+
+    for syndrome in detectors.astype(np.uint8):
+        costs = {}
+        for solver, d in decoders.items():
+            correction, ok = d.decode_single(syndrome)
+            assert ok
+            costs[solver] = weights @ correction
+        assert costs["scipy"] == pytest.approx(costs["highs"], abs=1e-6)
+
+
+@pytest.mark.parametrize("solver", _SOLVERS)
+def test_auto_solver_resolves(solver, monkeypatch):
+    """'auto' picks highspy when present and degrades to scipy when not."""
+    from lightstim.simulation.decoder_backend.decoders import mle_ilp
+
+    monkeypatch.setattr(
+        mle_ilp.importlib.util, "find_spec",
+        lambda name: object() if name == "highspy" else None)
+    assert mle_ilp._resolve_solver("auto") == "highs"
+
+    monkeypatch.setattr(mle_ilp.importlib.util, "find_spec", lambda name: None)
+    assert mle_ilp._resolve_solver("auto") == "scipy"
+
+
+def test_rejects_unknown_solver():
+    from lightstim.simulation.decoder_backend.decoders import mle_ilp
+
+    with pytest.raises(ValueError, match="Unknown solver"):
+        mle_ilp._resolve_solver("gurobi")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _HAS_HIGHSPY, reason="highspy not installed")
+def test_beats_mwpm_at_high_noise():
+    """Exact MLE should be at least as accurate as MWPM on the same circuit.
+
+    At p=5e-3 the gap is large enough to see in a few hundred shots; MLE
+    exploits hyperedge correlations that the decomposed matching graph loses.
+    """
+    import pymatching
+
+    p, shots, d, rounds = 5e-3, 400, 5, 5
+    kwargs = dict(distance=d, rounds=rounds,
+                  after_clifford_depolarization=p,
+                  before_measure_flip_probability=p,
+                  after_reset_flip_probability=p,
+                  before_round_data_depolarization=p)
+    circuit = stim.Circuit.generated("surface_code:rotated_memory_z", **kwargs)
+
+    dem = circuit.detector_error_model(decompose_errors=False, flatten_loops=True)
+    detectors, observables, _ = dem.compile_sampler(seed=3).sample(shots=shots)
+
+    predicted = _decode(dem, detectors, solver="highs")[:, :observables.shape[1]]
+    mle_ler = (predicted != observables).any(axis=1).mean()
+
+    matcher = pymatching.Matching.from_detector_error_model(
+        circuit.detector_error_model(decompose_errors=True))
+    mwpm_ler = (matcher.decode_batch(detectors) != observables).any(axis=1).mean()
+
+    assert mle_ler <= mwpm_ler

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -1,18 +1,12 @@
 """Tests for the exact most-likely-error (mle-ilp) decoder."""
 
-import importlib.util
-
 import numpy as np
 import pytest
+import scipy.sparse as sp
 import stim
 
 from lightstim.simulation.decoder_backend.dem_matrices import dem_to_matrices
 from lightstim.simulation.decoder_backend.registry import get_decoder, list_decoders
-
-_HAS_HIGHSPY = importlib.util.find_spec("highspy") is not None
-
-# Both backends are HiGHS and must agree exactly; "scipy" needs no extra install.
-_SOLVERS = ["scipy"] + (["highs"] if _HAS_HIGHSPY else [])
 
 
 def _surface_code_dem(distance=3, rounds=3, p=1e-3):
@@ -44,14 +38,13 @@ def test_registered():
     assert "mle-ilp" in list_decoders()
 
 
-@pytest.mark.parametrize("solver", _SOLVERS)
-def test_solution_satisfies_syndrome(solver):
+def test_solution_satisfies_syndrome():
     """The returned error must actually explain the observed syndrome."""
     dem = _surface_code_dem()
     H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
     detectors, _, _ = dem.compile_sampler(seed=5).sample(shots=25)
 
-    decoder = get_decoder("mle-ilp", backend="cpu", params={"solver": solver})
+    decoder = get_decoder("mle-ilp", backend="cpu")
     decoder.setup(H=H, priors=priors)
     for syndrome in detectors.astype(np.uint8):
         correction, ok = decoder.decode_single(syndrome)
@@ -59,52 +52,38 @@ def test_solution_satisfies_syndrome(solver):
         assert np.array_equal((H @ correction) % 2, syndrome)
 
 
-@pytest.mark.skipif(not _HAS_HIGHSPY, reason="highspy not installed")
-def test_backends_agree_on_optimal_cost():
-    """highspy and scipy are the same solver; they must find the same optimum.
+def test_finds_true_optimum_on_tiny_instance():
+    """The solution must be genuinely minimum-weight, not merely feasible.
 
-    Compares cost rather than the error vector itself: degenerate instances can
-    have several distinct minimisers of equal weight.
+    Checked against brute force over all 2^n errors on an instance small
+    enough to enumerate. Compares cost rather than the error vector, since a
+    degenerate instance can have several distinct minimisers of equal weight.
     """
-    dem = _surface_code_dem()
-    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
-    weights = np.log((1 - np.clip(priors, 1e-15, 0.5 - 1e-15))
-                     / np.clip(priors, 1e-15, 0.5 - 1e-15))
-    detectors, _, _ = dem.compile_sampler(seed=5).sample(shots=15)
+    import itertools
 
-    decoders = {}
-    for solver in ("scipy", "highs"):
-        d = get_decoder("mle-ilp", backend="cpu", params={"solver": solver})
-        d.setup(H=H, priors=priors)
-        decoders[solver] = d
+    rng = np.random.default_rng(0)
+    n_dets, n_errs = 6, 14
+    H = (rng.random((n_dets, n_errs)) < 0.35).astype(np.uint8)
+    H[:, H.sum(axis=0) == 0] = 0
+    H[0, 0] = 1                       # guarantee at least one non-empty column
+    priors = rng.uniform(1e-3, 0.2, size=n_errs)
+    weights = np.log((1 - priors) / priors)
 
-    for syndrome in detectors.astype(np.uint8):
-        costs = {}
-        for solver, d in decoders.items():
-            correction, ok = d.decode_single(syndrome)
-            assert ok
-            costs[solver] = weights @ correction
-        assert costs["scipy"] == pytest.approx(costs["highs"], abs=1e-6)
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=sp.csr_matrix(H), priors=priors)
 
+    all_errors = np.array(list(itertools.product([0, 1], repeat=n_errs)),
+                          dtype=np.uint8)
+    all_syndromes = (all_errors @ H.T) % 2
+    all_costs = all_errors @ weights
 
-def test_auto_resolves_to_scipy():
-    """'auto' must pick scipy even when highspy is installed.
-
-    scipy vendors its own (older, measurably faster) HiGHS build rather than
-    importing highspy, so presence of highspy is not a reason to prefer it.
-    """
-    from lightstim.simulation.decoder_backend.decoders import mle_ilp
-
-    assert mle_ilp._resolve_solver("auto") == "scipy"
-    assert mle_ilp._resolve_solver("scipy") == "scipy"
-    assert mle_ilp._resolve_solver("highs") == "highs"
-
-
-def test_rejects_unknown_solver():
-    from lightstim.simulation.decoder_backend.decoders import mle_ilp
-
-    with pytest.raises(ValueError, match="Unknown solver"):
-        mle_ilp._resolve_solver("gurobi")
+    for syndrome in np.unique(all_syndromes, axis=0):
+        matches = (all_syndromes == syndrome).all(axis=1)
+        best = all_costs[matches].min()
+        correction, ok = decoder.decode_single(syndrome)
+        assert ok
+        assert np.array_equal((H @ correction) % 2, syndrome)
+        assert weights @ correction == pytest.approx(best, abs=1e-9)
 
 
 def _bb_dem(rounds=2, p=1e-3):
@@ -131,7 +110,7 @@ def test_solves_bb_code_dem():
 
     A BB [[72,12,6]] detector row touches ~200 error mechanisms and columns
     reach weight 13, versus a handful for the surface code. This is the regime
-    where solver behaviour diverges, so it needs its own coverage.
+    where solver behaviour diverged in benchmarking, so it needs coverage.
     """
     dem = _bb_dem()
     H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
@@ -147,7 +126,6 @@ def test_solves_bb_code_dem():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not _HAS_HIGHSPY, reason="highspy not installed")
 def test_beats_mwpm_at_high_noise():
     """Exact MLE should be at least as accurate as MWPM on the same circuit.
 
@@ -167,7 +145,7 @@ def test_beats_mwpm_at_high_noise():
     dem = circuit.detector_error_model(decompose_errors=False, flatten_loops=True)
     detectors, observables, _ = dem.compile_sampler(seed=3).sample(shots=shots)
 
-    predicted = _decode(dem, detectors, solver="highs")[:, :observables.shape[1]]
+    predicted = _decode(dem, detectors)[:, :observables.shape[1]]
     mle_ler = (predicted != observables).any(axis=1).mean()
 
     matcher = pymatching.Matching.from_detector_error_model(

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -148,6 +148,8 @@ def test_solves_bb_code_dem():
     reach weight 13, versus a handful for the surface code. This is the regime
     where solver behaviour diverged in benchmarking, so it needs coverage.
     """
+    from scipy.optimize import Bounds, LinearConstraint, milp
+
     dem = _bb_dem()
     H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
     assert np.asarray(H.sum(axis=1)).ravel().mean() > 50, "expected a dense DEM"
@@ -155,10 +157,27 @@ def test_solves_bb_code_dem():
     detectors, _, _ = dem.compile_sampler(seed=7).sample(shots=5)
     decoder = get_decoder("mle-ilp", backend="cpu")
     decoder.setup(H=H, priors=priors)
+
+    m, n = H.shape
+    rowsum = np.asarray(H.sum(axis=1)).ravel()
+    A = sp.hstack([H.astype(float), -2.0 * sp.eye(m, format="csr")],
+                  format="csr")
+    c = np.concatenate([decoder._w, np.zeros(m)])
+    bounds = Bounds(np.zeros(n + m),
+                    np.concatenate([np.ones(n), np.floor(rowsum / 2.0)]))
+
     for syndrome in detectors.astype(np.uint8):
         correction, ok = decoder.decode_single(syndrome)
         assert ok
         assert np.array_equal((H @ correction) % 2, syndrome)
+        # Optimality, not just feasibility: this is the regime where cut
+        # generation does the most work, so it is where it could go wrong.
+        reference = milp(c=c,
+                         constraints=LinearConstraint(A, syndrome.astype(float),
+                                                      syndrome.astype(float)),
+                         integrality=np.ones(n + m), bounds=bounds)
+        assert reference.success
+        assert decoder._w @ correction == pytest.approx(reference.fun, abs=1e-6)
 
 
 @pytest.mark.slow

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -49,6 +49,51 @@ def test_rejects_prior_above_half():
                       priors=np.array([0.500001]))
 
 
+def test_zero_prior_mechanism_is_fixed_off():
+    """An impossible mechanism must never beat a positive-probability path."""
+    H = sp.csr_matrix([
+        [1, 1, 0],
+        [1, 0, 1],
+    ], dtype=np.uint8)
+    priors = np.array([0.0, 1e-9, 1e-9])
+    syndrome = np.array([1, 1], dtype=np.uint8)
+
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+    correction, ok = decoder.decode_single(syndrome)
+
+    assert ok
+    assert correction.tolist() == [0, 1, 1]
+    assert decoder._bounds.ub[0] == 0
+    assert decoder._lp_bounds[0, 1] == 0
+    assert np.array_equal((H @ correction) % 2, syndrome)
+
+
+def test_half_prior_has_zero_weight_and_max_prior_changes_model():
+    from lightstim.simulation.decoder_backend.decoders.mle_ilp import _weights
+
+    assert _weights(np.array([0.0, 0.5]), 0.5).tolist() == [0.0, 0.0]
+    supplied = _weights(np.array([0.4]), 0.5)[0]
+    clamped = _weights(np.array([0.4]), 0.2)[0]
+    assert supplied == pytest.approx(np.log(0.6 / 0.4))
+    assert clamped == pytest.approx(np.log(0.8 / 0.2))
+    assert clamped != pytest.approx(supplied)
+
+
+def test_time_limit_defaults_to_unlimited_and_rejects_invalid_values():
+    H = sp.csr_matrix([[1]], dtype=np.uint8)
+    priors = np.array([0.1])
+
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+    assert decoder._time_limit == 0.0
+
+    for invalid in (-1.0, np.inf, np.nan):
+        decoder = get_decoder("mle-ilp", backend="cpu", time_limit=invalid)
+        with pytest.raises(ValueError, match="time_limit"):
+            decoder.setup(H=H, priors=priors)
+
+
 def test_rpc_memory_guard_skips_before_allocating_packed_rows():
     """Oversized RPC workspaces must escalate without building the cache."""
     H = sp.eye(4, 1024, dtype=np.uint8, format="csr")

--- a/tests/test_mle_ilp_decoder.py
+++ b/tests/test_mle_ilp_decoder.py
@@ -86,6 +86,42 @@ def test_finds_true_optimum_on_tiny_instance():
         assert weights @ correction == pytest.approx(best, abs=1e-9)
 
 
+def test_lp_shortcut_matches_pure_milp():
+    """The LP-first path must return exactly what the plain MILP returns.
+
+    Guards the one way this optimisation could go wrong: accepting a
+    relaxation solution that is not actually the integer optimum, which would
+    quietly turn the decoder into a heuristic.
+    """
+    from scipy.optimize import Bounds, LinearConstraint, milp
+
+    dem = _surface_code_dem(distance=5, rounds=5)
+    H, _, priors = dem_to_matrices(dem, sparse=True, merge_duplicates=True)
+    detectors, _, _ = dem.compile_sampler(seed=11).sample(shots=20)
+
+    decoder = get_decoder("mle-ilp", backend="cpu")
+    decoder.setup(H=H, priors=priors)
+
+    m, n = H.shape
+    rowsum = np.asarray(H.sum(axis=1)).ravel()
+    A = sp.hstack([H.astype(float), -2.0 * sp.eye(m, format="csr")],
+                  format="csr")
+    c = np.concatenate([decoder._w, np.zeros(m)])
+    bounds = Bounds(np.zeros(n + m),
+                    np.concatenate([np.ones(n), np.floor(rowsum / 2.0)]))
+
+    for syndrome in detectors.astype(np.uint8):
+        correction, ok = decoder.decode_single(syndrome)
+        assert ok
+        reference = milp(c=c,
+                         constraints=LinearConstraint(A, syndrome.astype(float),
+                                                      syndrome.astype(float)),
+                         integrality=np.ones(n + m), bounds=bounds)
+        assert reference.success
+        # Compare cost, not the vector: equal-weight minimisers may differ.
+        assert decoder._w @ correction == pytest.approx(reference.fun, abs=1e-6)
+
+
 def _bb_dem(rounds=2, p=1e-3):
     from lightstim.ir.qec_system import QECSystem
     from lightstim.noise.config import NoiseConfig

--- a/tests/test_run_memory.py
+++ b/tests/test_run_memory.py
@@ -28,8 +28,10 @@ from run_memory import (
     COLOR_SE_CIRCUITS,
     _BB_CONFIGS,
     _HGP_CONFIGS,
+    _RESULT_COLUMNS,
     _TOPO_CODES,
     _decoder_config,
+    _ensure_result_schema,
     _task_key,
     build_circuit,
 )
@@ -215,7 +217,7 @@ def test_build_circuit_middle_out_rejects_y_basis():
 
 # ── Layer 2: decoder config + checkpointing ───────────────────────────────────
 
-@pytest.mark.parametrize("name", ["pymatching", "mwpf", "cpu_bposd"])
+@pytest.mark.parametrize("name", ["pymatching", "mwpf", "cpu_bposd", "mle-ilp"])
 def test_decoder_config_cpu(name):
     cfg = _decoder_config(name)
     assert cfg.backend == "cpu"
@@ -225,6 +227,14 @@ def test_decoder_config_cpu(name):
 def test_decoder_config_gpu():
     cfg = _decoder_config("gpu_bposd")
     assert cfg.backend == "gpu"
+
+
+def test_mle_decoder_config_propagates_budget_and_failure_policy():
+    cfg = _decoder_config(
+        "mle-ilp", mle_time_limit=1.25, on_decode_failure="discard"
+    )
+    assert cfg.params == {"time_limit": 1.25}
+    assert cfg.on_decode_failure == "discard"
 
 
 def test_task_key_excludes_result_columns():
@@ -248,6 +258,33 @@ def test_task_key_distinguishes_inputs():
          "noise_model": "circuit_level", "decoder_name": "pymatching"}
     b = {**a, "distance": 5}
     assert _task_key(a) != _task_key(b)
+
+
+def test_task_key_distinguishes_mle_budget_and_failure_policy():
+    base = {
+        "code": "rotated_sc", "distance": 3, "p": 1e-3,
+        "basis": "Z", "rounds": 3, "se_circuit": "default",
+        "noise_model": "circuit_level", "decoder_name": "mle-ilp",
+        "decoder_time_limit": 0.0, "on_decode_failure": "error",
+    }
+    assert _task_key(base) != _task_key({**base, "decoder_time_limit": 1.0})
+    assert _task_key(base) != _task_key({**base, "on_decode_failure": "discard"})
+
+
+def test_legacy_result_schema_adds_decoder_metadata(tmp_path):
+    path = tmp_path / "legacy.csv"
+    old_columns = [
+        column for column in _RESULT_COLUMNS
+        if column not in {"decoder_time_limit", "on_decode_failure"}
+    ]
+    pd.DataFrame([{column: 0 for column in old_columns}]).to_csv(path, index=False)
+
+    _ensure_result_schema(path)
+
+    migrated = pd.read_csv(path)
+    assert list(migrated.columns) == _RESULT_COLUMNS
+    assert migrated["decoder_time_limit"].iloc[0] == 0.0
+    assert migrated["on_decode_failure"].iloc[0] == "error"
 
 
 def test_task_key_distinguishes_color_se_circuits():
@@ -424,6 +461,33 @@ def test_cli_cpu_bposd_surface(tmp_path):
     assert r.returncode == 0, r.stderr
     df = pd.read_csv(out)
     assert df["decoder_name"].iloc[0] == "cpu_bposd"
+
+
+def test_cli_mle_ilp_surface(tmp_path):
+    out = tmp_path / "mle_surface.csv"
+    r = _run_cli([
+        "--codes", "rotated_sc", "--distances", "3",
+        "--p-values", "5e-3", "--decoder", "mle-ilp",
+        "--max-shots", "20", "--max-errors", "20",
+        "--batch-size", "10", "--num-workers", "1",
+        "--on-decode-failure", "discard",
+    ], out)
+    assert r.returncode == 0, r.stderr
+    df = pd.read_csv(out)
+    assert df["decoder_name"].iloc[0] == "mle-ilp"
+    assert df["decoder_time_limit"].iloc[0] == 0.0
+    assert df["on_decode_failure"].iloc[0] == "discard"
+
+
+def test_cli_rejects_mle_budget_for_other_decoder(tmp_path):
+    out = tmp_path / "invalid_mle_budget.csv"
+    r = _run_cli([
+        "--codes", "rotated_sc", "--distances", "3",
+        "--mle-time-limit", "1",
+    ], out)
+    assert r.returncode != 0
+    assert "only valid with --decoder mle-ilp" in r.stderr
+    assert not out.exists()
 
 
 @pytest.mark.slow

--- a/tests/test_tg_distillation_accounting.py
+++ b/tests/test_tg_distillation_accounting.py
@@ -1,0 +1,60 @@
+"""Failure-accounting regressions for TG's transformed observable loop."""
+
+import numpy as np
+import pytest
+import stim
+
+from lightstim.protocols.tg_distillation import run_simulation
+
+
+def _two_observable_circuit() -> stim.Circuit:
+    return stim.Circuit(
+        """
+        R 0 1
+        X_ERROR(0.5) 0
+        M 0 1
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-2]
+        OBSERVABLE_INCLUDE(1) rec[-1]
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    "policy, expected_kept, expected_errors",
+    [
+        ("error", 12, 12),
+        ("discard", 0, 0),
+        ("ignore", 12, 0),
+    ],
+)
+def test_transformed_tg_loop_honors_decode_failure_policy(
+    policy, expected_kept, expected_errors
+):
+    # Swapping observables forces the custom transform loop. Its target is the
+    # always-zero original observable 1, so trusting the zero timeout fallback
+    # under "ignore" produces no errors; the other policies remain observable.
+    transform = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    stats = run_simulation(
+        circuit=_two_observable_circuit(),
+        magic_qubits=set(),
+        p=0.0,
+        p_injected=0.0,
+        mode="injection",
+        T=transform,
+        ps_indices=[],
+        target_indices=[0],
+        decoder_name="mle-ilp",
+        max_shots=12,
+        max_errors=100,
+        num_workers=1,
+        backend="cpu",
+        batch_size=12,
+        decoder_params={"time_limit": 1e-12},
+        on_decode_failure=policy,
+    )
+
+    assert stats.shots == 12
+    assert stats.post_selected_shots == expected_kept
+    assert stats.errors == expected_errors


### PR DESCRIPTION
 ## Summary

  This PR adds `mle-ilp`, an exact most-likely-error decoder for Stim detector
  error models.

  The decoder is intended as a correctness/reference backend for small instances
  and as the final tier of hierarchical decoders. It uses SciPy’s HiGHS backend
  and requires no solver dependency beyond `scipy>=1.9`.

  ## Decoder design

  For binary error variables $e_j$ with priors $p_j$, the decoder solves:

  $$
  \underset{e \in \mathbb{F}_2^n}{\text{min}}
  \quad
  \sum_j \log\left(\frac{1-p_j}{p_j}\right)e_j
  $$

  subject to:

  $$
  He = s \pmod 2.
  $$

  The implementation linearizes each parity constraint using an integer slack
  variable $k_i$:

  $$
  \sum_j H_{ij}e_j - 2k_i = s_i.
  $$

  The implementation uses:

  - adaptive LP with forbidden-set cuts;
  - redundant-parity-check cuts for fractional pseudocodewords;
  - exact mixed-integer optimization when the LP remains fractional;
  - previously generated cuts to tighten the MILP fallback;
  - native detector-error-model hyperedges without graph decomposition.

  “Exact MLE” here means exact most-likely-error decoding for the supplied
  independent error mechanisms; it does not sum probabilities over degenerate
  logical cosets.

  ## Correctness and failure semantics

  - Priors outside `[0, 0.5]` are rejected.
  - Zero-probability mechanisms are fixed off.
  - Probability-`0.5` mechanisms receive exactly zero objective weight.
  - The default `max_prior=0.5` leaves valid priors unchanged.
  - The default solve budget is unlimited.
  - A positive `time_limit` is shared between LP cut generation and MILP.
  - Timeouts are explicitly flagged instead of returning an unverified
  correction.
  - Callers can select `error`, `discard`, or `ignore` failure accounting.

  ## Integration

  - Registers `mle-ilp`, with `mle` and `ilp` aliases.
  - Adds MLE support to memory and logical-circuit benchmark CLIs.
  - Propagates timeout and failure-policy settings through LS/TG distillation.
  - Includes decoder controls in checkpoint keys and result metadata.
  - Migrates legacy benchmark CSV schemas when possible.
  - Adds a deterministic benchmark comparing the optimized decoder with a direct
  SciPy MILP on identical syndromes.

  ## Testing

  Coverage includes:

  - exhaustive optimality checks on small instances;
  - agreement between the LP-first path and a direct MILP;
  - surface-code and dense BB-code detector models;
  - validity of generated RPC cuts;
  - timeout and failure-accounting behavior;
  - zero- and half-probability edge cases;
  - memory and logical-circuit CLI integration;
  - TG transformed-observable accounting;
  - benchmark objective-agreement checks.

  Useful commands:

  ```bash
  PYTHONPATH=. venv/bin/python -m pytest -q \
    tests/test_mle_ilp_decoder.py \
    tests/test_mle_benchmark.py \
    tests/test_run_memory.py \
    tests/test_logical_circuits_runner.py \
    tests/test_tg_distillation_accounting.py

  PYTHONPATH=. venv/bin/python benchmarks/mle/run_mle.py --quick

  ## Operational note

  Exact MILP tails can be long on large QLDPC detector models. Production-style
  runs should normally set time_limit and explicitly choose an on_decode_failure
  policy. Unlimited mode is primarily intended for exact offline simulation and
  validation.