### PR TITLE
feat(noise): add uniform per-moment idle errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ LightStim is a modular Quantum Error Correction (QEC) framework built on [Stim](
 
 - Build QEC experiments from reusable abstractions (`QECPatch`, `QECSystem`, `CircuitBuilder`, `SyndromeTracker`)
 - Support multi-patch workflows (transversal gates, lattice surgery, state injection)
-- Inject standardized noise models (`code_capacity`, `phenomenological`, `circuit_level`, `XZ_biased`)
+- Inject standardized noise models (`code_capacity`, `phenomenological`, `circuit_level`, `uniform_circuit_level`, `XZ_biased`)
 - Decode with a unified backend (PyMatching, BP+OSD CPU/GPU, MWPF, Relay-BP, Tesseract)
 - Analyze and visualize logical error rates
 - Inspect circuits interactively in a browser (DEM 3D, Circuit Timeline, DetSlice animator)

--- a/docs/api/ir.md
+++ b/docs/api/ir.md
@@ -288,7 +288,7 @@ builder.logical_canonicalization(canonical_logicals)
 ```python
 noisy_circuit = builder.build_noisy_circuit(
     noise_params,        # NoiseConfig
-    noise_model,         # str — 'circuit_level' | 'phenomenological' | 'code_capacity' | 'XZ_biased'
+    noise_model,         # str — includes 'circuit_level' and 'uniform_circuit_level'
 )
 # Returns a new stim.Circuit with noise channels injected.
 # Does NOT modify builder.circuit in place.

--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -218,13 +218,33 @@ noise = NoiseConfig(
     p_2q=1e-3,    # Depolarizing after two-qubit gates (CX, CZ, ...)
     p_meas=1e-3,  # Measurement bit-flip probability
     p_reset=1e-3, # State-preparation bit-flip probability
-    p_idle=0,     # Depolarizing on idle qubits between SE ticks
+    p_idle=0,     # Idle placement depends on the selected noise model
     custom_params={},  # Arbitrary extra rates for custom NoiseInjector rules
 )
 ```
 
 Pass to `builder.build_noisy_circuit(noise, noise_model)` where `noise_model` is one of:
-`'circuit_level'`, `'phenomenological'`, `'code_capacity'`, `'XZ_biased'`.
+`'circuit_level'`, `'uniform_circuit_level'`, `'phenomenological'`,
+`'code_capacity'`, `'XZ_biased'`.
+
+`circuit_level` preserves LightStim's historical convention: `p_idle` is
+applied to active data qubits at each `TICK[SE_start]`. Use
+`uniform_circuit_level` when every `TICK`-delimited moment should apply
+`p_idle` to the complement of that moment's operated qubits. Empty, reset-only,
+and measurement-only moments count; a non-empty final moment without a trailing
+`TICK` also counts. Moments whose physical operations are all tagged
+`noiseless` do not. `TICK[noiseless]` suppresses an otherwise empty moment;
+it does not hide untagged physical operations in a mixed moment.
+
+Here, *uniform* describes idle-noise coverage, not equal error rates. To use
+the common paper convention with one physical error probability, explicitly
+set `p_1q = p_2q = p_meas = p_reset = p_idle = p`. Gate and SPAM placement
+otherwise remains the same as LightStim's existing `circuit_level` model.
+
+Tick-aligned `REPEAT` blocks remain compressed. To preserve exact moment
+semantics, other repeat layouts (including nested or iteration-spanning
+moments) are expanded during injection; normalize very large repeat bodies
+with explicit `TICK` boundaries to avoid a large expansion.
 
 ---
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -195,13 +195,14 @@ rounds signal errors.
 
 ### Noise Models
 
-LightStim supports four noise models, each adding errors at different circuit locations:
+LightStim supports five noise models, each adding errors at different circuit locations:
 
 | Model | Where noise is added |
 |-------|---------------------|
 | `code_capacity` | Pauli errors on data qubits only (before measurement) |
 | `phenomenological` | Data qubit errors + measurement errors |
-| `circuit_level` | After every gate, measurement, reset, and idle |
+| `circuit_level` | Gate, measurement, and reset noise; data idle once per tagged SE round |
+| `uniform_circuit_level` | Circuit-level noise plus idle depolarization at every circuit moment |
 | `XZ_biased` | Circuit-level with asymmetric X/Z error rates |
 
 ### Detectors and Observables

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -1329,6 +1329,7 @@ class CircuitBuilder:
             noise_params: Noise parameters (NoiseConfig).
             noise_model: The name of the factory method in NoiseInjector to use.
                          e.g., 'circuit_level' -> calls NoiseInjector.from_circuit_level(...)
+                         e.g., 'uniform_circuit_level' -> adds idle noise every moment
                          e.g., 'custom_test'   -> calls NoiseInjector.from_custom_test(...)
         """
         # 1. Construct the expected factory method name
@@ -1344,9 +1345,16 @@ class CircuitBuilder:
         factory_method = getattr(NoiseInjector, method_name)
 
         # 3. Inject noise
-        # Assumptions: All factory methods must accept (config, data_qubits)
+        # Most models target data qubits for idle noise. The uniform model
+        # instead needs the complete physical-qubit universe so that it can
+        # take the complement of each moment's operated qubits.
         data_indices = [self.system.index_map[coord] for coord in self.system.data_coords]
-        injector = factory_method(noise_params, data_indices)
+        target_indices = (
+            list(range(self.circuit.num_qubits))
+            if noise_model == "uniform_circuit_level"
+            else data_indices
+        )
+        injector = factory_method(noise_params, target_indices)
         noisy_circuit = injector.inject_noise(self.circuit)
 
         return noisy_circuit

--- a/lightstim/noise/__init__.py
+++ b/lightstim/noise/__init__.py
@@ -4,9 +4,11 @@ from .config import NoiseConfig
 from .injector import NoiseInjector
 from .rules import (
     NoiseRule,
+    MomentNoiseRule,
     DepolarizeAfterGate,
     GeneralPauliAfterGate,
     FlipBeforeMeasurement,
     FlipAfterReset,
-    TaggedIdling
+    TaggedIdling,
+    UniformIdling,
 )

--- a/lightstim/noise/config.py
+++ b/lightstim/noise/config.py
@@ -12,7 +12,7 @@ class NoiseConfig:
     p_2q: float = 0.0        # Depolarizing noise after 2-qubit gates (CX, CZ, etc.)
     p_meas: float = 0.0      # Probability of measurement outcome flip (Readout error)
     p_reset: float = 0.0     # Probability of state prep flip (Reset error)
-    p_idle: float = 0.0      # Depolarizing noise applied to idle qubits (e.g., on data qubits before SE)
+    p_idle: float = 0.0      # Idle depolarization; placement depends on the selected noise model
     
     # --- Custom / Biased Parameters ---
     # Store specialized rates here (e.g., 'p_1q_x', 'p_1q_z', 'p_2q_zz')

--- a/lightstim/noise/injector.py
+++ b/lightstim/noise/injector.py
@@ -1,9 +1,10 @@
 import stim
-from typing import List, Dict, Set
+from typing import List, Optional, Set
 from .config import NoiseConfig
 # Import your defined rules
 from .rules import (
     NoiseRule,
+    MomentNoiseRule,
     DepolarizeAfterGate,
     GeneralPauliAfterGate,
     FlipBeforeMeasurement,
@@ -11,7 +12,13 @@ from .rules import (
     FlipAfterResetFiltered,
     FlipAfterYResetFiltered,
     TaggedIdling,
+    UniformIdling,
 )
+
+
+class _UnsupportedMomentRepeat(Exception):
+    """Signals that exact moment noise requires expanding a REPEAT block."""
+
 
 class NoiseInjector:
     """
@@ -20,23 +27,166 @@ class NoiseInjector:
     def __init__(self, model: NoiseConfig):
         self.model = model
         self.rules: List[NoiseRule] = []
+        self.moment_rules: List[MomentNoiseRule] = []
 
     def add_rule(self, rule: NoiseRule):
         self.rules.append(rule)
 
-    def inject_noise(self, circuit: stim.Circuit, active_qubits: Set[int] = None) -> stim.Circuit:
-        # Initialize active_qubits if not provided
+    def add_moment_rule(self, rule: MomentNoiseRule):
+        """Add a rule that needs all operations in a TICK-delimited moment."""
+        self.moment_rules.append(rule)
+
+    def _append_moment_noise(
+        self,
+        noisy_circuit: stim.Circuit,
+        moment: List[stim.CircuitInstruction],
+        boundary: Optional[stim.CircuitInstruction] = None,
+    ) -> None:
+        for rule in self.moment_rules:
+            for instruction in rule.apply(moment, self.model, boundary):
+                noisy_circuit.append(instruction)
+
+    @staticmethod
+    def _moment_has_physical_operation(
+        moment: List[stim.CircuitInstruction],
+    ) -> bool:
+        return any(UniformIdling._operated_qubits(item) for item in moment)
+
+    @classmethod
+    def _repeat_boundary_shape(
+        cls,
+        body: stim.Circuit,
+    ) -> tuple[Optional[stim.CircuitInstruction], bool]:
+        """Return the leading TICK and whether the body has a physical suffix."""
+        leading_tick = None
+        suffix: List[stim.CircuitInstruction] = []
+        for index, item in enumerate(body):
+            if isinstance(item, stim.CircuitRepeatBlock):
+                raise _UnsupportedMomentRepeat(
+                    "Uniform moment noise does not support nested REPEAT blocks"
+                )
+            if index == 0 and item.name == "TICK":
+                leading_tick = item
+            if item.name == "TICK":
+                suffix = []
+            else:
+                suffix.append(item)
+        return leading_tick, cls._moment_has_physical_operation(suffix)
+
+    def inject_noise(
+        self,
+        circuit: stim.Circuit,
+        active_qubits: Set[int] = None,
+    ) -> stim.Circuit:
+        """Return a noisy circuit while preserving compact safe REPEAT blocks.
+
+        Some valid Stim repeat bodies join one physical moment across iteration
+        boundaries. If that topology cannot carry exact moment noise while
+        remaining compressed, the circuit is flattened before injection.
+        """
         if active_qubits is None:
-            active_qubits = set[int]()
-        
+            active_qubits = set()
+
+        if self.moment_rules and any(
+            isinstance(item, stim.CircuitRepeatBlock) for item in circuit
+        ):
+            trial_active_qubits = set(active_qubits)
+            try:
+                result = self._inject_noise(circuit, trial_active_qubits)
+            except _UnsupportedMomentRepeat:
+                return self._inject_noise(circuit.flattened(), active_qubits)
+            active_qubits.clear()
+            active_qubits.update(trial_active_qubits)
+            return result
+
+        return self._inject_noise(circuit, active_qubits)
+
+    def _inject_noise(
+        self,
+        circuit: stim.Circuit,
+        active_qubits: Set[int],
+        *,
+        _suppress_first_tick_idle: bool = False,
+    ) -> stim.Circuit:
         # Insert noise
         noisy_circuit = stim.Circuit()
+        moment: List[stim.CircuitInstruction] = []
+        suppress_next_empty_tick_idle = _suppress_first_tick_idle
         for item in circuit:
             # Handle repeat blocks recursively
             if isinstance(item, stim.CircuitRepeatBlock):
-                noisy_body = self.inject_noise(item.body_copy(), active_qubits)
+                if not self.moment_rules:
+                    noisy_body = self._inject_noise(item.body_copy(), active_qubits)
+                    noisy_circuit.append(
+                        stim.CircuitRepeatBlock(item.repeat_count, noisy_body)
+                    )
+                    continue
+                if suppress_next_empty_tick_idle:
+                    raise _UnsupportedMomentRepeat(
+                        "A REPEAT suffix with operations must be followed by TICK"
+                    )
+                leading_tick, has_physical_suffix = self._repeat_boundary_shape(
+                    item.body_copy()
+                )
+                has_physical_prefix = self._moment_has_physical_operation(moment)
+                if leading_tick is None and has_physical_suffix:
+                    raise _UnsupportedMomentRepeat(
+                        "A REPEAT body must begin or end at a TICK boundary"
+                    )
+                if leading_tick is None and has_physical_prefix:
+                    raise _UnsupportedMomentRepeat(
+                        "Uniform moment noise requires a TICK between operations "
+                        "and a following REPEAT block"
+                    )
+                if leading_tick is not None and not has_physical_suffix:
+                    if has_physical_prefix:
+                        raise _UnsupportedMomentRepeat(
+                            "Cannot preserve a REPEAT whose leading TICK closes "
+                            "a non-empty outer moment but whose body has no "
+                            "physical suffix"
+                        )
+                elif leading_tick is not None:
+                    # The body's first TICK closes the outer moment on its first
+                    # iteration. Later iterations close the physical suffix,
+                    # whose idle channel is emitted at the end of the body.
+                    self._append_moment_noise(
+                        noisy_circuit,
+                        moment,
+                        leading_tick,
+                    )
+                moment = []
+                noisy_body = self._inject_noise(
+                    item.body_copy(),
+                    active_qubits,
+                    _suppress_first_tick_idle=(
+                        leading_tick is not None and has_physical_suffix
+                    ),
+                )
                 noisy_circuit.append(stim.CircuitRepeatBlock(item.repeat_count, noisy_body))
+                suppress_next_empty_tick_idle = has_physical_suffix
             elif isinstance(item, stim.CircuitInstruction):
+                # Moment-aware rules need to see the complete set of operations
+                # before the boundary itself is emitted.
+                if item.name == "TICK":
+                    if suppress_next_empty_tick_idle:
+                        if self._moment_has_physical_operation(moment):
+                            raise _UnsupportedMomentRepeat(
+                                "A REPEAT suffix must be followed directly by TICK"
+                            )
+                        suppress_next_empty_tick_idle = False
+                    else:
+                        self._append_moment_noise(noisy_circuit, moment, item)
+                    moment = []
+                else:
+                    if (
+                        suppress_next_empty_tick_idle
+                        and self._moment_has_physical_operation([item])
+                    ):
+                        raise _UnsupportedMomentRepeat(
+                            "A REPEAT suffix must be followed directly by TICK"
+                        )
+                    moment.append(item)
+
                 # --- Tracking active qubits ---
                 if item.name in {"R", "RX", "RY", "RZ"} :
                     # Add newly initialized qubits to active_qubits (use index not stim.target_rec)
@@ -64,6 +214,7 @@ class NoiseInjector:
                 # Concern about the order of rules applying to the same instruction, generating different noise sequences.
                 # Since we only consider Pauli error, changing the order of the noise sequence only potentially brings a -1 global phase,
                 # which is not physically observable.
+        self._append_moment_noise(noisy_circuit, moment)
         return noisy_circuit
 
     # =========================================================================
@@ -125,25 +276,61 @@ class NoiseInjector:
             tag="SE_start"
         ))
         
-        # 2. Measurement & Reset
-        injector.add_rule(FlipBeforeMeasurement(param_name="p_meas"))
-        injector.add_rule(FlipAfterReset(param_name="p_reset"))
+        injector._add_standard_circuit_level_rules()
+
+        return injector
+
+    @classmethod
+    def from_uniform_circuit_level(
+        cls,
+        config: NoiseConfig,
+        qubit_indices: List[int],
+    ) -> 'NoiseInjector':
+        """Circuit-level noise with idle depolarization after every moment.
+
+        At each TICK, ``p_idle`` is applied once to every qubit in
+        ``qubit_indices`` that has no unitary, reset, or measurement operation.
+        This includes empty moments. A non-empty final moment without a trailing
+        TICK is also covered. Moments containing only ``noiseless``-tagged
+        operations are left noiseless.
+
+        Unlike :meth:`from_circuit_level`, this model does not add the older
+        ``SE_start``-tagged data-idle channel. ``uniform`` describes idle
+        coverage; the five rates remain independently configurable. Repeat
+        layouts whose moments cross iteration boundaries are flattened to
+        preserve exact semantics.
+        """
+        injector = cls(config)
+        # Keep p_idle=0 a strict drop-in replacement for the historical
+        # circuit-level gate/SPAM rules. In particular, repeat blocks remain
+        # compressed and do not need moment-boundary analysis in this case.
+        if config.get("p_idle") > 0:
+            injector.add_moment_rule(UniformIdling(
+                target_qubits=qubit_indices,
+                param_name="p_idle",
+            ))
+        injector._add_standard_circuit_level_rules()
+        return injector
+
+    def _add_standard_circuit_level_rules(self) -> None:
+        """Add the gate, measurement, and reset rules shared by CL models."""
+        # 1. Measurement & Reset
+        self.add_rule(FlipBeforeMeasurement(param_name="p_meas"))
+        self.add_rule(FlipAfterReset(param_name="p_reset"))
         
-        # 3. 1-Qubit Gates
-        injector.add_rule(DepolarizeAfterGate(
+        # 2. 1-Qubit Gates
+        self.add_rule(DepolarizeAfterGate(
             target_gates=["H", "X", "Y", "Z", "S", "S_DAG"],
             param_name="p_1q",
             noise_op="DEPOLARIZE1"
         ))
         
-        # 4. 2-Qubit Gates
-        injector.add_rule(DepolarizeAfterGate(
+        # 3. 2-Qubit Gates
+        self.add_rule(DepolarizeAfterGate(
             target_gates=["CX", "CY", "CZ", "SWAP", "CNOT"],
             param_name="p_2q",
             noise_op="DEPOLARIZE2"
         ))
-        
-        return injector
 
     @classmethod
     def from_XZ_biased(cls, config: NoiseConfig, data_qubit_indices: List[int]) -> 'NoiseInjector':

--- a/lightstim/noise/rules.py
+++ b/lightstim/noise/rules.py
@@ -1,6 +1,6 @@
 import stim
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict, Set
+from typing import Iterable, List, Optional, Tuple, Dict, Set
 from .config import NoiseConfig
 
 class NoiseRule(ABC):
@@ -16,6 +16,20 @@ class NoiseRule(ABC):
         - pre_noise: Instructions to insert BEFORE the target.
         - post_noise: Instructions to insert AFTER the target.
         """
+        pass
+
+
+class MomentNoiseRule(ABC):
+    """Base class for noise that depends on a complete TICK-delimited moment."""
+
+    @abstractmethod
+    def apply(
+        self,
+        instructions: List[stim.CircuitInstruction],
+        config: NoiseConfig,
+        boundary: Optional[stim.CircuitInstruction],
+    ) -> List[stim.CircuitInstruction]:
+        """Return noise at a moment end or before its TICK ``boundary``."""
         pass
 
 # --- Implementation ---
@@ -317,3 +331,89 @@ class TaggedIdling(NoiseRule):
                     return [], [noise]
                 
         return [], []
+
+
+class UniformIdling(MomentNoiseRule):
+    """Depolarize every target qubit not operated on during a circuit moment.
+
+    A moment is the group of instructions between two ``TICK`` instructions.
+    Initialization, measurement, and unitary operations all make a moment take
+    time. An idle channel is added once at each ``TICK`` boundary, including
+    for an empty moment, and after a non-empty final moment without a trailing
+    TICK. An entirely ``noiseless``-tagged moment remains noiseless; a
+    ``TICK[noiseless]`` suppresses an otherwise empty moment.
+
+    Eligibility comes from an explicit, static qubit universe instead of the
+    injecter's active-qubit heuristic.  This matters for circuits that measure
+    a qubit and later reuse its collapsed state without resetting it.
+    """
+
+    def __init__(
+        self,
+        target_qubits: Iterable[int],
+        param_name: str = "p_idle",
+        noise_op: str = "DEPOLARIZE1",
+    ):
+        self.target_qubits = frozenset(target_qubits)
+        self.param_name = param_name
+        self.noise_op = noise_op
+
+    @staticmethod
+    def _operated_qubits(
+        instruction: stim.CircuitInstruction,
+    ) -> Set[int]:
+        # MPAD produces synthetic measurement-record bits; its integer targets
+        # are not physical qubits. Heralded noise channels are already noise,
+        # not operations whose duration should create more idle noise.
+        if instruction.name == "MPAD" or instruction.name.startswith("HERALDED_"):
+            return set()
+
+        gate_data = stim.gate_data(instruction.name)
+        if not (
+            gate_data.is_unitary
+            or gate_data.is_reset
+            or gate_data.produces_measurements
+        ):
+            return set()
+
+        return {
+            target.value
+            for target in instruction.targets_copy()
+            if (
+                target.is_qubit_target
+                or target.is_x_target
+                or target.is_y_target
+                or target.is_z_target
+            )
+        }
+
+    def apply(
+        self,
+        instructions: List[stim.CircuitInstruction],
+        config: NoiseConfig,
+        boundary: Optional[stim.CircuitInstruction],
+    ) -> List[stim.CircuitInstruction]:
+        p = config.get(self.param_name)
+        if p <= 0:
+            return []
+
+        operated_qubits: Set[int] = set()
+        has_noisy_physical_operation = False
+        for instruction in instructions:
+            targets = self._operated_qubits(instruction)
+            if not targets:
+                continue
+            operated_qubits.update(targets)
+            if instruction.tag != "noiseless":
+                has_noisy_physical_operation = True
+
+        if operated_qubits:
+            if not has_noisy_physical_operation:
+                return []
+        elif boundary is None or boundary.tag == "noiseless":
+            return []
+
+        idle_qubits = sorted(self.target_qubits - operated_qubits)
+        if not idle_qubits:
+            return []
+        return [stim.CircuitInstruction(self.noise_op, idle_qubits, [p])]

--- a/skills/custom-noise/SKILL.md
+++ b/skills/custom-noise/SKILL.md
@@ -3,10 +3,11 @@ name: custom-noise
 description: >
   Configure noise models and error rates for LightStim experiments. Use this
   skill whenever the user asks about noise models, setting physical error rates,
-  choosing between circuit_level / phenomenological / code_capacity / XZ_biased
-  noise, biased noise for neutral atom or trapped ion hardware, or wants to
-  understand how noise is applied to a circuit. Also trigger when the user asks
-  "what p should I use?" or "how do I add noise to my circuit?"
+  choosing between circuit_level / uniform_circuit_level / phenomenological /
+  code_capacity / XZ_biased noise, biased noise for neutral atom or trapped ion
+  hardware, or wants to understand how noise is applied to a circuit. Also
+  trigger when the user asks "what p should I use?" or "how do I add noise to
+  my circuit?"
 user-invocable: true
 ---
 
@@ -36,7 +37,7 @@ noise = NoiseConfig(
     p_2q=1e-3,    # Depolarizing after two-qubit gates (CX, CZ, ...)
     p_meas=1e-3,  # Measurement bit-flip probability
     p_reset=1e-3, # State-preparation bit-flip probability
-    p_idle=0,     # Depolarizing on data qubits at SE_start tick (between rounds)
+    p_idle=0,     # Placement depends on the selected noise model
     custom_params={},  # Arbitrary extra rates for XZ_biased or custom rules
 )
 ```
@@ -47,7 +48,8 @@ Unused fields default to 0. Set only the fields the target noise model uses.
 
 | Strategy | Injects | Relevant params | Use for |
 |---|---|---|---|
-| `circuit_level` | Depolarizing after every gate, flip before meas/after reset | `p_1q`, `p_2q`, `p_meas`, `p_reset` | Superconducting qubits, realistic simulation |
+| `circuit_level` | Gate/SPAM noise plus active-data idle at `TICK[SE_start]` | `p_1q`, `p_2q`, `p_meas`, `p_reset`, `p_idle` | LightStim's historical circuit-level convention |
+| `uniform_circuit_level` | Same gate/SPAM noise plus idle depolarization on every unoperated qubit in each moment | `p_1q`, `p_2q`, `p_meas`, `p_reset`, `p_idle` | Paper models with uniform per-moment idle coverage |
 | `phenomenological` | Data errors at SE_start tick + measurement flips | `p_idle`, `p_meas` | Fast threshold analysis, ignores gate structure |
 | `code_capacity` | Data errors only (no gate/meas noise) | `p_idle` | Ideal measurements, pure code distance study |
 | `XZ_biased` | Independent X and Z channels after each gate | See below | Biased noise (neutral atoms, trapped ions) |
@@ -55,6 +57,8 @@ Unused fields default to 0. Set only the fields the target noise model uses.
 ## Decision guide
 
 - **Superconducting hardware**: `circuit_level` with `p_2q ≈ 10× p_1q`, `p_meas ≈ p_2q`.
+- **Uniform per-moment idling**: `uniform_circuit_level`; set all five rates
+  equal to `p` only when the target paper defines one shared probability.
 - **Threshold plots (fast)**: `phenomenological` first, then cross-check key points with `circuit_level`.
 - **Code distance study only**: `code_capacity` — fastest, no gate noise.
 - **Biased hardware** (neutral atoms η ≫ 1, trapped ions η ≲ 1): `XZ_biased`.
@@ -93,8 +97,14 @@ builder.apply_unitary_block(gate, noiseless=True)           # same
 The noise injector skips all instructions tagged `'noiseless'`.
 This is how state-injection protocols avoid noising the unencoded region.
 
+For `uniform_circuit_level`, every `TICK`-delimited moment uses the complete
+physical-qubit set. Resets, measurements, and unitary gates count as operations;
+all other target qubits receive one `DEPOLARIZE1(p_idle)` channel. Empty moments
+also receive idle noise. Moments containing only `noiseless` physical operations
+remain noiseless.
+
 ## Working examples
 
 - `lightstim/protocols/memory.py` — standard circuit-level noise via `build_noisy_circuit()`
 - `lightstim/protocols/state_injection.py` — selective noise (injection region excluded via tags)
-- `lightstim/noise/injector.py` — `NoiseInjector` factory methods for all four built-in models
+- `lightstim/noise/injector.py` — `NoiseInjector` factory methods for all five built-in models

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -1,6 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
 import stim
 
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.noise.config import NoiseConfig
 from lightstim.noise.injector import NoiseInjector
 
 
@@ -37,4 +41,309 @@ def test_xz_biased_model_uses_z_dominant_gate_and_idle_channels():
         inst.name == "Z_ERROR"
         and inst.gate_args_copy()[0] == pytest.approx(cfg.custom_params["p_idle_z"])
         for inst in noisy
+    )
+
+
+def test_uniform_circuit_level_adds_idle_noise_to_each_operated_moment():
+    config = NoiseConfig(
+        p_1q=0.01,
+        p_2q=0.02,
+        p_meas=0.03,
+        p_reset=0.04,
+        p_idle=0.05,
+    )
+    clean = stim.Circuit(
+        """
+        R 0 1 2
+        TICK
+        H 0
+        TICK
+        CX 0 1
+        TICK
+        M 0
+        TICK
+        H[noiseless] 1
+        TICK
+        X 0
+        """
+    )
+
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1, 2],
+    ).inject_noise(clean)
+
+    assert noisy == stim.Circuit(
+        """
+        R 0 1 2
+        X_ERROR(0.04) 0 1 2
+        TICK
+        H 0
+        DEPOLARIZE1(0.01) 0
+        DEPOLARIZE1(0.05) 1 2
+        TICK
+        CX 0 1
+        DEPOLARIZE2(0.02) 0 1
+        DEPOLARIZE1(0.05) 2
+        TICK
+        X_ERROR(0.03) 0
+        M 0
+        DEPOLARIZE1(0.05) 1 2
+        TICK
+        H[noiseless] 1
+        TICK
+        X 0
+        DEPOLARIZE1(0.01) 0
+        DEPOLARIZE1(0.05) 1 2
+        """
+    )
+    assert noisy.without_noise() == clean
+
+
+def test_uniform_idling_uses_all_operations_in_a_moment():
+    clean = stim.Circuit(
+        """
+        R 0 1 2
+        TICK
+        H 0
+        X 1
+        TICK
+        M 0
+        R 0
+        TICK
+        MPAD 0
+        """
+    )
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        NoiseConfig(p_idle=0.125),
+        [0, 1, 2],
+    ).inject_noise(clean)
+
+    idle_errors = [
+        instruction
+        for instruction in noisy
+        if instruction.name == "DEPOLARIZE1"
+    ]
+    assert [
+        [target.value for target in instruction.targets_copy()]
+        for instruction in idle_errors
+    ] == [[2], [1, 2]]
+    assert noisy.without_noise() == clean
+
+
+def test_uniform_circuit_level_recurses_into_repeat_blocks():
+    clean = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        REPEAT 2 {
+            H 0
+            TICK
+        }
+        """
+    )
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        NoiseConfig(p_idle=0.125),
+        [0, 1],
+    ).inject_noise(clean)
+
+    assert noisy == stim.Circuit(
+        """
+        R 0 1
+        TICK
+        REPEAT 2 {
+            H 0
+            DEPOLARIZE1(0.125) 1
+            TICK
+        }
+        """
+    )
+    assert noisy.without_noise() == clean
+
+
+def test_uniform_repeat_boundaries_match_flattened_circuit():
+    clean = stim.Circuit(
+        """
+        R 0 1 2
+        TICK
+        M 0
+        REPEAT 2 {
+            TICK
+            R 0
+        }
+        TICK
+        H 0
+        """
+    )
+    config = NoiseConfig(p_idle=0.125)
+
+    repeated = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1, 2],
+    ).inject_noise(clean)
+    flattened = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1, 2],
+    ).inject_noise(clean.flattened())
+
+    assert repeated.flattened() == flattened
+
+
+def test_uniform_repeat_without_tick_falls_back_to_exact_flattened_semantics():
+    clean = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        REPEAT 2 {
+            H 0
+        }
+        TICK
+        """
+    )
+    config = NoiseConfig(p_idle=0.125)
+
+    repeated = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1],
+    ).inject_noise(clean)
+    flattened = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1],
+    ).inject_noise(clean.flattened())
+
+    assert repeated == flattened
+    assert repeated.without_noise() == clean.flattened()
+    assert sum(
+        instruction.name == "DEPOLARIZE1" for instruction in repeated
+    ) == 1
+
+
+def test_uniform_zero_idle_preserves_nested_repeat_blocks():
+    clean = stim.Circuit(
+        """
+        REPEAT 2 {
+            REPEAT 3 {
+                H 0
+                TICK
+            }
+        }
+        """
+    )
+
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        NoiseConfig(p_1q=0.125, p_idle=0),
+        [0],
+    ).inject_noise(clean)
+
+    assert isinstance(noisy[0], stim.CircuitRepeatBlock)
+    outer_body = noisy[0].body_copy()
+    assert isinstance(outer_body[0], stim.CircuitRepeatBlock)
+    assert noisy.without_noise() == clean
+
+
+def test_uniform_nested_repeat_falls_back_to_exact_flattened_semantics():
+    clean = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        REPEAT 2 {
+            REPEAT 3 {
+                H 0
+                TICK
+            }
+        }
+        """
+    )
+    config = NoiseConfig(p_idle=0.125)
+
+    nested = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1],
+    ).inject_noise(clean)
+    flattened = NoiseInjector.from_uniform_circuit_level(
+        config,
+        [0, 1],
+    ).inject_noise(clean.flattened())
+
+    assert nested == flattened
+    assert nested.without_noise() == clean.flattened()
+
+
+def test_uniform_idling_includes_qubits_measured_in_an_earlier_moment():
+    clean = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        M 0
+        TICK
+        H 1
+        """
+    )
+
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        NoiseConfig(p_idle=0.125),
+        [0, 1],
+    ).inject_noise(clean)
+
+    idle_errors = [
+        instruction
+        for instruction in noisy
+        if instruction.name == "DEPOLARIZE1"
+    ]
+    assert [
+        [target.value for target in instruction.targets_copy()]
+        for instruction in idle_errors
+    ] == [[1], [0]]
+
+
+def test_uniform_circuit_level_noises_empty_tick_moments():
+    clean = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        TICK
+        TICK[noiseless]
+        """
+    )
+    noisy = NoiseInjector.from_uniform_circuit_level(
+        NoiseConfig(p_idle=0.125),
+        [0, 1],
+    ).inject_noise(clean)
+
+    assert noisy == stim.Circuit(
+        """
+        R 0 1
+        TICK
+        DEPOLARIZE1(0.125) 0 1
+        TICK
+        TICK[noiseless]
+        """
+    )
+
+
+def test_builder_uniform_circuit_level_targets_non_data_qubits():
+    # The builder's historical factory argument contains data qubits only.
+    # Uniform idling instead needs every physical qubit in the circuit.
+    system = SimpleNamespace(
+        data_coords=[(0, 0)],
+        index_map={(0, 0): 0},
+    )
+    builder = CircuitBuilder(tracker=None, system_config=system)
+    builder.circuit = stim.Circuit(
+        """
+        R 0 1
+        TICK
+        H 0
+        """
+    )
+
+    noisy = builder.build_noisy_circuit(
+        NoiseConfig(p_idle=0.125),
+        noise_model="uniform_circuit_level",
+    )
+
+    assert any(
+        instruction.name == "DEPOLARIZE1"
+        and [target.value for target in instruction.targets_copy()] == [1]
+        for instruction in noisy
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,7 +80,7 @@ def test_pipeline_two_patch_ls():
 
 @pytest.mark.smoke
 def test_pipeline_noise_models():
-    """Code-capacity and phenomenological models produce valid LER."""
+    """Non-default built-in noise models produce valid LER."""
     from lightstim.qec_code.surface_code.rotated import RotatedSurfaceCode, RotatedSurfaceCodeExtractionBlock
     from lightstim.ir.qec_system import QECSystem
     from lightstim.ir.tracker import SyndromeTracker
@@ -89,6 +89,16 @@ def test_pipeline_noise_models():
     for nm, noise in [
         ("code_capacity",    NoiseConfig(p_idle=0.05)),
         ("phenomenological", NoiseConfig(p_idle=0.05, p_meas=0.05)),
+        (
+            "uniform_circuit_level",
+            NoiseConfig(
+                p_1q=0.05,
+                p_2q=0.05,
+                p_meas=0.05,
+                p_reset=0.05,
+                p_idle=0.05,
+            ),
+        ),
     ]:
         system = QECSystem()
         system.add_patch(RotatedSurfaceCode(distance=3), name="main")


### PR DESCRIPTION
## Summary

- add a `uniform_circuit_level` noise strategy that applies `DEPOLARIZE1(p_idle)` to every physical qubit not operated on in each TICK-delimited moment
- preserve LightStim's existing gate, measurement, reset, tagged-noiseless, and historical `circuit_level` behavior
- keep tick-aligned repeat blocks compact and use an exact flattening fallback for repeat layouts whose moments cross iteration boundaries
- document that "uniform" describes idle coverage; paper-style equal rates must be configured explicitly

## Motivation

This supports cultivation-protocol studies whose error model assigns an idle depolarizing channel to every qubit not participating in a given circuit moment, instead of applying idle noise only at `TICK[SE_start]`.

## Validation

- 11 focused noise-model tests, including empty/mixed/noiseless moments, measurement reuse, non-data qubits, aligned/unaligned/nested repeats, and zero-idle legacy compatibility
- real rotated-surface-code pipeline smoke with nonzero logical errors
- MagicCross d=3 cultivation: clean skeleton preserved, flattened-oracle equality, and valid DEMs for standard and full-postselection paths
- rotated d=3, five-round memory: compact repeat preserved and identical to flattened-oracle injection
- all non-slow local tests outside the pre-existing local FastAPI TestClient environment issue passed

Reference motivation: https://arxiv.org/abs/2509.05232
