### PR TITLE
refactor(noise): clarify per-moment idling name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ LightStim is a modular Quantum Error Correction (QEC) framework built on [Stim](
 
 - Build QEC experiments from reusable abstractions (`QECPatch`, `QECSystem`, `CircuitBuilder`, `SyndromeTracker`)
 - Support multi-patch workflows (transversal gates, lattice surgery, state injection)
-- Inject standardized noise models (`code_capacity`, `phenomenological`, `circuit_level`, `uniform_circuit_level`, `XZ_biased`)
+- Inject standardized noise models (`code_capacity`, `phenomenological`, `circuit_level`, `circuit_level_with_idling`, `XZ_biased`)
 - Decode with a unified backend (PyMatching, BP+OSD CPU/GPU, MWPF, Relay-BP, Tesseract)
 - Analyze and visualize logical error rates
 - Inspect circuits interactively in a browser (DEM 3D, Circuit Timeline, DetSlice animator)

--- a/docs/api/ir.md
+++ b/docs/api/ir.md
@@ -288,7 +288,7 @@ builder.logical_canonicalization(canonical_logicals)
 ```python
 noisy_circuit = builder.build_noisy_circuit(
     noise_params,        # NoiseConfig
-    noise_model,         # str — includes 'circuit_level' and 'uniform_circuit_level'
+    noise_model,         # str — includes 'circuit_level' and 'circuit_level_with_idling'
 )
 # Returns a new stim.Circuit with noise channels injected.
 # Does NOT modify builder.circuit in place.

--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -224,20 +224,20 @@ noise = NoiseConfig(
 ```
 
 Pass to `builder.build_noisy_circuit(noise, noise_model)` where `noise_model` is one of:
-`'circuit_level'`, `'uniform_circuit_level'`, `'phenomenological'`,
+`'circuit_level'`, `'circuit_level_with_idling'`, `'phenomenological'`,
 `'code_capacity'`, `'XZ_biased'`.
 
 `circuit_level` preserves LightStim's historical convention: `p_idle` is
 applied to active data qubits at each `TICK[SE_start]`. Use
-`uniform_circuit_level` when every `TICK`-delimited moment should apply
+`circuit_level_with_idling` when every `TICK`-delimited moment should apply
 `p_idle` to the complement of that moment's operated qubits. Empty, reset-only,
 and measurement-only moments count; a non-empty final moment without a trailing
 `TICK` also counts. Moments whose physical operations are all tagged
 `noiseless` do not. `TICK[noiseless]` suppresses an otherwise empty moment;
 it does not hide untagged physical operations in a mixed moment.
 
-Here, *uniform* describes idle-noise coverage, not equal error rates. To use
-the common paper convention with one physical error probability, explicitly
+The five error rates remain independently configurable. To use the common
+paper convention with one physical error probability, explicitly
 set `p_1q = p_2q = p_meas = p_reset = p_idle = p`. Gate and SPAM placement
 otherwise remains the same as LightStim's existing `circuit_level` model.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -202,7 +202,7 @@ LightStim supports five noise models, each adding errors at different circuit lo
 | `code_capacity` | Pauli errors on data qubits only (before measurement) |
 | `phenomenological` | Data qubit errors + measurement errors |
 | `circuit_level` | Gate, measurement, and reset noise; data idle once per tagged SE round |
-| `uniform_circuit_level` | Circuit-level noise plus idle depolarization at every circuit moment |
+| `circuit_level_with_idling` | Circuit-level noise plus idle depolarization at every circuit moment |
 | `XZ_biased` | Circuit-level with asymmetric X/Z error rates |
 
 ### Detectors and Observables

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -1329,7 +1329,7 @@ class CircuitBuilder:
             noise_params: Noise parameters (NoiseConfig).
             noise_model: The name of the factory method in NoiseInjector to use.
                          e.g., 'circuit_level' -> calls NoiseInjector.from_circuit_level(...)
-                         e.g., 'uniform_circuit_level' -> adds idle noise every moment
+                         e.g., 'circuit_level_with_idling' -> adds idle noise every moment
                          e.g., 'custom_test'   -> calls NoiseInjector.from_custom_test(...)
         """
         # 1. Construct the expected factory method name
@@ -1345,13 +1345,13 @@ class CircuitBuilder:
         factory_method = getattr(NoiseInjector, method_name)
 
         # 3. Inject noise
-        # Most models target data qubits for idle noise. The uniform model
+        # Most models target data qubits for idle noise. The per-moment model
         # instead needs the complete physical-qubit universe so that it can
         # take the complement of each moment's operated qubits.
         data_indices = [self.system.index_map[coord] for coord in self.system.data_coords]
         target_indices = (
             list(range(self.circuit.num_qubits))
-            if noise_model == "uniform_circuit_level"
+            if noise_model == "circuit_level_with_idling"
             else data_indices
         )
         injector = factory_method(noise_params, target_indices)

--- a/lightstim/noise/__init__.py
+++ b/lightstim/noise/__init__.py
@@ -10,5 +10,5 @@ from .rules import (
     FlipBeforeMeasurement,
     FlipAfterReset,
     TaggedIdling,
-    UniformIdling,
+    MomentIdling,
 )

--- a/lightstim/noise/injector.py
+++ b/lightstim/noise/injector.py
@@ -12,7 +12,7 @@ from .rules import (
     FlipAfterResetFiltered,
     FlipAfterYResetFiltered,
     TaggedIdling,
-    UniformIdling,
+    MomentIdling,
 )
 
 
@@ -50,7 +50,7 @@ class NoiseInjector:
     def _moment_has_physical_operation(
         moment: List[stim.CircuitInstruction],
     ) -> bool:
-        return any(UniformIdling._operated_qubits(item) for item in moment)
+        return any(MomentIdling._operated_qubits(item) for item in moment)
 
     @classmethod
     def _repeat_boundary_shape(
@@ -63,7 +63,7 @@ class NoiseInjector:
         for index, item in enumerate(body):
             if isinstance(item, stim.CircuitRepeatBlock):
                 raise _UnsupportedMomentRepeat(
-                    "Uniform moment noise does not support nested REPEAT blocks"
+                    "Moment-aware idle noise does not support nested REPEAT blocks"
                 )
             if index == 0 and item.name == "TICK":
                 leading_tick = item
@@ -135,7 +135,7 @@ class NoiseInjector:
                     )
                 if leading_tick is None and has_physical_prefix:
                     raise _UnsupportedMomentRepeat(
-                        "Uniform moment noise requires a TICK between operations "
+                        "Moment-aware idle noise requires a TICK between operations "
                         "and a following REPEAT block"
                     )
                 if leading_tick is not None and not has_physical_suffix:
@@ -281,7 +281,7 @@ class NoiseInjector:
         return injector
 
     @classmethod
-    def from_uniform_circuit_level(
+    def from_circuit_level_with_idling(
         cls,
         config: NoiseConfig,
         qubit_indices: List[int],
@@ -295,17 +295,16 @@ class NoiseInjector:
         operations are left noiseless.
 
         Unlike :meth:`from_circuit_level`, this model does not add the older
-        ``SE_start``-tagged data-idle channel. ``uniform`` describes idle
-        coverage; the five rates remain independently configurable. Repeat
-        layouts whose moments cross iteration boundaries are flattened to
-        preserve exact semantics.
+        ``SE_start``-tagged data-idle channel. The five rates remain
+        independently configurable. Repeat layouts whose moments cross
+        iteration boundaries are flattened to preserve exact semantics.
         """
         injector = cls(config)
         # Keep p_idle=0 a strict drop-in replacement for the historical
         # circuit-level gate/SPAM rules. In particular, repeat blocks remain
         # compressed and do not need moment-boundary analysis in this case.
         if config.get("p_idle") > 0:
-            injector.add_moment_rule(UniformIdling(
+            injector.add_moment_rule(MomentIdling(
                 target_qubits=qubit_indices,
                 param_name="p_idle",
             ))

--- a/lightstim/noise/rules.py
+++ b/lightstim/noise/rules.py
@@ -333,7 +333,7 @@ class TaggedIdling(NoiseRule):
         return [], []
 
 
-class UniformIdling(MomentNoiseRule):
+class MomentIdling(MomentNoiseRule):
     """Depolarize every target qubit not operated on during a circuit moment.
 
     A moment is the group of instructions between two ``TICK`` instructions.

--- a/skills/custom-noise/SKILL.md
+++ b/skills/custom-noise/SKILL.md
@@ -3,7 +3,7 @@ name: custom-noise
 description: >
   Configure noise models and error rates for LightStim experiments. Use this
   skill whenever the user asks about noise models, setting physical error rates,
-  choosing between circuit_level / uniform_circuit_level / phenomenological /
+  choosing between circuit_level / circuit_level_with_idling / phenomenological /
   code_capacity / XZ_biased noise, biased noise for neutral atom or trapped ion
   hardware, or wants to understand how noise is applied to a circuit. Also
   trigger when the user asks "what p should I use?" or "how do I add noise to
@@ -49,7 +49,7 @@ Unused fields default to 0. Set only the fields the target noise model uses.
 | Strategy | Injects | Relevant params | Use for |
 |---|---|---|---|
 | `circuit_level` | Gate/SPAM noise plus active-data idle at `TICK[SE_start]` | `p_1q`, `p_2q`, `p_meas`, `p_reset`, `p_idle` | LightStim's historical circuit-level convention |
-| `uniform_circuit_level` | Same gate/SPAM noise plus idle depolarization on every unoperated qubit in each moment | `p_1q`, `p_2q`, `p_meas`, `p_reset`, `p_idle` | Paper models with uniform per-moment idle coverage |
+| `circuit_level_with_idling` | Same gate/SPAM noise plus idle depolarization on every unoperated qubit in each moment | `p_1q`, `p_2q`, `p_meas`, `p_reset`, `p_idle` | Paper models with per-moment idle coverage |
 | `phenomenological` | Data errors at SE_start tick + measurement flips | `p_idle`, `p_meas` | Fast threshold analysis, ignores gate structure |
 | `code_capacity` | Data errors only (no gate/meas noise) | `p_idle` | Ideal measurements, pure code distance study |
 | `XZ_biased` | Independent X and Z channels after each gate | See below | Biased noise (neutral atoms, trapped ions) |
@@ -57,7 +57,7 @@ Unused fields default to 0. Set only the fields the target noise model uses.
 ## Decision guide
 
 - **Superconducting hardware**: `circuit_level` with `p_2q ≈ 10× p_1q`, `p_meas ≈ p_2q`.
-- **Uniform per-moment idling**: `uniform_circuit_level`; set all five rates
+- **Per-moment idling**: `circuit_level_with_idling`; set all five rates
   equal to `p` only when the target paper defines one shared probability.
 - **Threshold plots (fast)**: `phenomenological` first, then cross-check key points with `circuit_level`.
 - **Code distance study only**: `code_capacity` — fastest, no gate noise.
@@ -97,7 +97,7 @@ builder.apply_unitary_block(gate, noiseless=True)           # same
 The noise injector skips all instructions tagged `'noiseless'`.
 This is how state-injection protocols avoid noising the unencoded region.
 
-For `uniform_circuit_level`, every `TICK`-delimited moment uses the complete
+For `circuit_level_with_idling`, every `TICK`-delimited moment uses the complete
 physical-qubit set. Resets, measurements, and unitary gates count as operations;
 all other target qubits receive one `DEPOLARIZE1(p_idle)` channel. Empty moments
 also receive idle noise. Moments containing only `noiseless` physical operations

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -44,7 +44,7 @@ def test_xz_biased_model_uses_z_dominant_gate_and_idle_channels():
     )
 
 
-def test_uniform_circuit_level_adds_idle_noise_to_each_operated_moment():
+def test_circuit_level_with_idling_adds_idle_noise_to_each_operated_moment():
     config = NoiseConfig(
         p_1q=0.01,
         p_2q=0.02,
@@ -68,7 +68,7 @@ def test_uniform_circuit_level_adds_idle_noise_to_each_operated_moment():
         """
     )
 
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1, 2],
     ).inject_noise(clean)
@@ -100,7 +100,7 @@ def test_uniform_circuit_level_adds_idle_noise_to_each_operated_moment():
     assert noisy.without_noise() == clean
 
 
-def test_uniform_idling_uses_all_operations_in_a_moment():
+def test_moment_idling_uses_all_operations_in_a_moment():
     clean = stim.Circuit(
         """
         R 0 1 2
@@ -114,7 +114,7 @@ def test_uniform_idling_uses_all_operations_in_a_moment():
         MPAD 0
         """
     )
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         NoiseConfig(p_idle=0.125),
         [0, 1, 2],
     ).inject_noise(clean)
@@ -131,7 +131,7 @@ def test_uniform_idling_uses_all_operations_in_a_moment():
     assert noisy.without_noise() == clean
 
 
-def test_uniform_circuit_level_recurses_into_repeat_blocks():
+def test_circuit_level_with_idling_recurses_into_repeat_blocks():
     clean = stim.Circuit(
         """
         R 0 1
@@ -142,7 +142,7 @@ def test_uniform_circuit_level_recurses_into_repeat_blocks():
         }
         """
     )
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         NoiseConfig(p_idle=0.125),
         [0, 1],
     ).inject_noise(clean)
@@ -161,7 +161,7 @@ def test_uniform_circuit_level_recurses_into_repeat_blocks():
     assert noisy.without_noise() == clean
 
 
-def test_uniform_repeat_boundaries_match_flattened_circuit():
+def test_idling_repeat_boundaries_match_flattened_circuit():
     clean = stim.Circuit(
         """
         R 0 1 2
@@ -177,11 +177,11 @@ def test_uniform_repeat_boundaries_match_flattened_circuit():
     )
     config = NoiseConfig(p_idle=0.125)
 
-    repeated = NoiseInjector.from_uniform_circuit_level(
+    repeated = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1, 2],
     ).inject_noise(clean)
-    flattened = NoiseInjector.from_uniform_circuit_level(
+    flattened = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1, 2],
     ).inject_noise(clean.flattened())
@@ -189,7 +189,7 @@ def test_uniform_repeat_boundaries_match_flattened_circuit():
     assert repeated.flattened() == flattened
 
 
-def test_uniform_repeat_without_tick_falls_back_to_exact_flattened_semantics():
+def test_idling_repeat_without_tick_falls_back_to_exact_flattened_semantics():
     clean = stim.Circuit(
         """
         R 0 1
@@ -202,11 +202,11 @@ def test_uniform_repeat_without_tick_falls_back_to_exact_flattened_semantics():
     )
     config = NoiseConfig(p_idle=0.125)
 
-    repeated = NoiseInjector.from_uniform_circuit_level(
+    repeated = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1],
     ).inject_noise(clean)
-    flattened = NoiseInjector.from_uniform_circuit_level(
+    flattened = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1],
     ).inject_noise(clean.flattened())
@@ -218,7 +218,7 @@ def test_uniform_repeat_without_tick_falls_back_to_exact_flattened_semantics():
     ) == 1
 
 
-def test_uniform_zero_idle_preserves_nested_repeat_blocks():
+def test_idling_model_with_zero_idle_preserves_nested_repeat_blocks():
     clean = stim.Circuit(
         """
         REPEAT 2 {
@@ -230,7 +230,7 @@ def test_uniform_zero_idle_preserves_nested_repeat_blocks():
         """
     )
 
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         NoiseConfig(p_1q=0.125, p_idle=0),
         [0],
     ).inject_noise(clean)
@@ -241,7 +241,7 @@ def test_uniform_zero_idle_preserves_nested_repeat_blocks():
     assert noisy.without_noise() == clean
 
 
-def test_uniform_nested_repeat_falls_back_to_exact_flattened_semantics():
+def test_idling_nested_repeat_falls_back_to_exact_flattened_semantics():
     clean = stim.Circuit(
         """
         R 0 1
@@ -256,11 +256,11 @@ def test_uniform_nested_repeat_falls_back_to_exact_flattened_semantics():
     )
     config = NoiseConfig(p_idle=0.125)
 
-    nested = NoiseInjector.from_uniform_circuit_level(
+    nested = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1],
     ).inject_noise(clean)
-    flattened = NoiseInjector.from_uniform_circuit_level(
+    flattened = NoiseInjector.from_circuit_level_with_idling(
         config,
         [0, 1],
     ).inject_noise(clean.flattened())
@@ -269,7 +269,7 @@ def test_uniform_nested_repeat_falls_back_to_exact_flattened_semantics():
     assert nested.without_noise() == clean.flattened()
 
 
-def test_uniform_idling_includes_qubits_measured_in_an_earlier_moment():
+def test_moment_idling_includes_qubits_measured_in_an_earlier_moment():
     clean = stim.Circuit(
         """
         R 0 1
@@ -280,7 +280,7 @@ def test_uniform_idling_includes_qubits_measured_in_an_earlier_moment():
         """
     )
 
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         NoiseConfig(p_idle=0.125),
         [0, 1],
     ).inject_noise(clean)
@@ -296,7 +296,7 @@ def test_uniform_idling_includes_qubits_measured_in_an_earlier_moment():
     ] == [[1], [0]]
 
 
-def test_uniform_circuit_level_noises_empty_tick_moments():
+def test_circuit_level_with_idling_noises_empty_tick_moments():
     clean = stim.Circuit(
         """
         R 0 1
@@ -305,7 +305,7 @@ def test_uniform_circuit_level_noises_empty_tick_moments():
         TICK[noiseless]
         """
     )
-    noisy = NoiseInjector.from_uniform_circuit_level(
+    noisy = NoiseInjector.from_circuit_level_with_idling(
         NoiseConfig(p_idle=0.125),
         [0, 1],
     ).inject_noise(clean)
@@ -321,9 +321,9 @@ def test_uniform_circuit_level_noises_empty_tick_moments():
     )
 
 
-def test_builder_uniform_circuit_level_targets_non_data_qubits():
+def test_builder_circuit_level_with_idling_targets_non_data_qubits():
     # The builder's historical factory argument contains data qubits only.
-    # Uniform idling instead needs every physical qubit in the circuit.
+    # Per-moment idling instead needs every physical qubit in the circuit.
     system = SimpleNamespace(
         data_coords=[(0, 0)],
         index_map={(0, 0): 0},
@@ -339,7 +339,7 @@ def test_builder_uniform_circuit_level_targets_non_data_qubits():
 
     noisy = builder.build_noisy_circuit(
         NoiseConfig(p_idle=0.125),
-        noise_model="uniform_circuit_level",
+        noise_model="circuit_level_with_idling",
     )
 
     assert any(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,7 +90,7 @@ def test_pipeline_noise_models():
         ("code_capacity",    NoiseConfig(p_idle=0.05)),
         ("phenomenological", NoiseConfig(p_idle=0.05, p_meas=0.05)),
         (
-            "uniform_circuit_level",
+            "circuit_level_with_idling",
             NoiseConfig(
                 p_1q=0.05,
                 p_2q=0.05,


### PR DESCRIPTION
## Summary

- rename the public noise strategy from `uniform_circuit_level` to `circuit_level_with_idling`
- rename the implementation rule from `UniformIdling` to `MomentIdling`
- update the builder, documentation, repository skill, and tests consistently
- remove the old name instead of retaining an ambiguous alias

The new name describes the model composition directly and avoids suggesting that all five error probabilities must be equal.

## Validation

- focused noise and pipeline tests pass
- MagicCross d=3 cultivation and full-postselection circuits build with the new name and produce valid DEMs
- repository scan confirms that the old API and class names have no remaining references
