### PR TITLE
Support automatic subsystem gauge fixing with Bacon–Shor and SHYPS

### DIFF
--- a/docs/api/ir.md
+++ b/docs/api/ir.md
@@ -23,6 +23,7 @@ Abstract base class for all QEC codes. Subclass it to define a new code family.
 | `syndrome_indices_x` | `Set[int]` | UIDs used for X-syndrome readout |
 | `syndrome_indices_z` | `Set[int]` | UIDs used for Z-syndrome readout |
 | `stabilizers` | `List[Dict]` | See stabilizer record format below |
+| `gauges` | `List[Dict]` | Optional subsystem gauge generators; same record format. `stabilizers` then declares their centre. |
 | `logical_ops` | `List[Dict]` | See logical op record format below |
 | `num_logicals` | `int` | Number of logical qubits (must set in `build()`) |
 
@@ -53,6 +54,10 @@ self.create_stim_stabilizer(
     type,            # "X" or "Z"
 )
 # Appends one entry to self.stabilizers.
+
+self.create_stim_gauge(target_dict, syn_coord=None, type=None)
+# Appends one entry to self.gauges. Gauge generators may anticommute.
+# Centre stabilizers inferred from gauge outcomes can have syn_coord=None.
 
 self.create_stim_logical(
     target_dict,     # {(x, y): "X"/"Z"/"Y", ...}
@@ -127,6 +132,8 @@ global_patch = system.add_patch(
 | `system.local_to_global_map` | `{patch_name: {local_idx: global_idx}}` |
 | `system.stabilizers` | Master list of all stabilizer records (global indices) |
 | `system.active_stabilizer_indices` | Set of stabilizer UIDs currently ON |
+| `system.gauges` | Declared gauge records in global indices |
+| `system.active_gauge_indices` | Active gauge inventory; unchanged when the measurement phase alternates |
 
 ### Active stabilizer properties
 
@@ -134,10 +141,27 @@ global_patch = system.add_patch(
 system.active_stabilizers         # List of active stabilizer records
 system.active_stabilizers_x       # X-type only
 system.active_stabilizers_z       # Z-type only
+system.active_gauges              # Declared gauges, independent of the round phase
+system.active_gauges_x            # X-type only
+system.active_gauges_z            # Z-type only
 system.active_syndrome_indices    # Global indices of active syndrome qubits
 system.active_syndrome_indices_x  # X-syndrome only
 system.active_syndrome_indices_z  # Z-syndrome only
 ```
+
+For subsystem patches, registration validates that S is the full centre of G
+and that `num_logicals` is the protected count `n - (rank(G) + rank(S))/2`.
+Ancillas belonging to active gauges are included in the active syndrome
+properties. A patch without gauges retains the existing stabilizer-code path.
+
+`SyndromeTracker.infer_gauge_fixed_stabilizers(system)` returns a derived
+`PauliTableau` snapshot with measurement-record parities. It computes the
+intersection of the tracked physical state and the gauge span, including
+products of rows. The Builder automatically classifies subsystem state before
+and after each physical measurement block; users do not update active
+stabilizers between X/Z rounds. See
+[subsystem tracking](../design/subsystem_tracking.md) for initialization and
+the supported scope.
 
 ### Define-by-run (dynamic patch addition)
 

--- a/docs/design/subsystem_tracking.md
+++ b/docs/design/subsystem_tracking.md
@@ -1,0 +1,105 @@
+# Subsystem gauge-state inference
+
+An alternating gauge schedule previously reached the correct physical
+conditional state, then failed during code-state classification. A round
+ending in Z gauges was rebased onto the patch's static centre S; surviving
+gauge-fixed constraints were counted as additional protected logicals.
+Declaring all noncommuting gauges as stabilizers instead made that rebase
+demand X constraints destroyed by the Z measurements.
+
+The physical measurement update already projects anticommuting Paulis and
+forward-propagates the state. This extension changes its classification
+boundary and adds an explicit gauge declaration. It keeps the existing
+QECPatch, QECSystem, SE circuits, measurement blocks and atomic operations.
+
+## Fixed declaration and derived state
+
+A subsystem patch declares once:
+
+- `stabilizers`: generators for the centre S;
+- `gauges`: generators for G, which can be redundant or noncommuting;
+- `num_logicals`: the number k of protected qubits, excluding gauge qubits;
+- the existing geometry and optional logical representatives.
+
+Registration checks S is the full centre of G and
+`k = n - (rank(G) + rank(S))/2`, using data qubits only. These are Pauli
+spaces modulo phase. A declaration does not assert a known eigenvalue;
+initialization and the actual Stim circuit establish that information.
+
+The SE circuit still specifies what is measured and in which order. Each
+commuting physical measurement block drives the existing Pauli update. No
+per-round active-stabilizer list, transition object or manual outcome mapping
+is required. `system.active_gauges` exposes the fixed available gauge
+inventory, including operators that were not measured in the current phase.
+
+Let T be the row space of the complete tracked conditional state, combining
+the tracker stabilizer and logical tables. The known gauge-fixed constraints
+are **A = T ∩ G**. This is an intersection of spans: a product of two rows
+can lie in G even when neither row individually does. Each inferred row
+retains its coefficients over T; those coefficients XOR its absolute
+measurement records as well.
+
+Protected logical-state constraints must commute with every gauge. The
+classifier therefore finds **B = T ∩ G^perp** on the data register and picks
+independent representatives modulo A. Once the centre is known,
+`A ∩ B = S`, so this is the known bare-logical space `B/S`. This distinction
+matters for logical/gauge correlations: T/A alone is not always a collection
+of initialized protected logical states. The classifier preserves valid
+existing logical representatives where possible. Observable IDs follow the
+resulting tracker basis; declaration `logical_id` metadata does not itself
+choose the emitted observable basis.
+
+During initialization, T may not yet contain all of S. Remaining physical
+preparation constraints stay in the stabilizer bank and continue through
+the next measurements. No unmeasured stabilizer placeholders are inserted.
+Once all of S is known, the classifier validates k protected logical-state
+constraints. Final data readout requires the centre to be established.
+`infer_gauge_fixed_stabilizers(system)` returns A as a read-only derived
+snapshot; during preparation, it can be smaller than the full stabilizer bank.
+
+For a standard stabilizer code, mathematically G=S. In the implementation,
+an empty `patch.gauges` selects the original pipeline unchanged. In a system
+containing both kinds of patches, ordinary active stabilizers are included
+in the effective gauge span.
+
+## Integration and validation
+
+`GenericCSSGaugeExtractionBlock` builds separate X/Z measurement blocks
+from the declared gauges, with bipartite edge coloring within each basis.
+`basis_order` accepts single, repeated and reversed bases. The existing
+`MemoryExperiment` discovers this default extractor for:
+
+- `BaconShorCode(distance=d)`, square nearest-neighbor XX/ZZ gauges;
+- `SHYPSCode(r=3)` and `SHYPSCode(r=4)`, subsystem hypergraph-product
+  simplex constructions. See the [construction reference](../../lightstim/qec_code/shyps/README.md).
+
+The executable [memory notebook](../../notebooks/Memory/memory_subsystem.ipynb)
+uses the public pipeline for both families. Regression tests cover declaration
+algebra, signed Stim flows for measured gauges and bare logicals, partial and
+omitted gauge rounds, preparation, both memory bases and phase orders,
+noiseless sampling, and noisy detector error models. Bacon–Shor repeated-round
+tests compare the complete affine detector space and logical parities modulo
+detectors against explicit execution. Subsystem rounds use explicit execution
+whenever verified periodic compression is unavailable.
+
+## Scope
+
+This integration establishes fixed-algebra CSS subsystem memory with
+automatically inferred gauge fixing. General mixed protected states,
+logical/gauge-entangled inputs, pending absorbed logical relations and
+row-index post-selection metadata require additional handling and fail
+explicitly in the classifier. The legacy `z_only` readout shortcut assumes
+one directly measured ancilla per stabilizer and is rejected for subsystem
+gauges; the full detector pipeline supports both X and Z memories.
+
+Gauge-bearing coupler lifecycle, code-algebra changes between measurement
+boundaries, and general spacetime logical creation are not established by
+these integrations. The existing retained-data measurement engine and
+Middle-Out examples remain available on their original paths. A dynamically
+changing physical circuit does not by itself require a new patch abstraction;
+future examples must identify which code-boundary or logical-lifecycle
+assumption they actually exceed.
+
+The supplied generic schedules are functional integration baselines. Their
+noise DEMs do not establish circuit fault distance, an optimized decoder,
+single-shot performance or a threshold.

--- a/docs/design/tracker_measurement_semantics.md
+++ b/docs/design/tracker_measurement_semantics.md
@@ -32,8 +32,8 @@ physical measurement block. It returns the exact stabilizer rows that Gaussian
 elimination found eligible for later logical classification, but it does not
 decide whether to classify them.
 
-At the end of its declared measurement-block group, `CircuitBuilder` chooses
-one of three explicit actions:
+For patches without declared subsystem gauges, at the end of its declared
+measurement-block group, `CircuitBuilder` chooses one of three explicit actions:
 
 - a single disposable-ancilla block promotes the eligible rows with
   `promote_stabilizer_rows_to_logicals(...)`;
@@ -41,6 +41,12 @@ one of three explicit actions:
   `rebase_stabilizers_onto_code_basis(...)`;
 - a retained-data round keeps its physical state basis and validates the
   logical count after the block group.
+
+When active subsystem gauges are declared, Builder instead invokes
+`classify_subsystem_state(...)` before the first physical block and after
+each block. This computes the currently known gauge constraints and the
+protected logical-state constraints from the tracked physical state, with no
+per-phase edits to the code declaration. See [subsystem tracking](subsystem_tracking.md).
 
 The old `finalize_logicals` argument and
 `finalize_composite_syndrome_measurement(...)` protocol-shaped Tracker method

--- a/lightstim/ir/builder.py
+++ b/lightstim/ir/builder.py
@@ -223,6 +223,8 @@ class CircuitBuilder:
         """
         if rounds < 1:
             return
+        if z_only and self.if_detector and getattr(self.system, "active_gauges", ()):
+            raise ValueError("z_only readout is not supported for subsystem gauges; use the full detector pipeline.")
 
         blocks = tuple(measurement_blocks or (circuit_chunk,))
         if not blocks:
@@ -303,7 +305,10 @@ class CircuitBuilder:
             ))
             return
 
-        if not self._uses_disposable_syndrome_readout(analyses):
+        if getattr(self.system, "active_gauges", ()) or not self._uses_disposable_syndrome_readout(analyses):
+            # Subsystem rounds must preserve classification at every physical
+            # boundary even when the verified periodic compression declines.
+            # The legacy disposable fallback reuses a body without verifying it.
             persistent_logical_components = set(
                 self.tracker.stabilizer_with_logical_components
             )
@@ -532,6 +537,9 @@ class CircuitBuilder:
         tracker: Optional[SyndromeTracker] = None,
     ) -> None:
         tracker = self.tracker if tracker is None else tracker
+        subsystem = bool(getattr(self.system, "active_gauges", ()))
+        if subsystem:
+            tracker.classify_subsystem_state(self.system)
         promotable_stabilizer_rows = []
         for block_index, analysis in enumerate(analyses):
             output_circuit += analysis.circuit
@@ -550,10 +558,11 @@ class CircuitBuilder:
                 if reset_paulis is not None:
                     tracker.process_resets(reset_paulis)
                     reset_paulis = None
-                self._try_canonicalize_stateful_code_frame(
-                    analysis,
-                    tracker=tracker,
-                )
+                if not subsystem:
+                    self._try_canonicalize_stateful_code_frame(
+                        analysis,
+                        tracker=tracker,
+                    )
 
             promotable_stabilizer_rows.append(
                 tracker.process_mid_measurement(
@@ -576,6 +585,8 @@ class CircuitBuilder:
                     no_detector_mask=analysis.no_detector_mask,
                 )
             )
+            if subsystem:
+                tracker.classify_subsystem_state(self.system)
         self._finish_measurement_block_group(
             analyses,
             promotable_stabilizer_rows=tuple(
@@ -593,6 +604,10 @@ class CircuitBuilder:
     ) -> None:
         """Apply Builder-owned state classification at an SE-round boundary."""
         tracker = self.tracker if tracker is None else tracker
+        if getattr(self.system, "active_gauges", ()):
+            # Already classified from the physical state after every block.
+            # The static centre is a code declaration, not a gauge-phase basis.
+            return
         if self._uses_disposable_syndrome_readout(analyses):
             if len(analyses) == 1:
                 tracker.promote_stabilizer_rows_to_logicals(
@@ -1231,6 +1246,10 @@ class CircuitBuilder:
         """
         if final_measurements is None:
             final_measurements = {q: 'Z' for q in self.system.data_indices}
+        if self.if_detector and getattr(self.system, "active_gauges", ()):
+            if z_only:
+                raise ValueError("z_only readout is not supported for subsystem gauges; use the full detector pipeline.")
+            self.tracker.classify_subsystem_state(self.system, require_complete=True)
 
         # Final destructive data readout must start in a fresh moment. Some
         # extraction blocks, such as middle-out color-code circuits, end with

--- a/lightstim/ir/qec_patch.py
+++ b/lightstim/ir/qec_patch.py
@@ -3,6 +3,7 @@ from typing import Tuple, Dict, List, Set, Optional, Any, Literal
 import stim
 import numpy as np
 import math
+from ..utils.linear_algebra import check_commutativity, row_echelon
 
 
 class QECPatch(ABC):
@@ -35,6 +36,8 @@ class QECPatch(ABC):
         # Master source of truth for error correction properties
         # Store as stim.PauliString for efficiency
         self.stabilizers: List[Dict[str, Any]] = [] 
+        # Subsystem gauge generators; stabilizers remain the centre of this group.
+        self.gauges: List[Dict[str, Any]] = []
         self.logical_ops: List[Dict[str, Any]] = [] 
         self.num_logicals: int = 0
         self.rotation_angle: float = 0.0
@@ -213,7 +216,7 @@ class QECPatch(ABC):
         self._rebuild_grid_map()
 
         # 3. Update syndrome coords for the stabilizers
-        for stab in self.stabilizers:
+        for stab in self.stabilizers + self.gauges:
             if 'syn_idx' in stab:
                 idx = stab['syn_idx']
                 if idx in self.qubit_coords:
@@ -245,7 +248,7 @@ class QECPatch(ABC):
         self._rebuild_grid_map()
         
         # 3. Update syndrome coords for the stabilizers
-        for stab in self.stabilizers:
+        for stab in self.stabilizers + self.gauges:
             if 'syn_idx' in stab:
                 idx = stab['syn_idx']
                 if idx in self.qubit_coords:
@@ -289,15 +292,13 @@ class QECPatch(ABC):
         self._rebuild_grid_map()
 
         # 4. Update Stabilizers (Coordinate Metadata)
-        for stab in self.stabilizers:
-            if 'syn_idx' in stab:
+        for stab in self.stabilizers + self.gauges:
+            if stab.get('syn_idx') is not None:
                 idx = stab['syn_idx']
                 if idx in self.qubit_coords:
                      stab['syn_coord'] = self.qubit_coords[idx] # Avoid double calculation
                 else:
                     raise ValueError(f"Synaptic index {idx} not found in qubit coordinates.")
-            else:
-                raise ValueError(f"Stabilizer {stab} does not have a syndrome qubit index.")
 
         # 5. Update accumulated rotation angle and rebuild grid map
         self.rotation_angle = (self.rotation_angle + theta) % (2 * np.pi)
@@ -387,6 +388,108 @@ class QECPatch(ABC):
     }
         
         self.stabilizers.append(stabilizer_record)
+
+    def create_stim_gauge(self, target_dict: Dict[Tuple[int, int], str],
+                          syn_coord: Optional[Tuple[int, int]] = None,
+                          type: Optional[str] = None):
+        """Declare a phase-free gauge generator without making it a stabilizer.
+
+        Gauge generators may anticommute. Their support must consist of
+        registered data qubits; an optional syndrome qubit measures the gauge
+        in a separately supplied extraction circuit.
+        """
+        pauli = {}
+        for coord, factor in target_dict.items():
+            if coord not in self.index_map:
+                raise ValueError(f"Gauge support coordinate {coord} is not registered.")
+            index = self.index_map[coord]
+            if index not in self.data_indices:
+                raise ValueError(f"Gauge support qubit {index} is not a data qubit.")
+            if factor not in ("X", "Y", "Z"):
+                raise ValueError(f"Gauge Pauli factors must be X, Y or Z; got {factor!r}.")
+            pauli[index] = factor
+        syn_idx = None
+        if syn_coord is not None:
+            syn_idx = self.index_map.get(syn_coord)
+            if syn_idx not in self.syndrome_indices:
+                raise ValueError(f"Gauge syndrome coordinate {syn_coord} is not a registered syndrome qubit.")
+        self.gauges.append({
+            "pauli": pauli,
+            "type": type,
+            "data_indices": list(pauli),
+            "syn_coord": syn_coord,
+            "syn_idx": syn_idx,
+        })
+
+    def validate_subsystem_declaration(self) -> None:
+        """Validate S, G and k for a standard qubit subsystem code.
+
+        This phase-free algebra check runs only when gauges are declared.
+        Stabilizers must span the entire centre of the gauge group, and
+        ``num_logicals`` counts protected qubits, excluding gauge qubits.
+        Logical representative naming and extraction schedules are unchanged.
+        """
+        if not self.gauges:
+            return
+        if not self.data_indices.issubset(self.qubit_coords):
+            raise ValueError("Subsystem data qubits must have registered coordinates.")
+        data = {qubit: column for column, qubit in enumerate(sorted(self.data_indices))}
+        n = len(data)
+
+        def as_matrix(records, kind):
+            matrix = np.zeros((len(records), 2 * n), dtype=np.uint8)
+            for row, record in enumerate(records):
+                if "sign" in record or "phase" in record:
+                    raise ValueError(f"Subsystem {kind} {row} is phase-free and does not accept sign or phase metadata.")
+                pauli = record.get("pauli")
+                if not isinstance(pauli, dict):
+                    raise ValueError(f"Subsystem {kind} {row} requires a phase-free Pauli dictionary.")
+                for qubit, factor in pauli.items():
+                    if (qubit not in data or qubit not in self.qubit_coords
+                            or qubit in self.syndrome_indices):
+                        raise ValueError(f"Subsystem {kind} {row} acts on undeclared data qubit {qubit!r}.")
+                    if factor not in ("X", "Y", "Z"):
+                        raise ValueError(f"Subsystem {kind} {row} has invalid Pauli factor {factor!r}; expected X, Y or Z.")
+                    column = data[qubit]
+                    matrix[row, column] = factor in ("X", "Y")
+                    matrix[row, n + column] = factor in ("Z", "Y")
+                if not matrix[row].any():
+                    raise ValueError(f"Subsystem {kind} {row} must have nonempty Pauli support.")
+                if sorted(record.get("data_indices", pauli)) != sorted(pauli):
+                    raise ValueError(f"Subsystem {kind} {row} data_indices disagree with its Pauli support.")
+                syn_idx = record.get("syn_idx")
+                if syn_idx is not None and (
+                    syn_idx not in self.syndrome_indices
+                    or syn_idx not in self.qubit_coords
+                    or syn_idx in self.data_indices
+                ):
+                    raise ValueError(f"Subsystem {kind} {row} has an unregistered syndrome qubit.")
+                syn_coord = record.get("syn_coord")
+                if syn_coord is not None and (
+                    syn_idx is None or self.qubit_coords[syn_idx] != syn_coord
+                ):
+                    raise ValueError(f"Subsystem {kind} {row} syndrome coordinate disagrees with syn_idx.")
+            return matrix
+
+        def rank(matrix):
+            return int(row_echelon(matrix)[1]) if matrix.size else 0
+
+        stabilizers = as_matrix(self.stabilizers, "stabilizer")
+        gauges = as_matrix(self.gauges, "gauge")
+        if np.any(check_commutativity(stabilizers, stabilizers)):
+            raise ValueError("Subsystem stabilizers must commute with each other.")
+        if np.any(check_commutativity(stabilizers, gauges)):
+            raise ValueError("Subsystem stabilizers must commute with every gauge generator.")
+        g = rank(gauges)
+        s = rank(stabilizers)
+        if rank(np.vstack([gauges, stabilizers])) != g:
+            raise ValueError("Subsystem stabilizers must belong to the gauge group span.")
+        centre_rank = g - rank(check_commutativity(gauges, gauges))
+        if s != centre_rank:
+            raise ValueError("Subsystem stabilizers must span the entire centre of the gauge group.")
+        expected_k = n - (g + s) // 2
+        if self.num_logicals != expected_k:
+            raise ValueError(f"Subsystem num_logicals={self.num_logicals} does not match protected k={expected_k}.")
 
     def create_stim_logical(self, target_dict: Dict[Tuple[int, int], str], op_type: str):
         """Helper to convert list of coords to stim.PauliString"""

--- a/lightstim/ir/qec_system.py
+++ b/lightstim/ir/qec_system.py
@@ -41,12 +41,14 @@ class QECSystem:
         # The list index IS the stabilizer unique ID.
         self.stabilizers: List[Dict[str, Any]] = [] 
         self._stabilizer_signatures: Dict[str, Any] = {}
+        self.gauges: List[Dict[str, Any]] = []
         self.logical_ops: List[Dict[str, Any]] = [] 
         self.num_logicals: int = 0
 
         # 5. Dynamic Stabilizer Activities
         # Stores indices of self.stabilizers that are currently ON.
         self.active_stabilizer_indices: Set[int] = set()
+        self.active_gauge_indices: Set[int] = set()
         # coupler_name -> stabilizer_indices
         # The stabilizers indices that are paused because of the coupler's activation.
         self.paused_stabilizer_indices: Dict[str, Set[int]] = {}
@@ -122,6 +124,19 @@ class QECSystem:
             if self.stabilizers[idx].get('type') == 'Z'
         ]
 
+    @property
+    def active_gauges(self) -> List[Dict[str, Any]]:
+        """Declared gauges of active patches, independent of SE phase order."""
+        return [self.gauges[index] for index in sorted(self.active_gauge_indices)]
+
+    @property
+    def active_gauges_x(self) -> List[Dict[str, Any]]:
+        return [gauge for gauge in self.active_gauges if gauge.get("type") == "X"]
+
+    @property
+    def active_gauges_z(self) -> List[Dict[str, Any]]:
+        return [gauge for gauge in self.active_gauges if gauge.get("type") == "Z"]
+
     def effective_stabilizer(self, uid: int) -> Dict[str, Any]:
         """Return a stabilizer with disabled data qubits removed from support.
 
@@ -179,19 +194,22 @@ class QECSystem:
     def active_syndrome_indices(self) -> List[int]:
         """
         Returns the set of unique global indices for syndrome qubits 
-        that belong to CURRENTLY ACTIVE stabilizers.
+        that belong to currently active stabilizers or declared gauges.
         Used to generate 'R' and 'M' instructions only for relevant qubits.
         """
         return sorted({
             self.stabilizers[uid]['syn_idx']
             for uid in self.active_stabilizer_indices
             if self.stabilizers[uid].get('syn_idx') is not None
+        } | {
+            gauge['syn_idx'] for gauge in self.active_gauges
+            if gauge.get('syn_idx') is not None
         })
 
     @property
     def active_syndrome_indices_x(self) -> List[int]:
         """
-        Returns indices of syndrome qubits measuring active X-stabilizers.
+        Returns syndrome qubits measuring active X stabilizers or gauges.
         Used to determine where to apply Hadamard gates (or basis change).
         """
         return sorted({
@@ -201,12 +219,15 @@ class QECSystem:
                 self.stabilizers[uid].get('type') == 'X'
                 and self.stabilizers[uid].get('syn_idx') is not None
             )
+        } | {
+            gauge['syn_idx'] for gauge in self.active_gauges_x
+            if gauge.get('syn_idx') is not None
         })
 
     @property
     def active_syndrome_indices_z(self) -> List[int]:
         """
-        Returns indices of syndrome qubits measuring active Z-stabilizers.
+        Returns syndrome qubits measuring active Z stabilizers or gauges.
         """
         return sorted({
             self.stabilizers[uid]['syn_idx']
@@ -215,6 +236,9 @@ class QECSystem:
                 self.stabilizers[uid].get('type') == 'Z'
                 and self.stabilizers[uid].get('syn_idx') is not None
             )
+        } | {
+            gauge['syn_idx'] for gauge in self.active_gauges_z
+            if gauge.get('syn_idx') is not None
         })
 
     @property
@@ -246,6 +270,7 @@ class QECSystem:
         if name in self.patches:
             raise ValueError(f"Patch '{name}' already exists in the system.")
         
+        patch.validate_subsystem_declaration()
         if name is None:
             name = f"patch_{len(self.patches)+ len(self.coupler_patches)}"
 
@@ -307,8 +332,7 @@ class QECSystem:
             global_stab = self._translate_record(stab, local_to_global_map)
             global_stab['patch_name'] = name
             # Generate the stabilizer signature
-            pauli_indices = sorted(global_stab['data_indices'])
-            signature = (global_stab['type'], tuple(pauli_indices))
+            signature = (global_stab['type'], tuple(sorted(global_stab['pauli'].items())))
 
             if signature in self._stabilizer_signatures:
                 existing_uid = self._stabilizer_signatures[signature]
@@ -319,6 +343,15 @@ class QECSystem:
             self.stabilizers.append(global_stab)
             self._stabilizer_signatures[signature] = new_uid
             stabilizer_indices.append(new_uid)
+
+        gauge_indices = []
+        translated_gauges = []
+        for gauge in patch.gauges:
+            global_gauge = self._translate_record(gauge, local_to_global_map)
+            global_gauge['patch_name'] = name
+            gauge_indices.append(len(self.gauges))
+            self.gauges.append(global_gauge)
+            translated_gauges.append(global_gauge)
 
         for op in patch.logical_ops:
             global_op = self._translate_record(op, local_to_global_map)
@@ -331,14 +364,17 @@ class QECSystem:
 
         # 5. Store registered stabilizer UIDs on the patch (for coupler activate/deactivate)
         patch._registered_stabilizer_uids = set(stabilizer_indices)
+        patch._registered_gauge_uids = set(gauge_indices)
 
         # 6. Set Initial Active Stabilizers
         if is_active:
             self.active_stabilizer_indices.update(stabilizer_indices)
+            self.active_gauge_indices.update(gauge_indices)
 
         # 7. Create and return global patch view (with global indices)
         # This is a deep copy of the patch with all indices converted to global
         global_patch = copy.deepcopy(patch)
+        global_patch.gauges = copy.deepcopy(translated_gauges)
         
         # Convert data_indices from local to global
         global_patch.data_indices = {local_to_global_map[local_idx] for local_idx in patch.data_indices}

--- a/lightstim/ir/tracker.py
+++ b/lightstim/ir/tracker.py
@@ -1,7 +1,10 @@
 import stim
 import warnings
 import numpy as np
-from ..utils.linear_algebra import check_commutativity, solve_linear_decomposition
+from ..utils.linear_algebra import check_commutativity, kernel_gf2, solve_linear_decomposition
+from ..utils.subsystem_algebra import (
+    combine_records, independent_row_indices, intersect_row_spaces, reduce_modulo,
+)
 from ..utils.tableau_utils import stabilizers_to_symplectic
 from .tableau import PauliTableau
 from typing import List, Dict, Tuple, Optional, Set, Any
@@ -326,6 +329,11 @@ class SyndromeTracker:
 
         Call after encoding, before SE. Raises if logical count does not match expected.
         """
+        if getattr(system, "active_gauges", ()):
+            if stabilizer_uids is not None:
+                raise ValueError("Subsystem classification uses the full active S/G declaration.")
+            self.classify_subsystem_state(system)
+            return
         self._reject_pending_row_metadata("stabilizer_canonicalization")
         n = self.num_qubits
         if stabilizer_uids is not None:
@@ -399,6 +407,103 @@ class SyndromeTracker:
         self.logicals.records = new_log_records
 
         self.validate_logical_count(context="stabilizer canonicalization")
+
+    def _subsystem_spaces(self, system):
+        """Fixed code algebra in the current register (ordinary patches have G=S)."""
+        center = stabilizers_to_symplectic(system, system.active_stabilizers, self.num_qubits)
+        gauges = stabilizers_to_symplectic(system, system.active_gauges, self.num_qubits)
+        gauge_space = np.vstack([gauges, center])
+        return center, gauge_space
+
+    def infer_gauge_fixed_stabilizers(self, system) -> PauliTableau:
+        """Snapshot of the currently known gauge constraints, including record parities.
+
+        Compute T ∩ G from the actual conditional state T, without changing the
+        patch, the extraction schedule, or the tracker. Declarations do not
+        imply a measured or initialized eigenvalue. The result may therefore
+        contain only part of the code centre during preparation.
+        """
+        _, gauges = self._subsystem_spaces(system)
+        state = np.vstack([self.stabilizers.matrix, self.logicals.matrix])
+        records = self.stabilizers.records + self.logicals.records
+        if any(record < 0 for row in records for record in row):
+            raise RuntimeError("Subsystem inference requires physical state rows, not unmeasured placeholders.")
+        rows, coefficients = intersect_row_spaces(state, gauges)
+        result = PauliTableau(self.num_qubits)
+        result.add_stabilizers(rows, combine_records(coefficients, records))
+        return result
+
+    def classify_subsystem_state(self, system, *, require_complete: bool = False) -> None:
+        """Automatically separate known gauge and protected logical constraints.
+
+        A = T ∩ G supplies gauge-fixed stabilizers. Known bare logical-state
+        constraints come from T ∩ G^perp on the data register, modulo A; they
+        commute with every gauge, including the next round's measurements.
+        Residual preparation constraints remain in the stabilizer bank until
+        the rounds establish S. This avoids treating unprepared code checks
+        or gauge qubits as protected logical qubits.
+
+        Once S is known, this path requires the declared number of initialized
+        protected logical-state constraints. General mixed logical/gauge
+        states and pending logical absorption are not classified silently.
+        """
+        if not getattr(system, "active_gauges", ()):
+            return
+        self._reject_pending_row_metadata("subsystem classification")
+        if self.absorbed_ops.count or self._gauge_logical_vectors:
+            raise RuntimeError("Subsystem classification does not yet support pending absorbed logical relations.")
+        center, gauges = self._subsystem_spaces(system)
+        state = np.vstack([self.stabilizers.matrix, self.logicals.matrix])
+        records = self.stabilizers.records + self.logicals.records
+        if any(record < 0 for row in records for record in row):
+            raise RuntimeError("Subsystem classification requires physical state rows, not unmeasured placeholders.")
+        gauge_rows, gauge_coefficients = intersect_row_spaces(state, gauges)
+
+        # Bare logicals have support only on data, and commute with all G.
+        # Find combinations of state rows obeying these constraints directly;
+        # computing a centralizer over the full register would include ancillas.
+        nondata = sorted(set(range(self.num_qubits)) - set(system.data_indices))
+        nondata_columns = nondata + [q + self.num_qubits for q in nondata]
+        constraints = np.hstack([check_commutativity(state, gauges), state[:, nondata_columns]])
+        bare_coefficients = (kernel_gf2(constraints.T) if state.shape[0]
+                             else np.zeros((0, 0), dtype=np.uint8))
+        bare_rows = (bare_coefficients @ state) % 2
+
+        # Keep already valid logical representatives when possible, so a basis
+        # change in the gauge sector does not arbitrarily relabel observables.
+        old_log_indices = [idx for idx in range(self.stabilizers.count, state.shape[0])
+                           if not constraints[idx].any()]
+        identity = np.eye(state.shape[0], dtype=np.uint8)
+        candidates = np.vstack([state[old_log_indices], bare_rows])
+        candidate_coefficients = np.vstack([identity[old_log_indices], bare_coefficients])
+        gauge_rank = gauge_rows.shape[0]
+        logical_indices = [idx - gauge_rank for idx in independent_row_indices(
+            np.vstack([gauge_rows, candidates])) if idx >= gauge_rank]
+        logical_rows = candidates[logical_indices]
+        logical_coefficients = candidate_coefficients[logical_indices]
+
+        center_known = not reduce_modulo(center, state).any()
+        if require_complete and not center_known:
+            raise RuntimeError("Subsystem code centre is not yet established by initialization and gauge measurements.")
+        if center_known and logical_rows.shape[0] != self.expected_num_logicals:
+            raise RuntimeError(
+                "Subsystem classification requires initialized protected logical states: "
+                f"found {logical_rows.shape[0]} known bare logical constraints, expected "
+                f"{self.expected_num_logicals}. Logical/gauge entanglement, mixed logical "
+                "states, or a changed code boundary need additional support."
+            )
+
+        classified = np.vstack([gauge_rows, logical_rows])
+        classified_count = classified.shape[0]
+        residual_indices = [idx - classified_count for idx in independent_row_indices(
+            np.vstack([classified, state])) if idx >= classified_count]
+        stabilizer_rows = np.vstack([gauge_rows, state[residual_indices]])
+        stabilizer_coefficients = np.vstack([gauge_coefficients, identity[residual_indices]])
+        # Commit only after all checks, retaining exactly the same physical span.
+        self.stabilizers.matrix = stabilizer_rows
+        self.stabilizers.records = combine_records(stabilizer_coefficients, records)
+        self.logicals.matrix = logical_rows
+        self.logicals.records = combine_records(logical_coefficients, records)
 
     def logical_canonicalization(
         self,
@@ -1427,6 +1532,11 @@ class SyndromeTracker:
         This differs from :meth:`stabilizer_canonicalization`, which may insert
         unmeasured canonical rows when preparing a code for its first SE round.
         """
+        if getattr(system, "active_gauges", ()):
+            if stabilizer_uids is not None:
+                raise ValueError("Subsystem classification uses the full active S/G declaration.")
+            self.classify_subsystem_state(system, require_complete=True)
+            return
         self._reject_pending_row_metadata("rebase_stabilizers_onto_code_basis")
         n = self.num_qubits
         if stabilizer_uids is None:

--- a/lightstim/qec_code/bacon_shor/README.md
+++ b/lightstim/qec_code/bacon_shor/README.md
@@ -1,0 +1,54 @@
+# Bacon-Shor code
+
+`BaconShorCode(distance=d)` implements the square `[[d², 1, (d−1)², d]]`
+subsystem code for integer `d >= 2`. The implementation follows the subsystem
+construction introduced by Dave Bacon, [*Operator quantum error-correcting
+subsystems for self-correcting quantum memories*, Physical Review A **73**,
+012340 (2006)](https://doi.org/10.1103/PhysRevA.73.012340)
+([arXiv:quant-ph/0506023](https://arxiv.org/abs/quant-ph/0506023)).
+
+```python
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.bacon_shor import BaconShorCode
+
+experiment = MemoryExperiment(
+    qec_patch=BaconShorCode(distance=3),
+    basis="Z",  # X memory is also supported
+    rounds=5,
+)
+circuit = experiment.build()
+detections, observables = circuit.compile_detector_sampler().sample(
+    256, separate_observables=True,
+)
+assert not detections.any()
+assert not observables.any()
+```
+
+For data qubits `q[r,c]`, with `0 <= r,c < d`, this implementation uses:
+
+- **Gauge group G:** horizontal `X[r,c] X[r,c+1]` and vertical
+  `Z[r,c] Z[r+1,c]` generators, stored in `patch.gauges`.
+- **Stabilizer center S:** products of each horizontal XX generator over every
+  row, and products of each vertical ZZ generator over every column. These
+  `2(d−1)` checks are stored in `patch.stabilizers`, with `syn_idx=None`.
+- **Protected logicals:** X along the first full column and Z along the first
+  full row. There is one protected logical qubit and `(d−1)²` gauge qubits.
+
+The layout places data at `(2c, 2r)`, X-gauge ancillas at `(2c+1, 2r)`, and
+Z-gauge ancillas at `(2c, 2r+1)`. It uses `2d(d−1)` dedicated measurement
+ancillas, giving `d² + 2d(d−1)` physical qubits. Gauge qubits are subsystem
+degrees of freedom, distinct from these physical ancillas.
+
+The default `GenericCSSGaugeExtractionBlock` measures all X gauges and then
+all Z gauges, with a separate physical measurement block for each basis.
+`se_block_kwargs={"basis_order": ("Z", "X")}` reverses this order; single-basis
+and repeated-basis sequences are also accepted. The tracker infers the current
+gauge constraints and their record parities from the measurements while S and
+G remain fixed. A final memory readout requires adequate preparation of the
+code and protected logical state.
+
+Within each basis, bipartite edge coloring avoids simultaneous CNOT collisions.
+This generic schedule has tests for gauge measurement flows, protected logical
+flows, detector relations, and noisy DEM extraction. These checks do not establish
+its circuit-level distance, decoding threshold, or an optimized fault-tolerant
+schedule.

--- a/lightstim/qec_code/bacon_shor/__init__.py
+++ b/lightstim/qec_code/bacon_shor/__init__.py
@@ -1,0 +1,5 @@
+"""Bacon-Shor subsystem-code patches."""
+
+from .code_patch import BaconShorCode
+
+__all__ = ["BaconShorCode"]

--- a/lightstim/qec_code/bacon_shor/code_patch.py
+++ b/lightstim/qec_code/bacon_shor/code_patch.py
@@ -1,0 +1,67 @@
+"""Square Bacon-Shor subsystem codes with separate center and gauge declarations."""
+
+from numbers import Integral
+
+from lightstim.ir.qec_patch import QECPatch
+from lightstim.qec_code.generic_css.gauge_SE_block import GenericCSSGaugeExtractionBlock
+
+
+class BaconShorCode(QECPatch):
+    """The square ``[[d², 1, (d-1)², d]]`` Bacon-Shor subsystem code.
+
+    Horizontal nearest-neighbor XX and vertical nearest-neighbor ZZ operators
+    generate the gauge group. Products along complete pairs of columns/rows
+    generate its stabilizer center. Each gauge has a dedicated readout ancilla;
+    the default extraction circuit measures all X gauges, then all Z gauges.
+    """
+
+    default_extraction_block_class = GenericCSSGaugeExtractionBlock
+
+    def _process_params(self):
+        distance = self.params.get("distance")
+        if isinstance(distance, bool) or not isinstance(distance, Integral) or distance < 2:
+            raise ValueError("Bacon-Shor distance must be an integer >= 2.")
+        self.distance = int(distance)
+
+    def build(self):
+        d = self.distance
+        for row in range(d):
+            for col in range(d):
+                self.add_qubit(2 * col, 2 * row, role="data")
+
+        for row in range(d):
+            for col in range(d - 1):
+                ancilla = (2 * col + 1, 2 * row)
+                self.add_qubit(*ancilla, role="syndrome_x")
+                self.create_stim_gauge(
+                    {(2 * col, 2 * row): "X", (2 * col + 2, 2 * row): "X"},
+                    syn_coord=ancilla,
+                    type="X",
+                )
+
+        for row in range(d - 1):
+            for col in range(d):
+                ancilla = (2 * col, 2 * row + 1)
+                self.add_qubit(*ancilla, role="syndrome_z")
+                self.create_stim_gauge(
+                    {(2 * col, 2 * row): "Z", (2 * col, 2 * row + 2): "Z"},
+                    syn_coord=ancilla,
+                    type="Z",
+                )
+
+        # Center checks are inferred from gauge outcomes, not measured by an
+        # extra syndrome ancilla. The declaration stays fixed across X/Z phases.
+        for col in range(d - 1):
+            self.create_stim_stabilizer(
+                {(2 * c, 2 * row): "X" for row in range(d) for c in (col, col + 1)},
+                type="X",
+            )
+        for row in range(d - 1):
+            self.create_stim_stabilizer(
+                {(2 * col, 2 * r): "Z" for col in range(d) for r in (row, row + 1)},
+                type="Z",
+            )
+
+        self.create_stim_logical({(0, 2 * row): "X" for row in range(d)}, "X")
+        self.create_stim_logical({(2 * col, 0): "Z" for col in range(d)}, "Z")
+        self.num_logicals = 1

--- a/lightstim/qec_code/generic_css/__init__.py
+++ b/lightstim/qec_code/generic_css/__init__.py
@@ -1,7 +1,9 @@
 from .SE_block import GenericCSSColorationExtractionBlock
+from .gauge_SE_block import GenericCSSGaugeExtractionBlock
 from .bipartite_edge_coloring import color_bipartite_edges
 
 __all__ = [
     "GenericCSSColorationExtractionBlock",
+    "GenericCSSGaugeExtractionBlock",
     "color_bipartite_edges",
 ]

--- a/lightstim/qec_code/generic_css/gauge_SE_block.py
+++ b/lightstim/qec_code/generic_css/gauge_SE_block.py
@@ -1,0 +1,84 @@
+"""Physical CSS gauge measurements with explicit measurement-block boundaries."""
+
+from typing import Any, Sequence
+
+import stim
+
+from .bipartite_edge_coloring import color_bipartite_edges
+
+
+class GenericCSSGaugeExtractionBlock:
+    """Measure CSS gauges one commuting basis group at a time.
+
+    ``basis_order`` is any nonempty sequence of X/Z bases, including a single
+    basis or repeated bases. Each entry produces its own reset, Clifford, and
+    terminal-readout block. Noncommuting X/Z gauges are never combined into a
+    single measurement block. Same-basis CNOT layers use bipartite edge coloring;
+    this generic schedule does not promise a particular circuit-level distance.
+
+    Each gauge must have a distinct ancilla within its basis. Ancillas may be
+    reused across different bases because each block explicitly resets them.
+    Algebraically redundant gauge generators are allowed.
+    """
+
+    def __init__(self, system: Any, basis_order: Sequence[str] = ("X", "Z")):
+        self.system = system
+        self.basis_order = tuple(str(basis).upper() for basis in basis_order)
+        if not self.basis_order or any(basis not in {"X", "Z"} for basis in self.basis_order):
+            raise ValueError("basis_order must be a nonempty sequence of 'X'/'Z' bases.")
+
+        by_basis = {"X": [], "Z": []}
+        for gauge in system.active_gauges:
+            basis = gauge.get("type")
+            if basis not in by_basis or set(gauge.get("pauli", {}).values()) != {basis}:
+                raise ValueError("Generic CSS gauge extraction requires nonempty pure-X or pure-Z gauges.")
+            by_basis[basis].append(gauge)
+        if not any(by_basis.values()):
+            raise ValueError("Generic CSS gauge extraction requires active gauge generators.")
+
+        ancillas = {}
+        layers = {}
+        for basis, gauges in by_basis.items():
+            seen = set()
+            edges = []
+            for gauge in gauges:
+                ancilla = gauge.get("syn_idx")
+                if ancilla is None or ancilla not in system.syndrome_indices:
+                    raise ValueError("Every gauge requires a registered syndrome ancilla.")
+                if ancilla in seen:
+                    raise ValueError("Each gauge within one basis requires a distinct syndrome ancilla.")
+                seen.add(ancilla)
+                support = gauge.get("data_indices", ())
+                if not set(support) <= system.data_indices:
+                    raise ValueError("Gauge supports must contain registered data qubits only.")
+                edges.extend((ancilla, data) for data in support)
+            ancillas[basis] = sorted(seen)
+            layers[basis] = color_bipartite_edges(edges)
+
+        self.x_layers = layers["X"]
+        self.z_layers = layers["Z"]
+        self.depth_x = len(self.x_layers)
+        self.depth_z = len(self.z_layers)
+        self.cnot_depth = sum(len(layers[basis]) for basis in self.basis_order)
+        blocks = []
+        for basis in self.basis_order:
+            if not ancillas[basis]:
+                raise ValueError(f"No active {basis} gauges are available for the requested measurement block.")
+            block = stim.Circuit()
+            if blocks:
+                block.append("TICK")
+            block.append("RX" if basis == "X" else "R", ancillas[basis])
+            block.append("TICK", tag="SE_start")
+            for layer in layers[basis]:
+                targets = []
+                for ancilla, data in layer:
+                    targets.extend((ancilla, data) if basis == "X" else (data, ancilla))
+                block.append("CX", targets)
+                block.append("TICK")
+            block.append("MX" if basis == "X" else "M", ancillas[basis])
+            blocks.append(block)
+
+        self.measurement_blocks = tuple(blocks)
+        self.circuit = stim.Circuit()
+        for block in self.measurement_blocks:
+            self.circuit += block

--- a/lightstim/qec_code/shyps/README.md
+++ b/lightstim/qec_code/shyps/README.md
@@ -1,0 +1,51 @@
+# SHYPS memory integration
+
+`SHYPSCode(r=3)` implements the subsystem hypergraph-product simplex code
+with 49 data qubits, 9 protected logical qubits and code distance 4.
+`r=4` implements the 225-data-qubit, 16-logical-qubit, distance-8 instance.
+Other values of `r` are currently rejected.
+
+The construction follows Malcolm et al.,
+[Computing Efficiently in QLDPC Codes, §§VIII.4–VIII.5](https://arxiv.org/html/2502.07150v2).
+The classical circulant checks use `1 + x² + x³` for `r=3` and the primitive
+polynomial `1 + x + x⁴` for `r=4`. The canonical generator `C` spans the
+kernel of this circulant `H`. The quantum gauges are `H ⊗ I` and `I ⊗ H`;
+the centre generators are `H ⊗ C` and `C ⊗ H`. Redundant gauge checks are
+retained. Logical representatives are paired bare operators constructed
+using the canonical simplex pivots.
+
+```python
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.shyps import SHYPSCode
+
+experiment = MemoryExperiment(
+    qec_patch=SHYPSCode(r=3),
+    rounds=3,
+    basis="Z",  # "X" is also supported.
+    noise_params=NoiseConfig(p_2q=0.001, p_meas=0.001),
+)
+circuit = experiment.build()
+dem = circuit.detector_error_model()
+assert circuit.num_observables == 9
+```
+
+The patch declares its centre and gauges once. The default
+`GenericCSSGaugeExtractionBlock` measures all X gauges followed by all Z
+gauges; it is passed to `MemoryExperiment` automatically. A different
+`basis_order` can be supplied through `se_block_kwargs`.
+
+This realization uses a separate ancilla for every gauge generator:
+147 total physical qubits for `r=3`, or 675 for `r=4`. Coordinates provide
+a display layout, with no nearest-neighbor hardware constraint. The
+generic extraction schedule and noise example are integration baselines;
+they do not reproduce the paper's optimized circuit, Clifford compilation,
+decoder, single-shot results or performance claims. The code distance is
+an algebraic property of the code, not a measured circuit fault distance.
+
+The declaration's logical id `a*r+b` corresponds to bare X support `P[a] ⊗ C[b]` and bare Z
+support `C[a] ⊗ P[b]`. Here `P` contains unit vectors at the canonical
+simplex pivots and satisfies `P @ C.T = I`. The physical data index is
+`row*(2**r-1)+column`; its initial display coordinate is `(column,row)`.
+`MemoryExperiment` tracks a basis of the protected logical-state constraints;
+its observable indices do not promise this particular choice of representatives.

--- a/lightstim/qec_code/shyps/__init__.py
+++ b/lightstim/qec_code/shyps/__init__.py
@@ -1,0 +1,5 @@
+"""Subsystem hypergraph-product simplex (SHYPS) codes."""
+
+from .code_patch import SHYPSCode
+
+__all__ = ["SHYPSCode"]

--- a/lightstim/qec_code/shyps/code_patch.py
+++ b/lightstim/qec_code/shyps/code_patch.py
@@ -1,0 +1,217 @@
+"""SHYPS code algebra and a circuit realization with separate gauge ancillas.
+
+Reference: Malcolm et al., *Computing Efficiently in QLDPC Codes*,
+https://arxiv.org/html/2502.07150v2, Sections VIII.4--VIII.5.
+"""
+
+from __future__ import annotations
+
+from numbers import Integral
+from typing import Any
+
+import numpy as np
+
+from lightstim.ir.qec_patch import QECPatch
+from lightstim.qec_code.HGP.algebra import canonical_kernel_basis
+
+
+# These two explicit circulants are sufficient for the first two SHYPS sizes.
+# r=3 uses the polynomial in Example VIII.7; r=4 uses another primitive
+# trinomial in the construction of Section VIII.4. Both classical kernels
+# are checked exhaustively against the simplex weight distribution in tests.
+_SIMPLEX_CHECK_EXPONENTS = {3: (0, 2, 3), 4: (0, 1, 4)}
+
+
+class SHYPSCode(QECPatch):
+    """A CSS subsystem hypergraph-product simplex code.
+
+    ``r=3`` gives ``[[49, 9, 4]]`` and ``r=4`` gives ``[[225, 16, 8]]``;
+    these parameters count data qubits, protected logical qubits and code
+    distance. The realization adds one ancilla per weight-three gauge
+    generator, for ``3 * (2**r - 1)**2`` physical qubits in total.
+
+    With ``m = 2**r - 1``, ``H`` is the m-by-m circulant simplex parity
+    check and ``C`` is a canonical r-by-m generator for its kernel. This
+    class declares, separately and once,
+
+    * gauges ``G_X = H kron I`` and ``G_Z = I kron H``;
+    * their centre ``S_X = H kron C`` and ``S_Z = C kron H``.
+
+    Redundant rows of the physical gauge checks are retained. Centre
+    generators do not have measurement ancillas: their information is
+    inferred from the gauge measurement history.
+
+    Physical data index ``row * m + column`` corresponds to coordinate
+    ``(column, row)`` before shifting. Logical id ``a * r + b`` has bare
+    representatives ``P[a] kron C[b]`` and ``C[a] kron P[b]``, where the
+    unit-vector pivot matrix satisfies ``P @ C.T == I`` over GF(2). The
+    two representatives intersect only at ``(pivot[a], pivot[b])`` in
+    semantic (row, column) coordinates.
+
+    The default extraction is the generic X-then-Z gauge schedule. Its
+    display coordinates do not impose local hardware connectivity, and
+    this implementation does not reproduce the paper's gate compilation,
+    optimized syndrome schedule or logical-error performance.
+
+    Args:
+        r: Simplex dimension, currently 3 or 4.
+        shift: Translation of the display coordinates.
+    """
+
+    def __init__(self, r: int = 3, *, shift: tuple[float, float] = (0, 0)):
+        super().__init__(r=r, shift=shift)
+
+    def _process_params(self) -> None:
+        raw_r = self.params["r"]
+        if isinstance(raw_r, bool) or not isinstance(raw_r, Integral):
+            raise ValueError("r must be an integer, either 3 or 4.")
+        self.r = int(raw_r)
+        if self.r not in _SIMPLEX_CHECK_EXPONENTS:
+            raise ValueError("SHYPSCode currently supports r=3 and r=4.")
+        self.shift = self.params["shift"]
+        if not isinstance(self.shift, tuple) or len(self.shift) != 2:
+            raise ValueError("shift must be a two-number tuple.")
+
+        self.simplex_length = 2**self.r - 1
+        self.code_distance = 2 ** (self.r - 1)
+        self.num_gauge_qubits = (self.simplex_length - self.r) ** 2
+        self.data_qubits: dict[tuple[int, int], int] = {}
+        self.x_gauge_ancillas: dict[tuple[int, int], int] = {}
+        self.z_gauge_ancillas: dict[tuple[int, int], int] = {}
+        self.logical_pairs: list[dict[str, Any]] = []
+
+    @property
+    def num_data_qubits(self) -> int:
+        return self.simplex_length**2
+
+    @property
+    def data_index_order(self) -> tuple[int, ...]:
+        return tuple(self.data_qubits[key] for key in sorted(self.data_qubits))
+
+    @property
+    def default_extraction_block_class(self):
+        from lightstim.qec_code.generic_css.gauge_SE_block import (
+            GenericCSSGaugeExtractionBlock,
+        )
+
+        return GenericCSSGaugeExtractionBlock
+
+    def build(self) -> None:
+        m = self.simplex_length
+        first_row = np.zeros(m, dtype=np.uint8)
+        first_row[list(_SIMPLEX_CHECK_EXPONENTS[self.r])] = 1
+        self.simplex_parity_check = np.stack(
+            [np.roll(first_row, shift) for shift in range(m)]
+        )
+        kernel = canonical_kernel_basis(self.simplex_parity_check)
+        if kernel.nullity != self.r:
+            raise RuntimeError("The SHYPS seed does not have simplex dimension r.")
+        self.simplex_generator = kernel.basis.copy()
+        self.simplex_pivots = kernel.pivots
+        self.simplex_pivot_matrix = kernel.unit_complement.copy()
+
+        identity = np.eye(m, dtype=np.uint8)
+        self.gauge_matrix_x = np.kron(self.simplex_parity_check, identity)
+        self.gauge_matrix_z = np.kron(identity, self.simplex_parity_check)
+        self.center_matrix_x = np.kron(
+            self.simplex_parity_check, self.simplex_generator
+        )
+        self.center_matrix_z = np.kron(
+            self.simplex_generator, self.simplex_parity_check
+        )
+        self.logical_matrix_x = np.kron(
+            self.simplex_pivot_matrix, self.simplex_generator
+        )
+        self.logical_matrix_z = np.kron(
+            self.simplex_generator, self.simplex_pivot_matrix
+        )
+
+        self._register_qubits()
+        self._register_checks()
+        self._register_logicals()
+        self.num_logicals = self.r**2
+
+        if self.shift != (0, 0):
+            self.shift_coords(*self.shift)
+
+    def _register_qubits(self) -> None:
+        m = self.simplex_length
+        for row in range(m):
+            for column in range(m):
+                self.data_qubits[(row, column)] = self.add_qubit(
+                    column, row, role="data"
+                )
+
+        # Display the ancilla sectors below and to the right of the data.
+        # Each physical gauge generator has its own reset/readout qubit.
+        for check in range(m):
+            for column in range(m):
+                self.x_gauge_ancillas[(check, column)] = self.add_qubit(
+                    column, m + 1 + check, role="syndrome_x"
+                )
+        for row in range(m):
+            for check in range(m):
+                self.z_gauge_ancillas[(row, check)] = self.add_qubit(
+                    m + 1 + check, row, role="syndrome_z"
+                )
+
+    def _targets(self, row: np.ndarray, basis: str) -> dict:
+        data_indices = self.data_index_order
+        return {
+            self.qubit_coords[data_indices[int(column)]]: basis
+            for column in np.flatnonzero(row)
+        }
+
+    def _register_checks(self) -> None:
+        m = self.simplex_length
+        for basis, matrix, ancillas in (
+            ("X", self.gauge_matrix_x, self.x_gauge_ancillas),
+            ("Z", self.gauge_matrix_z, self.z_gauge_ancillas),
+        ):
+            for index, row in enumerate(matrix):
+                pair = divmod(index, m)
+                self.create_stim_gauge(
+                    self._targets(row, basis),
+                    syn_coord=self.qubit_coords[ancillas[pair]],
+                    type=basis,
+                )
+                self.gauges[-1]["product_index"] = pair
+
+        for basis, matrix in (
+            ("X", self.center_matrix_x),
+            ("Z", self.center_matrix_z),
+        ):
+            for row in matrix:
+                self.create_stim_stabilizer(self._targets(row, basis), type=basis)
+
+    def _register_logicals(self) -> None:
+        for logical_id, (x_row, z_row) in enumerate(
+            zip(self.logical_matrix_x, self.logical_matrix_z)
+        ):
+            a, b = divmod(logical_id, self.r)
+            pair = {"logical_id": logical_id, "simplex_indices": (a, b)}
+            for basis, row in (("X", x_row), ("Z", z_row)):
+                self.create_stim_logical(self._targets(row, basis), basis)
+                record = self.logical_ops[-1]
+                record.update(
+                    logical_id=logical_id,
+                    simplex_indices=(a, b),
+                    logical_kind="bare",
+                )
+                pair[basis.lower()] = record
+            pair["pivot_index"] = self.data_qubits[
+                (self.simplex_pivots[a], self.simplex_pivots[b])
+            ]
+            self.logical_pairs.append(pair)
+
+    def get_info(self):
+        info = super().get_info()
+        info.update(
+            r=self.r,
+            num_data_qubits=self.num_data_qubits,
+            num_logicals=self.num_logicals,
+            num_gauge_qubits=self.num_gauge_qubits,
+            code_distance=self.code_distance,
+            num_gauge_generators=len(self.gauges),
+        )
+        return info

--- a/lightstim/utils/subsystem_algebra.py
+++ b/lightstim/utils/subsystem_algebra.py
@@ -1,0 +1,59 @@
+"""Pauli row-space operations retaining coefficients in the input state basis."""
+
+import numpy as np
+
+from .linear_algebra import kernel_gf2, row_echelon
+
+
+def independent_row_indices(matrix):
+    """Select original rows, in order, spanning a possibly redundant matrix."""
+    if not matrix.size:
+        return []
+    return list(row_echelon(matrix.T)[3])
+
+
+def reduce_modulo(rows, basis):
+    """Return row residues modulo a Pauli span, without changing the inputs."""
+    result = np.asarray(rows, dtype=np.uint8).copy()
+    if basis.shape[0] and basis.shape[1]:
+        reduced, rank, _, pivots = row_echelon(basis, reduced=True)
+        for row, pivot in zip(reduced[:rank], pivots):
+            result[result[:, pivot].astype(bool)] ^= row.astype(np.uint8)
+    return result
+
+
+def intersect_row_spaces(left, right):
+    """Return independent rows of span(left) ∩ span(right), and their lineage.
+
+    The second result C satisfies ``intersection == (C @ left) % 2``.
+    Unlike filtering input rows by membership, this also finds intersections
+    that only appear as products of several tracked Paulis. Coefficients can
+    be applied to measurement-record parities using the same XOR operations.
+    """
+    left = np.asarray(left, dtype=np.uint8)
+    right = np.asarray(right, dtype=np.uint8)
+    if left.ndim != 2 or right.ndim != 2 or left.shape[1] != right.shape[1]:
+        raise ValueError("Pauli spaces must be matrices of the same width.")
+    if not left.shape[0] or not right.shape[0] or not left.shape[1]:
+        return (np.zeros((0, left.shape[1]), dtype=np.uint8),
+                np.zeros((0, left.shape[0]), dtype=np.uint8))
+    residues = reduce_modulo(left, right)
+    coefficients = kernel_gf2(residues.T)
+    intersection = (coefficients @ left) % 2
+    indices = independent_row_indices(intersection)
+    return intersection[indices], coefficients[indices]
+
+
+def combine_records(coefficients, records):
+    """Apply a GF(2) basis change to absolute measurement-record parities."""
+    result = []
+    for coefficients_row in coefficients:
+        parity = set()
+        for idx in np.flatnonzero(coefficients_row):
+            for record in records[idx]:
+                if record in parity:
+                    parity.remove(record)
+                else:
+                    parity.add(record)
+        result.append(sorted(parity))
+    return result

--- a/notebooks/Memory/memory_subsystem.ipynb
+++ b/notebooks/Memory/memory_subsystem.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2280c338",
+   "metadata": {},
+   "source": [
+    "# Subsystem memory: Bacon–Shor and SHYPS\n",
+    "\n",
+    "**[DEMO]** — this notebook uses the packaged `MemoryExperiment` protocol and code classes.\n",
+    "\n",
+    "The patch declares the stabilizer centre and gauge generators once. The default extraction measures X gauges and then Z gauges, and LightStim derives detectors from their measurement history. No manual changes to the active checks are needed between those groups.\n",
+    "\n",
+    "We build two-round X/Z memories for Bacon–Shor `[[9,1,4,3]]` (the third entry counts gauge qubits) and SHYPS `[[49,9,4]]` (data, protected logicals, distance). SHYPS uses 147 physical qubits here, including its 98 gauge-readout ancillas. These are integration checks; code distance is not a claim about the fault distance of this extraction schedule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0d172ee8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = next(\n",
+    "    path\n",
+    "    for path in (Path.cwd(), *Path.cwd().parents)\n",
+    "    if (path / \"lightstim\").is_dir() and (path / \"pyproject.toml\").exists()\n",
+    ")\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "\n",
+    "from lightstim.noise.config import NoiseConfig\n",
+    "from lightstim.protocols.memory import MemoryExperiment\n",
+    "from lightstim.qec_code.bacon_shor import BaconShorCode\n",
+    "from lightstim.qec_code.shyps import SHYPSCode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46a8e795",
+   "metadata": {},
+   "source": [
+    "## Ideal memory checks\n",
+    "\n",
+    "Each returned observable belongs to a protected logical qubit. Gauge-state directions are excluded from that count. The small ideal samples below must contain no detector or observable flips, and the detector error model must be constructible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "249c02eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bacon–Shor Z: {'physical_qubits': 21, 'detectors': 12, 'protected_observables': 1, 'ideal_detector_flips': 0, 'ideal_observable_flips': 0}\n",
+      "Bacon–Shor X: {'physical_qubits': 21, 'detectors': 12, 'protected_observables': 1, 'ideal_detector_flips': 0, 'ideal_observable_flips': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def check_ideal_memory(circuit, expected_logicals):\n",
+    "    detectors, observables = circuit.compile_detector_sampler(seed=71).sample(\n",
+    "        128, separate_observables=True\n",
+    "    )\n",
+    "    assert circuit.num_observables == expected_logicals\n",
+    "    assert observables.shape == (128, expected_logicals)\n",
+    "    assert not detectors.any()\n",
+    "    assert not observables.any()\n",
+    "    assert circuit.detector_error_model().num_observables == expected_logicals\n",
+    "    return {\n",
+    "        \"physical_qubits\": circuit.num_qubits,\n",
+    "        \"detectors\": circuit.num_detectors,\n",
+    "        \"protected_observables\": circuit.num_observables,\n",
+    "        \"ideal_detector_flips\": int(detectors.sum()),\n",
+    "        \"ideal_observable_flips\": int(observables.sum()),\n",
+    "    }\n",
+    "\n",
+    "bacon_z = MemoryExperiment(\n",
+    "    qec_patch=BaconShorCode(distance=3), rounds=2, basis=\"Z\"\n",
+    ").build()\n",
+    "bacon_x = MemoryExperiment(\n",
+    "    qec_patch=BaconShorCode(distance=3), rounds=2, basis=\"X\"\n",
+    ").build()\n",
+    "print(\"Bacon–Shor Z:\", check_ideal_memory(bacon_z, 1))\n",
+    "print(\"Bacon–Shor X:\", check_ideal_memory(bacon_x, 1))\n",
+    "\n",
+    "# Optional small circuit visualization; keep its output cleared when saving.\n",
+    "# bacon_z.diagram(\"detslice-with-ops-svg\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e16d0f4a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SHYPS Z: {'physical_qubits': 147, 'detectors': 148, 'protected_observables': 9, 'ideal_detector_flips': 0, 'ideal_observable_flips': 0}\n",
+      "SHYPS X: {'physical_qubits': 147, 'detectors': 148, 'protected_observables': 9, 'ideal_detector_flips': 0, 'ideal_observable_flips': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "shyps_z = MemoryExperiment(\n",
+    "    qec_patch=SHYPSCode(r=3), rounds=2, basis=\"Z\"\n",
+    ").build()\n",
+    "shyps_x = MemoryExperiment(\n",
+    "    qec_patch=SHYPSCode(r=3), rounds=2, basis=\"X\"\n",
+    ").build()\n",
+    "print(\"SHYPS Z:\", check_ideal_memory(shyps_z, 9))\n",
+    "print(\"SHYPS X:\", check_ideal_memory(shyps_x, 9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b6a97ef",
+   "metadata": {},
+   "source": [
+    "## Circuit noise and detector error models\n",
+    "\n",
+    "The same public protocol accepts a `NoiseConfig`. Here we add two-qubit and readout noise, then construct each DEM without requesting graphlike decomposition. Sampling or constructing a DEM is not decoding; these counts do not establish a logical error rate, threshold or single-shot performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b750696b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bacon–Shor DEM: {'error_terms': 58, 'observables': 1}\n",
+      "SHYPS DEM: {'error_terms': 2009, 'observables': 9}\n"
+     ]
+    }
+   ],
+   "source": [
+    "noise = NoiseConfig(p_2q=0.001, p_meas=0.001)\n",
+    "\n",
+    "bacon_noisy = MemoryExperiment(\n",
+    "    qec_patch=BaconShorCode(distance=3), rounds=2, basis=\"Z\",\n",
+    "    noise_params=noise,\n",
+    ").build()\n",
+    "shyps_noisy = MemoryExperiment(\n",
+    "    qec_patch=SHYPSCode(r=3), rounds=2, basis=\"Z\",\n",
+    "    noise_params=noise,\n",
+    ").build()\n",
+    "\n",
+    "bacon_dem = bacon_noisy.detector_error_model()\n",
+    "shyps_dem = shyps_noisy.detector_error_model()\n",
+    "assert bacon_dem.num_errors > 0 and bacon_dem.num_observables == 1\n",
+    "assert shyps_dem.num_errors > 0 and shyps_dem.num_observables == 9\n",
+    "print(\"Bacon–Shor DEM:\", {\"error_terms\": bacon_dem.num_errors, \"observables\": bacon_dem.num_observables})\n",
+    "print(\"SHYPS DEM:\", {\"error_terms\": shyps_dem.num_errors, \"observables\": shyps_dem.num_observables})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b503d149",
+   "metadata": {},
+   "source": [
+    "## Construction references\n",
+    "\n",
+    "- [Aliferis and Cross, *Subsystem fault tolerance with the Bacon–Shor code*](https://arxiv.org/html/quant-ph/0610063v3): low-weight gauge measurements and protected/gauge degrees of freedom.\n",
+    "- [Malcolm et al., *Computing Efficiently in QLDPC Codes*, §§VIII.4–VIII.5](https://arxiv.org/html/2502.07150v2): the SHYPS matrices, parameters and paired bare logical representatives.\n",
+    "- [SHYPS implementation notes](../../lightstim/qec_code/shyps/README.md): supported sizes, indexing and ancilla allocation.\n",
+    "\n",
+    "The SHYPS default is a generic finite gauge-extraction schedule. It does not reproduce the paper's logical Clifford compiler, decoder or optimized performance results."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -62,6 +62,7 @@ They compare LER vs PER and show distance scaling for each code family.
 | `memory_HGP.ipynb` | HGP codes ([[13,1,3]], [[18,2,3]], [[225,9,4]]) |
 | `memory_BB.ipynb` | Bivariate Bicycle codes ([[72,12,6]] … [[288,12,18]]) |
 | `memory_color.ipynb` | Triangular color code (6-6-6) |
+| `memory_subsystem.ipynb` | Bacon–Shor and SHYPS subsystem memory with automatic gauge-state inference |
 | `memory_PQRM.ipynb` | PQRM codes (1,2,4), (1,3,5), (1,4,6) |
 | `memory_repetition.ipynb` | Repetition code (sanity check) |
 | `memory_4D_hadamard.ipynb` | 4D geometric code (Hadamard-encoded) |

--- a/tests/test_bacon_shor_code.py
+++ b/tests/test_bacon_shor_code.py
@@ -1,0 +1,245 @@
+"""Bacon-Shor center/gauge algebra and protected-memory regressions."""
+
+import numpy as np
+import pytest
+import stim
+
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.bacon_shor import BaconShorCode
+from lightstim.qec_code.generic_css import GenericCSSGaugeExtractionBlock
+from lightstim.qec_code.repetition import RepetitionCode
+from lightstim.utils.linear_algebra import row_echelon
+
+
+def _symplectic(records, n):
+    matrix = np.zeros((len(records), 2 * n), dtype=np.uint8)
+    for i, record in enumerate(records):
+        for qubit, basis in record["pauli"].items():
+            matrix[i, qubit] = basis in {"X", "Y"}
+            matrix[i, n + qubit] = basis in {"Z", "Y"}
+    return matrix
+
+
+def _rank(matrix):
+    return row_echelon(matrix.copy())[1]
+
+
+def _commutators(left, right):
+    n = left.shape[1] // 2
+    return (left[:, :n] @ right[:, n:].T + left[:, n:] @ right[:, :n].T) % 2
+
+
+@pytest.mark.parametrize("distance", [2, 3, 4])
+def test_bacon_shor_declares_center_gauges_and_bare_logicals(distance):
+    patch = BaconShorCode(distance=distance)
+    n = patch.num_qubits
+    gauges = _symplectic(patch.gauges, n)
+    center = _symplectic(patch.stabilizers, n)
+    logicals = _symplectic(patch.logical_ops, n)
+
+    assert len(patch.data_indices) == distance**2
+    assert len(patch.gauges) == 2 * distance * (distance - 1)
+    assert len(patch.syndrome_indices) == len(patch.gauges)
+    assert all(len(g["pauli"]) == 2 for g in patch.gauges)
+    assert all(s["syn_idx"] is None for s in patch.stabilizers)
+    assert _rank(gauges) == 2 * distance * (distance - 1)
+    assert _rank(center) == 2 * (distance - 1)
+    assert _rank(np.vstack([gauges, center])) == _rank(gauges)
+    assert not _commutators(center, gauges).any()
+    assert _rank(_commutators(gauges, gauges)) == 2 * (distance - 1)**2
+    assert not _commutators(logicals, gauges).any()
+    assert _commutators(logicals, logicals).tolist() == [[0, 1], [1, 0]]
+    assert patch.num_logicals == 1
+    assert all(len(op["pauli"]) == distance for op in patch.logical_ops)
+
+
+@pytest.mark.parametrize("distance", [None, 0, 1, -3, 2.5, True, "3"])
+def test_bacon_shor_requires_integer_distance_at_least_two(distance):
+    with pytest.raises(ValueError, match="integer >= 2"):
+        BaconShorCode(distance=distance)
+
+
+@pytest.mark.parametrize("distance", [2, 3])
+@pytest.mark.parametrize("basis", ["X", "Z"])
+@pytest.mark.parametrize("order", [("X", "Z"), ("Z", "X")])
+def test_bacon_shor_memory_infers_each_gauge_phase(distance, basis, order):
+    experiment = MemoryExperiment(
+        qec_patch=BaconShorCode(distance=distance),
+        basis=basis,
+        rounds=3,
+        se_block_kwargs={"basis_order": order},
+    )
+    circuit = experiment.build()
+    detectors, observables = circuit.compile_detector_sampler(seed=3).sample(
+        256, separate_observables=True,
+    )
+    assert circuit.num_detectors > 0
+    assert circuit.num_observables == 1
+    assert not detectors.any()
+    assert not observables.any()
+    circuit.detector_error_model()
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_bacon_shor_noisy_memory_has_detector_error_model(basis):
+    circuit = MemoryExperiment(
+        qec_patch=BaconShorCode(distance=3),
+        basis=basis,
+        rounds=3,
+        noise_params=NoiseConfig(
+            p_1q=0.001, p_2q=0.001, p_meas=0.001, p_reset=0.001, p_idle=0.001,
+        ),
+    ).build()
+    dem = circuit.detector_error_model()
+    assert dem.num_errors > 0
+    assert dem.num_observables == 1
+    assert dem.num_detectors == circuit.num_detectors
+
+
+def test_bacon_shor_repeated_single_basis_phases_keep_static_declaration():
+    system = QECSystem()
+    system.add_patch(BaconShorCode(distance=3), name="bs")
+    tracker = SyndromeTracker(system.num_qubits, system.num_logicals)
+    builder = CircuitBuilder(tracker, system)
+    builder.initialize({q: "Z" for q in system.data_indices}, system.num_qubits)
+    active_center = set(system.active_stabilizer_indices)
+    center_supports = [dict(s["pauli"]) for s in system.stabilizers]
+
+    for order in [("X", "Z"), ("Z",), ("Z",), ("X",), ("Z",)]:
+        block = GenericCSSGaugeExtractionBlock(system, basis_order=order)
+        builder.apply_syndrome_extraction(
+            block.circuit, rounds=1, measurement_blocks=block.measurement_blocks,
+        )
+        assert tracker.logicals.count == 1
+        assert tracker.expected_num_logicals == 1
+        assert system.active_stabilizer_indices == active_center
+        assert [dict(s["pauli"]) for s in system.stabilizers] == center_supports
+
+    builder.apply_data_readout({q: "Z" for q in system.data_indices})
+    samples = builder.circuit.compile_detector_sampler(seed=4).sample(256, append_observables=True)
+    assert not samples.any()
+    builder.circuit.detector_error_model()
+
+
+def _physical_operations(circuit):
+    physical = stim.Circuit()
+    for instruction in circuit.flattened():
+        if instruction.name not in {"DETECTOR", "OBSERVABLE_INCLUDE", "QUBIT_COORDS", "SHIFT_COORDS", "TICK"}:
+            physical.append(instruction)
+    return physical
+
+
+def _affine_annotation_rows(circuit):
+    """Record parities augmented by their noiseless reference values."""
+    reference = circuit.reference_sample().astype(np.uint8)
+    detectors = []
+    observable = np.zeros(circuit.num_measurements, dtype=np.uint8)
+    count = 0
+    for instruction in circuit.flattened():
+        if instruction.name in {"DETECTOR", "OBSERVABLE_INCLUDE"}:
+            row = np.zeros(circuit.num_measurements, dtype=np.uint8)
+            for target in instruction.targets_copy():
+                assert target.is_measurement_record_target
+                row[count + target.value] ^= 1
+            if instruction.name == "DETECTOR":
+                detectors.append(np.append(row, (row @ reference) % 2))
+            else:
+                assert instruction.gate_args_copy() == [0.0]
+                observable ^= row
+        else:
+            single = stim.Circuit()
+            single.append(instruction)
+            count += single.num_measurements
+    assert count == circuit.num_measurements
+    return np.asarray(detectors, dtype=np.uint8), np.append(observable, (observable @ reference) % 2)
+
+
+@pytest.mark.parametrize("distance", [2, 3])
+@pytest.mark.parametrize("basis", ["X", "Z"])
+@pytest.mark.parametrize("order", [("X", "Z"), ("Z", "X")])
+def test_bacon_shor_compressed_memory_preserves_all_record_relations(distance, basis, order):
+    rounds = 7
+    compressed = MemoryExperiment(
+        qec_patch=BaconShorCode(distance=distance),
+        basis=basis,
+        rounds=rounds,
+        se_block_kwargs={"basis_order": order},
+    ).build()
+
+    system = QECSystem()
+    system.add_patch(BaconShorCode(distance=distance), name="explicit")
+    tracker = SyndromeTracker(system.num_qubits, system.num_logicals)
+    builder = CircuitBuilder(tracker, system)
+    builder.initialize({q: basis for q in system.data_indices}, system.num_qubits)
+    block = GenericCSSGaugeExtractionBlock(system, basis_order=order)
+    for _ in range(rounds):
+        builder.apply_syndrome_extraction(
+            block.circuit, rounds=1, measurement_blocks=block.measurement_blocks,
+        )
+    builder.apply_data_readout({q: basis for q in system.data_indices})
+    explicit = builder.circuit
+
+    assert any(
+        isinstance(instruction, stim.CircuitRepeatBlock)
+        and instruction.repeat_count == rounds - 2
+        for instruction in compressed
+    )
+    assert _physical_operations(compressed) == _physical_operations(explicit)
+    compressed_detectors, compressed_logical = _affine_annotation_rows(compressed)
+    explicit_detectors, explicit_logical = _affine_annotation_rows(explicit)
+
+    # Equal affine rowspaces mean identical detectability for every possible
+    # record fault, even when the emitted detector generators differ.
+    joint_rank = _rank(np.vstack([compressed_detectors, explicit_detectors]))
+    assert joint_rank == _rank(compressed_detectors) == _rank(explicit_detectors)
+    # Logical representatives may differ by detector products. Their normalized
+    # parity must agree on every syndrome-free record, including logical faults.
+    difference = compressed_logical ^ explicit_logical
+    assert _rank(np.vstack([compressed_detectors, difference])) == joint_rank
+
+
+def test_bacon_shor_and_ordinary_patch_keep_two_protected_logicals():
+    system = QECSystem()
+    system.add_patch(RepetitionCode(distance=3), name="ordinary")
+    system.add_patch(BaconShorCode(distance=2), name="subsystem", offset=(10, 0))
+    tracker = SyndromeTracker(system.num_qubits, system.num_logicals)
+    builder = CircuitBuilder(tracker, system)
+    builder.initialize({q: "Z" for q in system.data_indices}, system.num_qubits)
+
+    # Measure only the ordinary patch's checks, using its registered global
+    # supports. The Bacon-Shor centers have no direct measurement ancilla.
+    ordinary_checks = [s for s in system.active_stabilizers if s["patch_name"] == "ordinary"]
+    ordinary = stim.Circuit()
+    ordinary.append("R", [s["syn_idx"] for s in ordinary_checks])
+    ordinary.append("TICK", tag="SE_start")
+    for neighbor in range(2):
+        for check in ordinary_checks:
+            ordinary.append("CX", [sorted(check["data_indices"])[neighbor], check["syn_idx"]])
+        ordinary.append("TICK")
+    ordinary.append("M", [s["syn_idx"] for s in ordinary_checks])
+    builder.apply_syndrome_extraction(ordinary, rounds=1)
+
+    gauges = GenericCSSGaugeExtractionBlock(system)
+    builder.apply_syndrome_extraction(
+        gauges.circuit, rounds=3, measurement_blocks=gauges.measurement_blocks,
+    )
+    assert tracker.logicals.count == 2
+    assert tracker.expected_num_logicals == 2
+    assert _rank(tracker.stabilizers.matrix) == 5  # two ordinary + three gauge constraints
+
+    # Both logical-Z state constraints remain in the full conditioned span.
+    full_state = np.vstack([tracker.stabilizers.matrix, tracker.logicals.matrix])
+    logical_z = _symplectic([op for op in system.logical_ops if op["type"] == "Z"], system.num_qubits)
+    assert _rank(np.vstack([full_state, logical_z])) == _rank(full_state)
+
+    builder.apply_data_readout({q: "Z" for q in system.data_indices})
+    circuit = builder.circuit
+    assert circuit.num_observables == 2
+    detectors, observables = circuit.compile_detector_sampler(seed=5).sample(256, separate_observables=True)
+    assert not detectors.any()
+    assert not observables.any()
+    circuit.detector_error_model()

--- a/tests/test_gauge_extraction.py
+++ b/tests/test_gauge_extraction.py
@@ -1,0 +1,94 @@
+"""Physical instrument checks for the generic CSS gauge extraction circuit."""
+
+import pytest
+import stim
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.qec_code.bacon_shor import BaconShorCode
+from lightstim.qec_code.generic_css import GenericCSSGaugeExtractionBlock
+
+
+def _system(distance=3):
+    system = QECSystem()
+    system.add_patch(BaconShorCode(distance=distance), name="bs", offset=(10, 20))
+    return system
+
+
+def _pauli(record, n):
+    result = stim.PauliString(n)
+    for qubit, basis in record["pauli"].items():
+        result[qubit] = basis
+    return result
+
+
+@pytest.mark.parametrize("distance", [2, 3, 4])
+@pytest.mark.parametrize("order", [("X", "Z"), ("Z", "X"), ("Z", "Z", "X"), ("X",)])
+def test_gauge_extraction_measures_declared_generators_and_preserves_bare_logicals(distance, order):
+    system = _system(distance)
+    block = GenericCSSGaugeExtractionBlock(system, basis_order=order)
+    assert len(block.measurement_blocks) == len(order)
+    assert sum(block.measurement_blocks, stim.Circuit()) == block.circuit
+
+    for basis, physical in zip(order, block.measurement_blocks):
+        gauges = sorted(
+            (g for g in system.active_gauges if g["type"] == basis),
+            key=lambda g: g["syn_idx"],
+        )
+        assert physical[-1].name == ("MX" if basis == "X" else "M")
+        assert physical.num_measurements == len(gauges)
+        for record_index, gauge in enumerate(gauges):
+            assert physical.has_flow(
+                stim.Flow(input=_pauli(gauge, system.num_qubits), measurements=[record_index]),
+                unsigned=False,
+            )
+        for logical in system.logical_ops:
+            pauli = _pauli(logical, system.num_qubits)
+            assert physical.has_flow(stim.Flow(input=pauli, output=pauli), unsigned=False)
+
+    for logical in system.logical_ops:
+        pauli = _pauli(logical, system.num_qubits)
+        assert block.circuit.has_flow(stim.Flow(input=pauli, output=pauli), unsigned=False)
+
+    # Every color is an actual physical matching, including both endpoint types.
+    for layer in block.x_layers + block.z_layers:
+        endpoints = [q for edge in layer for q in edge]
+        assert len(endpoints) == len(set(endpoints))
+    assert block.cnot_depth == sum(block.depth_x if b == "X" else block.depth_z for b in order)
+
+
+@pytest.mark.parametrize("order", [(), ("Y",), ("X", "invalid")])
+def test_gauge_extraction_rejects_empty_or_non_css_orders(order):
+    with pytest.raises(ValueError, match="nonempty sequence"):
+        GenericCSSGaugeExtractionBlock(_system(), basis_order=order)
+
+
+def test_gauge_extraction_rejects_accidental_same_basis_ancilla_reuse():
+    system = _system()
+    x_gauges = [g for g in system.gauges if g["type"] == "X"]
+    x_gauges[1]["syn_idx"] = x_gauges[0]["syn_idx"]
+    with pytest.raises(ValueError, match="distinct syndrome ancilla"):
+        GenericCSSGaugeExtractionBlock(system)
+
+
+def test_gauge_extraction_accepts_redundant_generators_with_separate_ancillas():
+    # A third X generator is a center product of two existing X gauges.
+    # Its record must still measure that product correctly and independently.
+    patch = BaconShorCode(distance=2)
+    patch.add_qubit(5, 5, role="syndrome_x")
+    patch.create_stim_gauge(
+        {patch.qubit_coords[q]: "X" for q in patch.data_indices},
+        syn_coord=(5, 5),
+        type="X",
+    )
+    system = QECSystem()
+    system.add_patch(patch, name="redundant")
+    block = GenericCSSGaugeExtractionBlock(system, basis_order=("X",))
+    measured = sorted(
+        (g for g in system.active_gauges if g["type"] == "X"),
+        key=lambda g: g["syn_idx"],
+    )
+    for i, gauge in enumerate(measured):
+        assert block.circuit.has_flow(
+            stim.Flow(input=_pauli(gauge, system.num_qubits), measurements=[i]),
+            unsigned=False,
+        )

--- a/tests/test_shyps_code.py
+++ b/tests/test_shyps_code.py
@@ -1,0 +1,216 @@
+"""SHYPS algebra and memory contracts, including all protected logicals."""
+
+from itertools import product
+
+import numpy as np
+import pytest
+import stim
+
+from lightstim.ir.qec_system import QECSystem
+from lightstim.noise.config import NoiseConfig
+from lightstim.protocols.memory import MemoryExperiment
+from lightstim.qec_code.generic_css.gauge_SE_block import GenericCSSGaugeExtractionBlock
+from lightstim.qec_code.repetition import RepetitionCode
+from lightstim.qec_code.shyps import SHYPSCode
+
+
+def _binary_rank(matrix):
+    # Integer XOR elimination keeps this independent of the constructor's
+    # column-elimination algorithm and of floating-point numerical rank.
+    pivots = {}
+    for row in np.asarray(matrix, dtype=np.uint8):
+        vector = int.from_bytes(np.packbits(row).tobytes(), "big")
+        while vector:
+            pivot = vector.bit_length() - 1
+            if pivot not in pivots:
+                pivots[pivot] = vector
+                break
+            vector ^= pivots[pivot]
+    return len(pivots)
+
+
+def _matrix_from_records(records, basis, data_order):
+    column_by_qubit = {qubit: column for column, qubit in enumerate(data_order)}
+    rows = []
+    for record in records:
+        if record["type"] != basis:
+            continue
+        row = np.zeros(len(data_order), dtype=np.uint8)
+        assert set(record["pauli"].values()) == {basis}
+        for qubit in record["pauli"]:
+            row[column_by_qubit[qubit]] = 1
+        rows.append(row)
+    return np.array(rows, dtype=np.uint8)
+
+
+@pytest.mark.parametrize("r", [3, 4])
+def test_simplex_seed_has_correct_kernel_and_weight_distribution(r):
+    code = SHYPSCode(r)
+    m = 2**r - 1
+    h = code.simplex_parity_check
+    generator = code.simplex_generator
+
+    assert h.shape == (m, m)
+    assert np.all(h.sum(axis=0) == 3)
+    assert np.all(h.sum(axis=1) == 3)
+    assert _binary_rank(h) == m - r
+    assert _binary_rank(generator) == r
+    assert not np.any(h @ generator.T % 2)
+    words = np.array(list(product((0, 1), repeat=r)), dtype=np.uint8) @ generator % 2
+    assert not words[0].any()
+    assert np.all(words[1:].sum(axis=1) == 2 ** (r - 1))
+    assert np.array_equal(
+        code.simplex_pivot_matrix @ generator.T % 2,
+        np.eye(r, dtype=np.uint8),
+    )
+    if r == 3:
+        # Exact circulant starting row from Malcolm et al., Example VIII.7.
+        assert h[0].tolist() == [1, 0, 1, 1, 0, 0, 0]
+
+
+@pytest.mark.parametrize("r", [3, 4])
+def test_gauge_center_and_complete_bare_logical_algebra(r):
+    code = SHYPSCode(r)
+    m = code.simplex_length
+    gx, gz = code.gauge_matrix_x, code.gauge_matrix_z
+    sx, sz = code.center_matrix_x, code.center_matrix_z
+    lx, lz = code.logical_matrix_x, code.logical_matrix_z
+
+    assert code.num_data_qubits == m**2
+    assert code.num_qubits == 3 * m**2
+    assert code.num_logicals == r**2
+    assert code.num_gauge_qubits == (m - r) ** 2
+    assert code.code_distance == 2 ** (r - 1)
+    assert _binary_rank(gx) == _binary_rank(gz) == m * (m - r)
+    assert _binary_rank(gx @ gz.T % 2) == code.num_gauge_qubits
+    assert _binary_rank(sx) == _binary_rank(sz) == r * (m - r)
+    assert _binary_rank(np.vstack([gx, sx])) == _binary_rank(gx)
+    assert _binary_rank(np.vstack([gz, sz])) == _binary_rank(gz)
+    assert not np.any(sx @ gz.T % 2)
+    assert not np.any(sz @ gx.T % 2)
+
+    # These commute with every gauge, not merely with the centre.
+    assert not np.any(lx @ gz.T % 2)
+    assert not np.any(lz @ gx.T % 2)
+    assert np.array_equal(lx @ lz.T % 2, np.eye(r**2, dtype=np.uint8))
+    assert _binary_rank(np.vstack([sx, lx])) - _binary_rank(sx) == r**2
+    assert _binary_rank(np.vstack([sz, lz])) - _binary_rank(sz) == r**2
+    assert np.all(lx.sum(axis=1) == code.code_distance)
+    assert np.all(lz.sum(axis=1) == code.code_distance)
+
+    for records, expected_x, expected_z in (
+        (code.gauges, gx, gz),
+        (code.stabilizers, sx, sz),
+        (code.logical_ops, lx, lz),
+    ):
+        assert np.array_equal(_matrix_from_records(records, "X", code.data_index_order), expected_x)
+        assert np.array_equal(_matrix_from_records(records, "Z", code.data_index_order), expected_z)
+    assert all(record["syn_idx"] is None for record in code.stabilizers)
+    assert len({record["syn_idx"] for record in code.gauges}) == 2 * m**2
+
+    for logical_id, pair in enumerate(code.logical_pairs):
+        a, b = divmod(logical_id, r)
+        assert pair["logical_id"] == logical_id
+        assert pair["simplex_indices"] == (a, b)
+        assert set(pair["x"]["data_indices"]) & set(pair["z"]["data_indices"]) == {pair["pivot_index"]}
+        assert pair["pivot_index"] == code.data_qubits[
+            (code.simplex_pivots[a], code.simplex_pivots[b])
+        ]
+
+
+def test_shifted_multi_patch_registration_keeps_gauge_and_logical_supports():
+    code = SHYPSCode(3, shift=(20, 30))
+    system = QECSystem()
+    system.add_patch(RepetitionCode(distance=3), name="first")
+    system.add_patch(code, offset=(10, -5), name="shyps")
+    mapping = system.local_to_global_map["shyps"]
+
+    assert mapping[0] != 0
+    assert system.qubit_coords[mapping[0]] == (30, 25)
+    for local, global_record in zip(
+        code.gauges,
+        [record for record in system.gauges if record["patch_name"] == "shyps"],
+    ):
+        assert global_record["pauli"] == {mapping[q]: b for q, b in local["pauli"].items()}
+        assert global_record["syn_idx"] == mapping[local["syn_idx"]]
+        assert global_record["syn_coord"] == system.qubit_coords[global_record["syn_idx"]]
+    for local, global_record in zip(
+        code.logical_ops,
+        [record for record in system.logical_ops if record["patch_name"] == "shyps"],
+    ):
+        assert global_record["pauli"] == {mapping[q]: b for q, b in local["pauli"].items()}
+        assert global_record["logical_id"] == local["logical_id"]
+
+
+@pytest.mark.parametrize("r", [3, 4])
+def test_extraction_measures_declared_gauges_and_preserves_bare_logicals(r):
+    system = QECSystem()
+    system.add_patch(SHYPSCode(r), name="shyps")
+    extraction = GenericCSSGaugeExtractionBlock(system)
+    assert extraction.depth_x == extraction.depth_z == 3
+
+    for basis, block in zip(("X", "Z"), extraction.measurement_blocks):
+        readout_order = [
+            target.value
+            for instruction in block
+            if instruction.name in ("M", "MX")
+            for target in instruction.targets_copy()
+        ]
+        for gauge in system.active_gauges:
+            if gauge["type"] != basis:
+                continue
+            pauli = stim.PauliString(system.num_qubits)
+            for qubit, factor in gauge["pauli"].items():
+                pauli[qubit] = factor
+            flow = stim.Flow(
+                input=pauli,
+                measurements=[readout_order.index(gauge["syn_idx"])],
+            )
+            assert block.has_flow(flow, unsigned=False)
+        for logical in system.logical_ops:
+            pauli = stim.PauliString(system.num_qubits)
+            for qubit, factor in logical["pauli"].items():
+                pauli[qubit] = factor
+            assert block.has_flow(stim.Flow(input=pauli, output=pauli), unsigned=False)
+
+
+@pytest.mark.parametrize("r", [True, 2, 5, 3.5, "3"])
+def test_unsupported_simplex_dimension_is_rejected(r):
+    with pytest.raises(ValueError, match="r"):
+        SHYPSCode(r)
+
+
+@pytest.mark.parametrize("basis", ["X", "Z"])
+def test_public_shyps_memory_tracks_all_nine_logicals(basis):
+    experiment = MemoryExperiment(qec_patch=SHYPSCode(), rounds=2, basis=basis)
+    original_centers = frozenset(experiment.system.active_stabilizer_indices)
+    original_gauges = frozenset(experiment.system.active_gauge_indices)
+    circuit = experiment.build()
+    assert experiment.system.active_stabilizer_indices == original_centers
+    assert experiment.system.active_gauge_indices == original_gauges
+    assert circuit.num_observables == 9
+    assert circuit.num_detectors > 0
+    assert circuit.detector_error_model().num_observables == 9
+    detectors, observables = circuit.compile_detector_sampler(seed=31).sample(
+        64, separate_observables=True
+    )
+    assert observables.shape == (64, 9)
+    assert not detectors.any()
+    assert not observables.any()
+
+
+def test_shyps_circuit_noise_preserves_the_nine_observable_interface():
+    circuit = MemoryExperiment(
+        qec_patch=SHYPSCode(),
+        rounds=2,
+        basis="Z",
+        noise_params=NoiseConfig(p_2q=0.001, p_meas=0.001),
+    ).build()
+    dem = circuit.detector_error_model()
+    assert dem.num_errors > 0
+    assert dem.num_observables == circuit.num_observables == 9
+    detectors, observables = circuit.compile_detector_sampler(seed=32).sample(
+        64, separate_observables=True
+    )
+    assert detectors.shape == (64, circuit.num_detectors)
+    assert observables.shape == (64, 9)

--- a/tests/test_subsystem_declarations.py
+++ b/tests/test_subsystem_declarations.py
@@ -1,0 +1,184 @@
+"""Subsystem declarations preserve algebra, placement, and ancilla roles."""
+
+import copy
+
+import numpy as np
+import pytest
+
+from lightstim.ir.qec_patch import QECPatch
+from lightstim.ir.qec_system import QECSystem
+
+
+class SmallSubsystem(QECPatch):
+    """One protected qubit and one gauge qubit, with centre Z0 Z1."""
+
+    def _process_params(self):
+        pass
+
+    def build(self):
+        for x in range(3):
+            self.add_qubit(x, 0, "data")
+        self.add_qubit(0, 1, "syndrome_x")
+        self.add_qubit(1, 1, "syndrome_z")
+        self.add_qubit(2, 1, "syndrome_z")
+        self.create_stim_stabilizer({(0, 0): "Z", (1, 0): "Z"}, type="Z")
+        self.create_stim_gauge({(0, 0): "X", (1, 0): "X"}, (0, 1), "X")
+        self.create_stim_gauge({(0, 0): "Z"}, (1, 1), "Z")
+        self.create_stim_gauge({(1, 0): "Z"}, (2, 1), "Z")
+        self.create_stim_logical({(2, 0): "X"}, "X")
+        self.create_stim_logical({(2, 0): "Z"}, "Z")
+        self.num_logicals = 1
+
+
+class MixedSubsystem(QECPatch):
+    def _process_params(self):
+        pass
+
+    def build(self):
+        self.add_qubit(0, 0, "data")
+        self.add_qubit(1, 0, "data")
+        first = {(0, 0): "X", (1, 0): "Z"}
+        if self.params.get("commuting"):
+            second = {(0, 0): "Z", (1, 0): "X"}
+            self.create_stim_stabilizer(first, type="Mixed")
+            self.create_stim_stabilizer(second, type="Mixed")
+            self.num_logicals = 0
+        else:
+            second = {(0, 0): "Y", (1, 0): "Z"}
+            self.num_logicals = 1
+        self.create_stim_gauge(first, type="Mixed")
+        self.create_stim_gauge(second, type="Mixed")
+
+
+def test_registration_translates_gauges_and_exposes_ancillas():
+    patch = SmallSubsystem()
+    original_gauges = copy.deepcopy(patch.gauges)
+    system = QECSystem()
+    system.add_patch(SmallSubsystem(), name="first")
+    placed = system.add_patch(patch, name="second", offset=(10, 20))
+
+    assert patch.gauges == original_gauges
+    assert len(system.stabilizers) == 2
+    assert len(system.gauges) == 6
+    assert placed.gauges == system.gauges[3:]
+    assert placed.gauges[0]["pauli"] == {6: "X", 7: "X"}
+    assert placed.gauges[0]["syn_idx"] == 9
+    assert placed.gauges[0]["syn_coord"] == (10, 21)
+    assert all(gauge["patch_name"] == "second" for gauge in placed.gauges)
+    assert system.active_syndrome_indices == [3, 4, 5, 9, 10, 11]
+    assert system.active_syndrome_indices_x == [3, 9]
+    assert system.active_syndrome_indices_z == [4, 5, 10, 11]
+    assert len(system.active_gauges_x) == 2
+    assert len(system.active_gauges_z) == 4
+    placed.gauges[0]["pauli"].clear()
+    assert system.gauges[3]["pauli"] == {6: "X", 7: "X"}
+
+
+def test_inactive_patch_does_not_activate_gauge_readout_ancillas():
+    system = QECSystem()
+    system.add_patch(SmallSubsystem(), name="inactive", is_active=False)
+    assert len(system.gauges) == 3
+    assert system.active_gauges == []
+    assert system.active_syndrome_indices == []
+    assert system.active_syndrome_indices_x == []
+    assert system.active_syndrome_indices_z == []
+
+
+def test_gauge_geometry_follows_shift_transpose_and_rotation():
+    patch = SmallSubsystem()
+    paulis = [dict(gauge["pauli"]) for gauge in patch.gauges]
+    patch.shift_coords(7, 11)
+    patch.transpose_coords()
+    patch.rotate_coords(np.pi / 2, center=(0, 0))
+    for gauge, pauli in zip(patch.gauges, paulis):
+        assert gauge["pauli"] == pauli
+        assert gauge["syn_coord"] == patch.qubit_coords[gauge["syn_idx"]]
+    assert patch.gauges[0]["syn_coord"] == (-7, 12)
+    assert patch.stabilizers[0]["syn_idx"] is None
+    patch.validate_subsystem_declaration()
+
+
+@pytest.mark.parametrize("commuting", [False, True])
+def test_same_support_mixed_paulis_do_not_collapse(commuting):
+    patch = MixedSubsystem(commuting=commuting)
+    system = QECSystem()
+    system.add_patch(patch)
+    assert len(system.gauges) == 2
+    assert system.gauges[0]["pauli"] != system.gauges[1]["pauli"]
+    assert len(system.stabilizers) == (2 if commuting else 0)
+
+
+@pytest.mark.parametrize("invalid", [
+    "num_logicals", "missing_centre", "outside_span", "noncentral",
+    "noncommuting", "syndrome_support", "unknown_support", "signed_factor",
+    "support_metadata", "duplicate_support", "sign_metadata", "phase_metadata",
+    "missing_data_geometry", "syndrome_metadata",
+])
+def test_invalid_declaration_fails_before_system_mutation(invalid):
+    patch = SmallSubsystem()
+    if invalid == "num_logicals":
+        patch.num_logicals = 2
+    elif invalid == "missing_centre":
+        patch.stabilizers.clear()
+    elif invalid == "outside_span":
+        patch.create_stim_stabilizer({(2, 0): "Z"}, type="Z")
+    elif invalid == "noncentral":
+        patch.create_stim_stabilizer({(0, 0): "X", (1, 0): "X"}, type="X")
+    elif invalid == "noncommuting":
+        patch.create_stim_stabilizer({(0, 0): "X"}, type="X")
+    elif invalid in ("syndrome_support", "unknown_support"):
+        qubit = 3 if invalid == "syndrome_support" else 100
+        patch.gauges[0]["pauli"] = {qubit: "X"}
+        patch.gauges[0]["data_indices"] = [qubit]
+    elif invalid == "signed_factor":
+        patch.gauges[0]["pauli"][0] = "-X"
+    elif invalid == "duplicate_support":
+        patch.gauges[0]["data_indices"] = [0, 1, 1]
+    elif invalid in ("sign_metadata", "phase_metadata"):
+        patch.gauges[0][invalid.removesuffix("_metadata")] = -1
+    elif invalid == "missing_data_geometry":
+        del patch.qubit_coords[2]
+    elif invalid == "syndrome_metadata":
+        patch.gauges[0]["syn_coord"] = (100, 100)
+    else:
+        patch.gauges[0]["data_indices"] = [0]
+
+    system = QECSystem()
+    with pytest.raises(ValueError, match="Subsystem"):
+        system.add_patch(patch, name="bad")
+    assert system.patches == {}
+    assert system.num_qubits == 0
+    assert system.stabilizers == []
+    assert system.gauges == []
+    assert system.num_logicals == 0
+
+
+def test_redundant_gauge_generators_are_allowed():
+    patch = SmallSubsystem()
+    patch.gauges.append(copy.deepcopy(patch.gauges[0]))
+    patch.validate_subsystem_declaration()
+
+
+@pytest.mark.parametrize("targets,syndrome", [
+    ({(99, 0): "X"}, None),
+    ({(0, 1): "X"}, None),
+    ({(0, 0): "-X"}, None),
+    ({(0, 0): "X"}, (99, 0)),
+    ({(0, 0): "X"}, (0, 0)),
+])
+def test_gauge_helper_rejects_invalid_physical_support(targets, syndrome):
+    patch = SmallSubsystem()
+    with pytest.raises(ValueError, match="Gauge"):
+        patch.create_stim_gauge(targets, syndrome)
+    assert len(patch.gauges) == 3
+
+
+def test_no_gauge_declarations_preserve_existing_registration_behavior():
+    patch = SmallSubsystem()
+    patch.gauges.clear()
+    patch.num_logicals = 3  # The existing static path accepts caller-supplied k.
+    system = QECSystem()
+    system.add_patch(patch)
+    assert system.num_logicals == 3
+    assert system.gauges == []
+    assert system.active_syndrome_indices == []

--- a/tests/test_subsystem_tracking.py
+++ b/tests/test_subsystem_tracking.py
@@ -1,0 +1,236 @@
+"""Physical state inference, including products, partial rounds and preparation."""
+
+import copy
+
+import numpy as np
+import pytest
+import stim
+
+from lightstim.ir.builder import CircuitBuilder
+from lightstim.ir.qec_patch import QECPatch
+from lightstim.ir.qec_system import QECSystem
+from lightstim.ir.tracker import SyndromeTracker
+from lightstim.qec_code.bacon_shor import BaconShorCode
+from lightstim.qec_code.generic_css import GenericCSSGaugeExtractionBlock
+from lightstim.utils.linear_algebra import check_commutativity
+from lightstim.utils.subsystem_algebra import (
+    combine_records, intersect_row_spaces, reduce_modulo,
+)
+from lightstim.utils.tableau_utils import stabilizers_to_symplectic
+
+
+def make_builder(*, bells=False):
+    system = QECSystem()
+    system.add_patch(BaconShorCode(distance=2), name="bs")
+    tracker = SyndromeTracker(system.num_qubits, system.num_logicals)
+    builder = CircuitBuilder(tracker, system)
+    builder.initialize({q: "Z" for q in system.data_indices}, system.num_qubits)
+    if bells:
+        builder.apply_unitary_block(stim.Circuit("H 0 2\nCX 0 1 2 3"))
+    return builder
+
+
+def measure_gauge(builder, basis, index=0):
+    gauge = [g for g in builder.system.active_gauges if g["type"] == basis][index]
+    ancilla = gauge["syn_idx"]
+    block = stim.Circuit()
+    block.append("RX" if basis == "X" else "R", [ancilla])
+    block.append("TICK")
+    for data in gauge["data_indices"]:
+        block.append("CX", [ancilla, data] if basis == "X" else [data, ancilla])
+        block.append("TICK")
+    block.append("MX" if basis == "X" else "M", [ancilla])
+    builder.apply_syndrome_extraction(block)
+
+
+def assert_same_span(left, right):
+    assert not reduce_modulo(left, right).any()
+    assert not reduce_modulo(right, left).any()
+
+
+def assert_physical_flows(builder, tableau):
+    for row, records in zip(tableau.matrix, tableau.records):
+        n = builder.tracker.num_qubits
+        pauli = stim.PauliString.from_numpy(xs=row[:n].astype(bool), zs=row[n:].astype(bool))
+        assert builder.circuit.has_flow(stim.Flow(output=pauli, measurements=records), unsigned=False)
+
+
+def assert_phase(builder, basis):
+    fixed = builder.tracker.infer_gauge_fixed_stabilizers(builder.system)
+    expected = stabilizers_to_symplectic(
+        builder.system,
+        [g for g in builder.system.active_gauges if g["type"] == basis]
+        + [s for s in builder.system.active_stabilizers if s["type"] != basis],
+        builder.system.num_qubits,
+    )
+    assert fixed.count == 3
+    assert_same_span(fixed.matrix, expected)
+    assert_physical_flows(builder, fixed)
+    assert_physical_flows(builder, builder.tracker.logicals)
+    assert builder.tracker.logicals.count == builder.tracker.expected_num_logicals == 1
+    gauges = stabilizers_to_symplectic(builder.system, builder.system.active_gauges, builder.system.num_qubits)
+    assert not check_commutativity(builder.tracker.logicals.matrix, gauges).any()
+
+
+def test_intersection_finds_products_and_xors_record_lineage():
+    # Neither original state row is in the right span; their product is.
+    left = np.array([[1, 0, 0, 0], [0, 1, 0, 0]], dtype=np.uint8)
+    right = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    intersection, coefficients = intersect_row_spaces(left, right)
+    assert_same_span(intersection, right)
+    np.testing.assert_array_equal(intersection, (coefficients @ left) % 2)
+    assert combine_records(coefficients, [[1, 3], [2, 3]]) == [[1, 2]]
+
+
+@pytest.mark.parametrize("left_count,right_count", [(0, 0), (0, 2), (2, 0)])
+def test_empty_intersections_have_consistent_shapes(left_count, right_count):
+    rows, coefficients = intersect_row_spaces(
+        np.zeros((left_count, 8), dtype=np.uint8), np.zeros((right_count, 8), dtype=np.uint8),
+    )
+    assert rows.shape == (0, 8)
+    assert coefficients.shape == (0, left_count)
+
+
+def test_bell_preparation_requires_span_intersection_and_both_tableaus():
+    builder = make_builder(bells=True)
+    tracker = builder.tracker
+    original = tracker.stabilizers.matrix.copy()
+    gauges = stabilizers_to_symplectic(builder.system, builder.system.active_gauges, tracker.num_qubits)
+    individually_in_g = [row for row in original if not reduce_modulo(row[None, :], gauges).any()]
+    assert len(individually_in_g) == 2
+    assert tracker.infer_gauge_fixed_stabilizers(builder.system).count == 3
+    # A previous classification can leave a gauge direction in the logical bank.
+    tracker.logicals.add_stabilizers(tracker.stabilizers.matrix[:1].copy(), [tracker.stabilizers.records[0]])
+    tracker.stabilizers.remove_rows([0])
+    before = copy.deepcopy(tracker)
+    assert tracker.infer_gauge_fixed_stabilizers(builder.system).count == 3
+    np.testing.assert_array_equal(tracker.stabilizers.matrix, before.stabilizers.matrix)
+    assert tracker.logicals.records == before.logicals.records
+    builder.stabilizer_canonicalization()
+    assert_phase(builder, "X")
+    assert_same_span(original, np.vstack([tracker.stabilizers.matrix, tracker.logicals.matrix]))
+
+
+def test_partial_omitted_and_repeated_gauges_infer_unmeasured_products():
+    builder = make_builder(bells=True)
+    declaration = copy.deepcopy((builder.system.stabilizers, builder.system.gauges,
+                                 builder.system.active_stabilizer_indices, builder.system.active_gauge_indices))
+    builder.stabilizer_canonicalization()
+    assert_phase(builder, "X")
+    for step, (basis, index) in enumerate([("Z", 0), ("Z", 0), ("X", 0), ("X", 1), ("Z", 1)]):
+        old_detectors = builder.circuit.num_detectors
+        measure_gauge(builder, basis, index)
+        assert_phase(builder, basis)
+        if step == 1:
+            assert builder.circuit.num_detectors == old_detectors + 1
+    assert declaration == (builder.system.stabilizers, builder.system.gauges,
+                           builder.system.active_stabilizer_indices, builder.system.active_gauge_indices)
+    builder.apply_data_readout({q: "Z" for q in builder.system.data_indices})
+    assert builder.circuit.num_observables == 1
+    assert not builder.circuit.compile_detector_sampler(seed=7).sample(256, append_observables=True).any()
+    builder.circuit.detector_error_model()
+
+
+def test_preparation_preserves_physical_constraints_until_center_established():
+    builder = make_builder()
+    original = builder.tracker.stabilizers.matrix.copy()
+    builder.stabilizer_canonicalization()
+    assert builder.tracker.infer_gauge_fixed_stabilizers(builder.system).count == 2
+    assert builder.tracker.logicals.count == 1
+    assert_same_span(original, np.vstack([builder.tracker.stabilizers.matrix, builder.tracker.logicals.matrix]))
+    assert all(r >= 0 for records in builder.tracker.stabilizers.records for r in records)
+    measure_gauge(builder, "X", 0)
+    before = builder.circuit.copy()
+    with pytest.raises(RuntimeError, match="centre is not yet established"):
+        builder.apply_data_readout()
+    assert builder.circuit == before  # Failure precedes destructive readout.
+    measure_gauge(builder, "X", 1)
+    assert_phase(builder, "X")
+    measure_gauge(builder, "Z", 0)
+    assert_phase(builder, "Z")
+    builder.apply_data_readout()
+    builder.circuit.detector_error_model()
+
+
+class LogicalAndGauge(QECPatch):
+    def _process_params(self):
+        pass
+
+    def build(self):
+        self.add_qubit(0, 0, "data")
+        self.add_qubit(1, 0, "data")
+        self.create_stim_gauge({(1, 0): "X"}, type="X")
+        self.create_stim_gauge({(1, 0): "Z"}, type="Z")
+        self.num_logicals = 1
+
+
+def test_logical_gauge_entanglement_is_not_counted_as_two_known_logicals():
+    system = QECSystem()
+    system.add_patch(LogicalAndGauge(), name="mixed")
+    tracker = SyndromeTracker(2, 1)
+    builder = CircuitBuilder(tracker, system)
+    builder.initialize({0: "Z", 1: "Z"}, 2)
+    builder.apply_unitary_block(stim.Circuit("H 0\nCX 0 1"))
+    before = tracker.stabilizers.matrix.copy()
+    assert tracker.infer_gauge_fixed_stabilizers(system).count == 0
+    with pytest.raises(RuntimeError, match="0 known bare logical constraints"):
+        builder.stabilizer_canonicalization()
+    np.testing.assert_array_equal(tracker.stabilizers.matrix, before)
+
+
+@pytest.mark.parametrize("metadata", ["post_select_row_indices", "stabilizer_with_logical_components"])
+def test_pending_row_metadata_is_rejected_before_recombination(metadata):
+    builder = make_builder(bells=True)
+    setattr(builder.tracker, metadata, {0})
+    before = builder.circuit.copy()
+    block = GenericCSSGaugeExtractionBlock(builder.system)
+    with pytest.raises(RuntimeError, match=metadata):
+        builder.apply_syndrome_extraction(block.circuit, measurement_blocks=block.measurement_blocks)
+    assert builder.circuit == before
+
+
+def test_unmeasured_placeholder_cannot_supply_gauge_knowledge():
+    builder = make_builder(bells=True)
+    builder.tracker.stabilizers.records[0] = [-1]
+    with pytest.raises(RuntimeError, match="unmeasured placeholders"):
+        builder.tracker.infer_gauge_fixed_stabilizers(builder.system)
+    with pytest.raises(RuntimeError, match="unmeasured placeholders"):
+        builder.stabilizer_canonicalization()
+
+
+def test_subsystem_rebase_uses_gauge_fixed_span_after_preparation():
+    builder = make_builder(bells=True)
+    builder.tracker.rebase_stabilizers_onto_code_basis(builder.system)
+    assert_phase(builder, "X")
+    measure_gauge(builder, "Z", 0)
+    builder.tracker.rebase_stabilizers_onto_code_basis(builder.system)
+    assert_phase(builder, "Z")
+
+
+def test_absorbed_logical_metadata_is_not_silently_dropped():
+    builder = make_builder(bells=True)
+    builder.tracker.absorbed_ops.matrix = builder.tracker.stabilizers.matrix[:1].copy()
+    before = builder.tracker.stabilizers.matrix.copy()
+    with pytest.raises(RuntimeError, match="pending absorbed logical relations"):
+        builder.stabilizer_canonicalization()
+    np.testing.assert_array_equal(builder.tracker.stabilizers.matrix, before)
+
+
+def test_unverified_compression_falls_back_to_full_subsystem_updates(monkeypatch):
+    builder = make_builder()
+    block = GenericCSSGaugeExtractionBlock(builder.system)
+    monkeypatch.setattr(builder, "_try_compress_steady_rounds", lambda **kwargs: None)
+    builder.apply_syndrome_extraction(block.circuit, rounds=5, measurement_blocks=block.measurement_blocks)
+    assert not any(isinstance(instruction, stim.CircuitRepeatBlock) for instruction in builder.circuit)
+    assert_phase(builder, "Z")
+    builder.apply_data_readout()
+    builder.circuit.detector_error_model()
+
+
+def test_z_only_legacy_shortcut_is_rejected_before_mutation():
+    builder = make_builder()
+    block = GenericCSSGaugeExtractionBlock(builder.system, basis_order=("Z",))
+    before = builder.circuit.copy()
+    with pytest.raises(ValueError, match="full detector pipeline"):
+        builder.apply_syndrome_extraction(block.circuit, z_only=True)
+    assert builder.circuit == before


### PR DESCRIPTION
Alternating subsystem rounds reached the correct physical conditional state, then the static-centre rebase counted surviving gauge constraints as extra logical qubits. Declaring every gauge as a stabilizer instead made that rebase demand constraints destroyed by the next noncommuting round.

This change declares S and G once on the existing patch and automatically classifies the physical state at each measurement-block boundary. No per-round edits to active stabilizers, new protocol containers, or manually supplied outcome transitions are needed.

### Changes

- Add phase-free gauge declarations, S/G/k registration validation, global gauge translation and gauge-ancilla recognition. Patches without declared gauges keep the existing classification path.
- Infer known gauge constraints as T ∩ G, retaining measurement-record XOR lineage. Select protected logical-state constraints from T ∩ G^perp on data qubits, preserving residual preparation constraints until the centre is established. Keep the existing physical Pauli measurement/forward-propagation engine.
- Classify before/after physical blocks; use explicit subsystem rounds whenever verified repeat compression is unavailable. Reject unsupported pending logical absorption, row-index post-selection, unmeasured placeholders and the legacy z_only shortcut explicitly.
- Integrate square Bacon–Shor and SHYPS r=3/r=4 with a shared CSS gauge extractor, documentation and an executed public-memory notebook. Fix full-Pauli stabilizer deduplication so distinct Mixed checks with the same support survive registration.

### Validation

- **103 new tests pass**: declaration algebra, physical signed Stim flows, span intersections and record lineage, partial/omitted/repeated gauge measurements, preparation, mixed ordinary/subsystem patches, X/Z memory, noisy DEMs and metadata guards.
- Existing non-slow regression suite passes, with one optional decoder test skipped. The eight existing API tests were run separately outside the sandbox because its asyncio thread portal stalled before entering QEC code; all eight pass.
- Eight Bacon–Shor cases compare compressed and explicit physical circuits, complete affine detector rowspaces and logical parities modulo detectors, covering arbitrary measurement-record faults rather than only ideal samples.
- All notebook Python cells executed successfully: Bacon–Shor d=3 and SHYPS r=3 X/Z memories, plus noisy DEM examples. The notebook kernel harness stalled in the sandbox, so its unchanged cells were executed sequentially using the project venv.
- Manual SHYPS r=4 Z-memory check: 2 rounds, 675 physical qubits, 537 detectors, 16 observables, valid DEM and 64 ideal shots with no flips; build took about 46 seconds. r=4 X/noisy memory was not part of this manual check; both sizes have signed extraction/logical-flow tests.
- `git diff --check` passes. Local verification uses the original project venv (Python 3.10, Stim 1.15).

### Scope

This establishes fixed-algebra CSS subsystem memory and automatic gauge fixing. General logical/gauge-entangled or mixed protected states, gauge-bearing coupler lifecycle, changing code-boundary algebra and spacetime logical creation require separate integration work. Existing Color Code/Middle-Out paths remain covered by regressions. The generic schedules and DEM checks do not establish optimized circuit distance, decoder performance or thresholds.
